### PR TITLE
[FEAT] reconnect after pause kill

### DIFF
--- a/packages/sdk-communication-layer/src/SocketService.ts
+++ b/packages/sdk-communication-layer/src/SocketService.ts
@@ -329,9 +329,10 @@ export class SocketService extends EventEmitter2 implements CommunicationLayer {
         );
       }
       if (this.isOriginator) {
+        // If it wasn't paused - need to reset keys.
         this.keyExchange.clean();
       }
-      // If it wasn't paused - need to reset keys.
+
       this.emit(EventType.CLIENTS_DISCONNECTED, channelId);
     });
 

--- a/packages/sdk-communication-layer/src/SocketService.ts
+++ b/packages/sdk-communication-layer/src/SocketService.ts
@@ -325,10 +325,12 @@ export class SocketService extends EventEmitter2 implements CommunicationLayer {
       this.clientsConnected = false;
       if (this.debug) {
         console.debug(
-          `SocketService::${this.context}::setupChannelListener::on 'clients_disconnected-${channelId}' -- reset key exchange state.`,
+          `SocketService::${this.context}::setupChannelListener::on 'clients_disconnected-${channelId}'`,
         );
       }
-      this.keyExchange.clean();
+      if (this.isOriginator) {
+        this.keyExchange.clean();
+      }
       // If it wasn't paused - need to reset keys.
       this.emit(EventType.CLIENTS_DISCONNECTED, channelId);
     });

--- a/packages/sdk-communication-layer/src/SocketService.ts
+++ b/packages/sdk-communication-layer/src/SocketService.ts
@@ -323,9 +323,12 @@ export class SocketService extends EventEmitter2 implements CommunicationLayer {
 
     this.socket.on(`clients_disconnected-${channelId}`, () => {
       this.clientsConnected = false;
-      if (this.isOriginator && !this.clientsPaused) {
-        this.keyExchange.clean();
+      if (this.debug) {
+        console.debug(
+          `SocketService::${this.context}::setupChannelListener::on 'clients_disconnected-${channelId}' -- reset key exchange state.`,
+        );
       }
+      this.keyExchange.clean();
       // If it wasn't paused - need to reset keys.
       this.emit(EventType.CLIENTS_DISCONNECTED, channelId);
     });


### PR DESCRIPTION
With session persistence, we need to ignore the PAUSED status as the wallet may be killed after being paused.
When restarting, it would generate new encryption key pair that would be ignored by the dapp.
The best way is to always reset key exchange status everytime wallet is disconnected.