### PR TITLE
Prevent duplicate preview build

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -52,6 +52,7 @@ jobs:
         run: yarn publish-previews
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}
+          SKIP_PREPACK: true
       - name: Generate preview build message
         run: yarn ts-node scripts/generate-preview-build-message.ts
       - name: Post build preview in comment


### PR DESCRIPTION
The publish preview build job was building the project twice. Now it will only build once.