### PR TITLE
[FEAT] Allow modal customisation 

### DIFF
--- a/packages/devreactnative/package.json
+++ b/packages/devreactnative/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android": "react-native run-android --port=9095",
     "ios": "react-native run-ios --port=9095 --simulator 'iPhone 12 Pro'",
-    "ios:device": "react-native run-ios --port=9095 --device \"NAME’s iPhone\"",
+    "ios:device": "react-native run-ios --port=9095 --device \"Arthur’s iPhone\"",
     "lint": "eslint .",
     "start": "react-native start --port=9095",
     "test": "jest"

--- a/packages/devreactnative/package.json
+++ b/packages/devreactnative/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android": "react-native run-android --port=9095",
     "ios": "react-native run-ios --port=9095 --simulator 'iPhone 12 Pro'",
-    "ios:device": "react-native run-ios --port=9095 --device \"Arthur’s iPhone\"",
+    "ios:device": "react-native run-ios --port=9095 --device \"NAME’s iPhone\"",
     "lint": "eslint .",
     "start": "react-native start --port=9095",
     "test": "jest"

--- a/packages/examples/nodejs/index.js
+++ b/packages/examples/nodejs/index.js
@@ -1,9 +1,27 @@
 const { MetaMaskSDK } = require('@metamask/sdk');
+const qrcode = require('qrcode-terminal');
 
 const sdk = new MetaMaskSDK({
   shouldShimWeb3: false,
   storage: {
     enabled: true,
+  },
+  modals: {
+    install: ({ link }) => {
+      // console.debug(`open link ${link}`);
+      qrcode.generate(link, { small: true }, (qr) => console.log(qr));
+    },
+    otp: () => {
+      return {
+        updateOTPValue: (otpValue) => {
+          if (otpValue !== '') {
+            console.debug(
+              `[CUSTOMIZE TEXT] Choose the following value on your metamask mobile wallet: ${otpValue}`,
+            );
+          }
+        },
+      }
+    }
   },
 });
 
@@ -68,7 +86,7 @@ const start = async () => {
 
 ethereum.on('_initialized', () => {
   start();
-})
+});
 
 ethereum.request({
   method: 'eth_requestAccounts',

--- a/packages/examples/nodejs/package.json
+++ b/packages/examples/nodejs/package.json
@@ -9,6 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@metamask/sdk": "^0.2.2"
+    "@metamask/sdk": "^0.2.2",
+    "qrcode-terminal": "^0.12.0"
   }
 }

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -14,7 +14,10 @@ import { MetaMaskInstaller } from './Platform/MetaMaskInstaller';
 import { Platform } from './Platform/Platfform';
 import initializeProvider from './provider/initializeProvider';
 import { Ethereum } from './services/Ethereum';
-import { RemoteConnection } from './services/RemoteConnection';
+import {
+  RemoteConnection,
+  RemoteConnectionProps,
+} from './services/RemoteConnection';
 import { WalletConnect } from './services/WalletConnect';
 import { getStorageManager } from './storage-manager/getStorageManager';
 import { PlatformType } from './types/PlatformType';
@@ -46,9 +49,7 @@ export interface MetaMaskSDKOptions {
   developerMode?: boolean;
   ui?: SDKUIOptions;
   autoConnect?: AutoConnectOptions;
-  modals?: {
-    // TODO
-  };
+  modals?: Pick<RemoteConnectionProps, 'modals'>;
   communicationServerUrl?: string;
   storage?: StorageManagerProps;
   logging?: SDKLoggingOptions;
@@ -129,6 +130,7 @@ export class MetaMaskSDK extends EventEmitter2 {
       enableDebug = true,
       communicationServerUrl,
       autoConnect,
+      modals,
       // persistence settings
       storage,
       logging = {},
@@ -213,6 +215,7 @@ export class MetaMaskSDK extends EventEmitter2 {
         autoConnect,
         logging: runtimeLogging,
         modals: {
+          ...modals,
           onPendingModalDisconnect: this.terminate.bind(this),
         },
       });

--- a/packages/sdk/src/ui/InstallModal/pendingModal-nodejs.ts
+++ b/packages/sdk/src/ui/InstallModal/pendingModal-nodejs.ts
@@ -14,8 +14,6 @@ const PendingModal = (onDisconnect = () => {}) => {
           `Choose the following value on your metamask mobile wallet: ${otpValue}`,
         );
       }
-
-      return false;
     },
     mount: () => {
       return false;


### PR DESCRIPTION
- Provide developer with the ability to customize all the modal windows that are displayed (eg: i18n)
- Solves https://github.com/MetaMask/metamask-sdk/issues/87
- Add example of customization for nodejs project

```js
const sdk = new MetaMaskSDK({
  shouldShimWeb3: false,
  storage: {
    enabled: true,
  },
  modals: {
    install: ({ link }) => {
      // console.debug(`open link ${link}`);
      qrcode.generate(link, { small: true }, (qr) => console.log(qr));
    },
    otp: () => {
      return {
        updateOTPValue: (otpValue) => {
          if (otpValue !== '') {
            console.debug(
              `[CUSTOMIZE TEXT] Choose the following value on your metamask mobile wallet: ${otpValue}`,
            );
          }
        },
      }
    }
  },
});

```