### PR TITLE
Fix root build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "packages/deve2e"
   ],
   "scripts": {
-    "build": "yarn workspaces foreach run build:pre-tsc && yarn workspaces foreach -ptR --from '@metamask/sdk-install-modal-web' --from '@metamask/sdk-communication-layer' --no-private run build && yarn workspaces foreach run build:post-tsc",
+    "build": "yarn workspaces foreach --verbose run build:pre-tsc && yarn workspaces foreach --verbose --topological --parallel --no-private run build && yarn workspaces foreach --verbose run build:post-tsc",
     "build:clean": "yarn clean && yarn build",
     "build:tsc": "tsc --build --force tsconfig.json",
     "clean": "yarn workspaces foreach run clean",


### PR DESCRIPTION
The root build command was only building the communication layer and install web modal packages. Now it will build all packages.

The verbose flag has been added as well, so that we get more informative logs from the build process.