### PR TITLE
Release 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "15.0.0",
+  "version": "16.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.4...HEAD
-[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.3...@metamask/sdk-react@0.5.4
-[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.3.1...@metamask/sdk-react@0.5.3
-[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react@0.3.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/v0.3.1...v0.5.3
+[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.3.1

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.5.4]
-### Uncategorized
+### Added
 - fix: sdk hook connector error with strictmode ([#234](https://github.com/MetaMask/metamask-sdk/pull/234))
 
 ## [0.5.3]

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4]
+### Uncategorized
+- fix: sdk hook connector error with strictmode ([#234](https://github.com/MetaMask/metamask-sdk/pull/234))
+
 ## [0.5.3]
 ### Added
 - Upgrade to latest sdk
@@ -18,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.3...HEAD
-[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/v0.3.1...v0.5.3
-[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.3.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.4...HEAD
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.3...@metamask/sdk-react@0.5.4
+[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.3.1...@metamask/sdk-react@0.5.3
+[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react@0.3.1

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.4]
 ### Added
+- feat: monorepo examples integration ([#239](https://github.com/MetaMask/metamask-sdk/pull/239))
 - fix: sdk hook connector error with strictmode ([#234](https://github.com/MetaMask/metamask-sdk/pull/234))
 
 ## [0.5.3]

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.5.4]
-### Uncategorized
+### Added
 - fix: autoconnection setting ([#235](https://github.com/MetaMask/metamask-sdk/pull/235))
 - fix: invalid types during build pipeline ([#233](https://github.com/MetaMask/metamask-sdk/pull/233))
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.4]
 ### Added
+- feat: monorepo examples integration ([#239](https://github.com/MetaMask/metamask-sdk/pull/239))
+- feat: check init before connect (+dynamic platform import) ([#238](https://github.com/MetaMask/metamask-sdk/pull/238))
+- fix: sdk hook connector error with strictmode ([#234](https://github.com/MetaMask/metamask-sdk/pull/234))
 - fix: autoconnection setting ([#235](https://github.com/MetaMask/metamask-sdk/pull/235))
 - fix: invalid types during build pipeline ([#233](https://github.com/MetaMask/metamask-sdk/pull/233))
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4]
+### Uncategorized
+- fix: autoconnection setting ([#235](https://github.com/MetaMask/metamask-sdk/pull/235))
+- fix: invalid types during build pipeline ([#233](https://github.com/MetaMask/metamask-sdk/pull/233))
+
 ## [0.5.3]
 ### Added
 - feat: persist extension provider preferences
@@ -72,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.3...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.4...HEAD
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.3...@metamask/sdk@0.5.4
 [0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.2...@metamask/sdk@0.5.3
 [0.5.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.1...@metamask/sdk@0.5.2
 [0.5.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.0...@metamask/sdk@0.5.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -221,7 +221,7 @@ export class MetaMaskSDK extends EventEmitter2 {
     });
 
     if (storage?.enabled === true && !storage.storageManager) {
-      storage.storageManager = await getStorageManager(
+      storage.storageManager = getStorageManager(
         // this.platformManager,
         storage,
       );
@@ -333,13 +333,28 @@ export class MetaMaskSDK extends EventEmitter2 {
     this.initEventListeners();
 
     if (preferExtension) {
+      if (this.debug) {
+        console.debug(
+          `SDK::_doInit() preferExtension is detected -- connect with it.`,
+        );
+      }
+
       this.connectWithExtensionProvider().catch((_err) => {
         console.warn(`Can't connect with MetaMask extension...`);
       });
     } else if (checkInstallationImmediately) {
       // This will check if the connection was correctly done or if the user needs to install MetaMask
       try {
-        await this.connect();
+        if (this.debug) {
+          console.debug(`SDK::_doInit() checkInstallationImmediately`);
+        }
+
+        this.connect().catch((_err) => {
+          // ignore error on autoconnect
+          if (this.debug) {
+            console.warn(`error during autoconnect`, _err);
+          }
+        });
       } catch (err: unknown) {
         // ignore error on autorocnnect
       }

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -222,7 +222,7 @@ export class MetaMaskSDK extends EventEmitter2 {
 
     if (storage?.enabled === true && !storage.storageManager) {
       storage.storageManager = await getStorageManager(
-        this.platformManager,
+        // this.platformManager,
         storage,
       );
     }

--- a/packages/sdk/src/storage-manager/getStorageManager.ts
+++ b/packages/sdk/src/storage-manager/getStorageManager.ts
@@ -13,10 +13,10 @@ import { StorageManagerWeb as SMDyn } from './StorageManagerWeb';
 import { StorageManagerAS as SMDyn } from './StorageManagerAS';
 // #endif
 
-export const getStorageManager = async (
+export const getStorageManager = (
   // platformManager: PlatformManager,
   options: StorageManagerProps,
-): Promise<StorageManager> => {
+): StorageManager => {
   // TODO uncomment and test to use similar dynamic imports for each platforms and drop support for JSCC
   // Currently might have an issue with NextJS and server side rendering
   // if (platformManager.isNotBrowser()) {

--- a/packages/sdk/src/storage-manager/getStorageManager.ts
+++ b/packages/sdk/src/storage-manager/getStorageManager.ts
@@ -3,7 +3,7 @@ import {
   StorageManager,
   StorageManagerProps,
 } from '@metamask/sdk-communication-layer';
-import { PlatformManager } from '../Platform/PlatfformManager';
+// import { PlatformManager } from '../Platform/PlatfformManager';
 
 /* #if _NODEJS
 import { StorageManagerNode as SMDyn } from './StorageManagerNode';
@@ -14,13 +14,14 @@ import { StorageManagerAS as SMDyn } from './StorageManagerAS';
 // #endif
 
 export const getStorageManager = async (
-  platformManager: PlatformManager,
+  // platformManager: PlatformManager,
   options: StorageManagerProps,
 ): Promise<StorageManager> => {
-  // TODO use similar dynamic imports for each platforms and drop support for JSCC
-  if (platformManager.isNotBrowser()) {
-    const { StorageManagerNode } = await import('./StorageManagerNode');
-    return new StorageManagerNode(options);
-  }
+  // TODO uncomment and test to use similar dynamic imports for each platforms and drop support for JSCC
+  // Currently might have an issue with NextJS and server side rendering
+  // if (platformManager.isNotBrowser()) {
+  //   const { StorageManagerNode } = await import('./StorageManagerNode');
+  //   return new StorageManagerNode(options);
+  // }
   return new SMDyn(options);
 };


### PR DESCRIPTION
## sdk-react [0.5.4]
### Added
- feat: monorepo examples integration ([#239](https://github.com/MetaMask/metamask-sdk/pull/239))
- fix: sdk hook connector error with strictmode ([#234](https://github.com/MetaMask/metamask-sdk/pull/234))

## sdk [0.5.4]
### Added
- feat: monorepo examples integration ([#239](https://github.com/MetaMask/metamask-sdk/pull/239))
- feat: check init before connect (+dynamic platform import) ([#238](https://github.com/MetaMask/metamask-sdk/pull/238))
- fix: sdk hook connector error with strictmode ([#234](https://github.com/MetaMask/metamask-sdk/pull/234))
- fix: autoconnection setting ([#235](https://github.com/MetaMask/metamask-sdk/pull/235))
- fix: invalid types during build pipeline ([#233](https://github.com/MetaMask/metamask-sdk/pull/233))
