### PR TITLE
[FEAT] wait for authorized event

### DIFF
--- a/packages/sdk-communication-layer/src/RemoteCommunication.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.ts
@@ -665,7 +665,7 @@ export class RemoteCommunication extends EventEmitter2 {
       }
 
       // Only let eth_requestAccounts through to the wallet so the connection can be authorized.
-      if (message.method === 'eth_requestAccounts') {
+      if (message.method === 'eth_requestAccounts' || !this.isOriginator) {
         this.communicationLayer?.sendMessage(message);
         resolve();
       } else {

--- a/packages/sdk-communication-layer/src/RemoteCommunication.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.ts
@@ -7,6 +7,7 @@ import {
   CHANNEL_MAX_WAITING_TIME,
   DEFAULT_SERVER_URL,
   DEFAULT_SESSION_TIMEOUT_MS,
+  RPC_METHODS,
 } from './config';
 import { ECIESProps } from './ECIES';
 import { SocketService } from './SocketService';
@@ -493,7 +494,7 @@ export class RemoteCommunication extends EventEmitter2 {
       // backward compatibility for wallet <6.6
       if ('6.6'.localeCompare(this.walletInfo?.version || '') === 1) {
         this.emit(EventType.SDK_RPC_CALL, {
-          method: 'eth_requestAccounts',
+          method: RPC_METHODS.ETH_REQUESTACCOUNTS,
           params: [],
         });
       }

--- a/packages/sdk-communication-layer/src/RemoteCommunication.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.ts
@@ -667,7 +667,10 @@ export class RemoteCommunication extends EventEmitter2 {
 
       // Only let eth_requestAccounts through to the wallet so the connection can be authorized.
       // ignore authorization for wallet.
-      if (message.method === 'eth_requestAccounts' || !this.isOriginator) {
+      if (
+        message.method === RPC_METHODS.ETH_REQUESTACCOUNTS ||
+        !this.isOriginator
+      ) {
         this.communicationLayer?.sendMessage(message);
         resolve();
       } else {

--- a/packages/sdk-communication-layer/src/RemoteCommunication.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.ts
@@ -665,6 +665,7 @@ export class RemoteCommunication extends EventEmitter2 {
       }
 
       // Only let eth_requestAccounts through to the wallet so the connection can be authorized.
+      // ignore authorization for wallet.
       if (message.method === 'eth_requestAccounts' || !this.isOriginator) {
         this.communicationLayer?.sendMessage(message);
         resolve();

--- a/packages/sdk-communication-layer/src/config.ts
+++ b/packages/sdk-communication-layer/src/config.ts
@@ -9,3 +9,8 @@ export const DEFAULT_SESSION_TIMEOUT_MS = 7 * DAY_IN_MS;
 
 // time upon which we wait for a metamask reocnnection before creating a new channel
 export const CHANNEL_MAX_WAITING_TIME = 3 * 1000; // 3 seconds
+
+export const RPC_METHODS = {
+  METAMASK_GETPROVIDERSTATE: 'metamask_getProviderState',
+  ETH_REQUESTACCOUNTS: 'eth_requestAccounts',
+};


### PR DESCRIPTION
Currently, communication layer was waiting for 'ready' message from the wallet to send rpc requests.
This is incorrect since ready only means the key exchange has been completed (not that the connection was authorized or otp completed).

With this new feature, rpc methods won't be send to wallet until connection is authorized and validated on the wallet and thus prevent errors in the console.