### PR TITLE
version 0.1.0 for sdk-communication-layer and sdk-install-modal-web

### DIFF
--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.0.1-beta.5",
+  "version": "0.1.0",
   "private": false,
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk-communication-layer#readme",

--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-install-modal-web",
-  "version": "0.0.1-beta.5",
+  "version": "0.1.0",
   "private": false,
   "description": "MetaMask SDK Install Modal for Web",
   "author": "MetaMask",


### PR DESCRIPTION
Bumps `sdk-communication-layer` and `sdk-install-modal-web` modules version to 0.1.0