### PR TITLE
Fix types path

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,7 +15,7 @@
   "module": "dist/node/es/metamask-sdk.js",
   "browser": "dist/browser/umd/metamask-sdk.js",
   "react-native": "dist/react-native/es/metamask-sdk.js",
-  "types": "dist/browser/es/index.d.ts",
+  "types": "dist/browser/es/src/index.d.ts",
   "files": [
     "/dist"
   ],


### PR DESCRIPTION
Updating to 0.3.0 makes TypeScript fail because it can't find the type defs.