### PR TITLE
[FIX] hanging keyexchange mm63

### DIFF
--- a/packages/examples/create-react-app/sdk-copy.sh
+++ b/packages/examples/create-react-app/sdk-copy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Make sure to start from base workspace folder
+reldir="$( dirname -- "$0"; )";
+cd "$reldir/../../..";
+SDK_WORKSPACE_DIR="$( pwd; )";
+COMM_LAYER_DIR="$SDK_WORKSPACE_DIR/packages/sdk-communication-layer"
+SDK_DIR="$SDK_WORKSPACE_DIR/packages/sdk"
+DAPP_DIR="$SDK_WORKSPACE_DIR/packages/examples/create-react-app"
+
+echo "SDK_DIR: $SDK_DIR"
+echo "COMM_LAYER_DIR: $COMM_LAYER_DIR"
+echo "DAPPDIR_EXAMPLE_DIR: $DAPP_DIR"
+
+cd $DAPP_DIR
+echo "Hack Metamask sdk && sdk-communication-layer packages..."
+## hack to debug to latest unpublished version of the sdk
+rm -rf node_modules/@metamask/sdk-communication-layer node_modules/@metamask/sdk
+cp -rf $COMM_LAYER_DIR node_modules/@metamask/
+cp -rf $SDK_DIR node_modules/@metamask/
+
+
+echo "All done."

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": false,
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",

--- a/packages/sdk-communication-layer/src/KeyExchange.ts
+++ b/packages/sdk-communication-layer/src/KeyExchange.ts
@@ -187,14 +187,28 @@ export class KeyExchange extends EventEmitter2 {
     }
 
     // Only if we are not already in progress
-    if (this.step !== KeyExchangeMessageType.KEY_HANDSHAKE_NONE) {
+    if (
+      (this.keysExchanged ||
+        this.step !== KeyExchangeMessageType.KEY_HANDSHAKE_NONE) &&
+      !force
+    ) {
+      // Key exchange can be restarted if the wallet ask for a new key.
       if (this.debug) {
         console.debug(
-          `KeyExchange::${this.context}::start -- restart key exchange -- step=${this.step}`,
+          `KeyExchange::${this.context}::start -- key exchange already ${
+            this.keysExchanged ? 'done' : 'in progress'
+          } -- aborted.`,
           this.step,
         );
       }
-      // Key exchange can be restarted if the wallet ask for a new key.
+      return;
+    }
+
+    if (this.debug) {
+      console.debug(
+        `KeyExchange::${this.context}::start -- start key exchange (force=${force}) -- step=${this.step}`,
+        this.step,
+      );
     }
 
     this.clean();

--- a/packages/sdk-communication-layer/src/KeyExchange.ts
+++ b/packages/sdk-communication-layer/src/KeyExchange.ts
@@ -186,7 +186,6 @@ export class KeyExchange extends EventEmitter2 {
       return;
     }
 
-    // Only if we are not already in progress
     if (
       (this.keysExchanged ||
         this.step !== KeyExchangeMessageType.KEY_HANDSHAKE_NONE) &&

--- a/packages/sdk-communication-layer/src/SocketService.ts
+++ b/packages/sdk-communication-layer/src/SocketService.ts
@@ -297,6 +297,14 @@ export class SocketService extends EventEmitter2 implements CommunicationLayer {
           isOriginator: this.isOriginator ?? false,
           force: true,
         });
+      } else if (this.isOriginator) {
+        await wait(3000);
+        // Backward compatibility for MetaMask Wallet < v6.5
+        // if key exchange wasn't started -- initialize it.
+        this.keyExchange.start({
+          isOriginator: this.isOriginator,
+          force: false,
+        });
       }
 
       this.clientsConnected = true;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,7 +42,7 @@
     "@metamask/onboarding": "^1.0.1",
     "@metamask/post-message-stream": "^6.1.0",
     "@metamask/providers": "^10.2.1",
-    "@metamask/sdk-communication-layer": "^0.2.3",
+    "@metamask/sdk-communication-layer": "^0.2.4",
     "@metamask/sdk-install-modal-web": "^0.2.1",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@types/dom-screen-wake-lock": "^1.0.0",


### PR DESCRIPTION
- bump sdk version
- bump comm layer version
- fix hanging keyexchange (both side waiting each other) on newest sdk connecting to older metamask