### PR TITLE
[FIX] sdk backward compatibility issue

### DIFF
--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",

--- a/packages/sdk-communication-layer/src/KeyExchange.ts
+++ b/packages/sdk-communication-layer/src/KeyExchange.ts
@@ -145,7 +145,8 @@ export class KeyExchange extends EventEmitter2 {
     this.step = KeyExchangeMessageType.KEY_HANDSHAKE_NONE;
     this.emit(EventType.KEY_INFO, this.step);
     this.keysExchanged = false;
-    this.otherPublicKey = undefined;
+    // Do not uncomment next line otherwise it breaks old sdk compatibility.
+    // this.otherPublicKey = undefined;
   }
 
   start({

--- a/packages/sdk-install-modal-web/src/components/AdvantagesListItem.tsx
+++ b/packages/sdk-install-modal-web/src/components/AdvantagesListItem.tsx
@@ -8,7 +8,7 @@ const AdvantagesListItem = ({ Icon, text }: {Icon: any, text: String}) => (
       <Icon />
     </div>
     <div style={styles.flexItem11}>
-      <span style={{ lineHeight: "2" }}>{text}</span>
+      <span style={{ lineHeight: "2", color: 'black' }}>{text}</span>
     </div>
   </div>
 );


### PR DESCRIPTION
- Fix an issue with backward compatibility on Android making the app going back by itself.
- Fix a css issue from https://github.com/MetaMask/metamask-sdk/issues/72
