### PR TITLE
feat: check init before connect (+dynamic platform import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@ Import the SDK (for possible parameters check this):
 ```ts
 import { MetaMaskSDK } from '@metamask/sdk';
 const MMSDK = new MetaMaskSDK({});
-MMSDK.init()
-  .then(() => {
-    console.log('MetaMask SDK is ready');
+MMSDK.connect()
+  .then((accounts) => {
+    console.log('MetaMask SDK is connected', accounts);
     const ethereum = MMSDK.getProvider();
-    ethereum.request({ method: 'eth_requestAccounts', params: [] });
+    const ethereum = sdk.getProvider();
+    const balance = await ethereum.request({
+      method: 'eth_getBalance',
+      params: accounts,
+    });
+
+    console.debug(`account balance`, balance);
   })
   .catch((error) => {
     console.error(error);

--- a/packages/deve2e/package.json
+++ b/packages/deve2e/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "",
-  "main": "dist/node/es/deve2e.js",
+  "main": "dist/deve2e.js",
   "files": [
     "dist"
   ],
@@ -17,8 +17,9 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "reset": "rimraf node_modules && yarn clean",
-    "start": "ROLLUP_RUN=true yarn build",
+    "start": "yarn build && node dist/deve2e.js ${TARGET:-sdk}",
     "test": "echo 'N/A'",
+    "allow-scripts": "echo 'N/A'",
     "test:ci": "echo 'N/A'",
     "watch": "yarn start --watch"
   },
@@ -30,7 +31,6 @@
     "pump": "^3.0.0"
   },
   "devDependencies": {
-    "@lavamoat/allow-scripts": "^2.3.1",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-run": "^3.0.1",
@@ -38,15 +38,7 @@
     "rollup": "^3.7.3",
     "rollup-plugin-serve": "^2.0.2",
     "rollup-plugin-typescript2": "^0.34.1",
+    "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
-  },
-  "lavamoat": {
-    "allowScripts": {
-      "@metamask/sdk>eciesjs>secp256k1": false,
-      "@metamask/sdk>react-native>react-devtools-core>ws>bufferutil": false,
-      "@metamask/sdk>react-native>react-devtools-core>ws>utf-8-validate": false,
-      "@metamask/sdk>socket.io-client>engine.io-client>ws>bufferutil": false,
-      "@metamask/sdk>socket.io-client>engine.io-client>ws>utf-8-validate": false
-    }
   }
 }

--- a/packages/deve2e/rollup.config.cjs
+++ b/packages/deve2e/rollup.config.cjs
@@ -34,6 +34,7 @@ const config = [
       {
         file: 'dist/deve2e.js',
         format: 'cjs',
+        inlineDynamicImports: true,
         sourcemap: true,
       },
     ],

--- a/packages/deve2e/src/e2e-communication.ts
+++ b/packages/deve2e/src/e2e-communication.ts
@@ -1,3 +1,4 @@
+import { PlatformType } from '@metamask/sdk';
 import {
   CommunicationLayerPreference,
   EventType,
@@ -20,12 +21,11 @@ const waitForReady = async (): Promise<void> => {
 
 export const mainCommunication = async () => {
   const communicationLayerPreference = CommunicationLayerPreference.SOCKET;
-  const platform = 'jest';
   const communicationServerUrl = 'http://localhost:4000/';
 
   const remote = new RemoteCommunication({
     communicationLayerPreference,
-    platform,
+    platformType: PlatformType.NonBrowser,
     communicationServerUrl,
     context: 'dapp',
     logging: {
@@ -37,7 +37,7 @@ export const mainCommunication = async () => {
     analytics: true,
   });
 
-  const { channelId, pubKey } = await remote.generateChannelId();
+  const { channelId, pubKey } = await remote.generateChannelIdConnect();
 
   remote.on(EventType.CLIENTS_READY, () => {
     clientsReady = true;
@@ -45,7 +45,7 @@ export const mainCommunication = async () => {
 
   const mmRemote = new RemoteCommunication({
     communicationLayerPreference,
-    platform,
+    platformType: 'metamask-mobile',
     otherPublicKey: pubKey,
     communicationServerUrl,
     context: 'metamask',

--- a/packages/deve2e/src/e2e-sdk.ts
+++ b/packages/deve2e/src/e2e-sdk.ts
@@ -3,21 +3,24 @@ import { MetaMaskSDK } from '@metamask/sdk';
 export const mainSDK = async () => {
   const sdk = new MetaMaskSDK({
     shouldShimWeb3: false,
-    // communicationServerUrl: 'http://localhost:4000/',
+    communicationServerUrl: 'http://localhost:4000/',
+    logging: {
+      developerMode: false,
+    },
     dappMetadata: {
       name: 'NodeJS Console',
       url: 'N/A',
     },
   });
 
-  const ethereum = sdk.getProvider();
+  const accounts = await sdk.connect();
 
-  const accounts = await ethereum.request({
-    method: 'eth_requestAccounts',
-    params: [],
+  console.log(`connected with accounts`, accounts);
+  const ethereum = sdk.getProvider();
+  const balance = await ethereum.request({
+    method: 'eth_getBalance',
+    params: accounts,
   });
 
-  console.log('request accounts', accounts);
-
-  sdk.disconnect();
+  console.debug(`account balance`, balance);
 };

--- a/packages/deve2e/src/e2e-sdk.ts
+++ b/packages/deve2e/src/e2e-sdk.ts
@@ -3,10 +3,7 @@ import { MetaMaskSDK } from '@metamask/sdk';
 export const mainSDK = async () => {
   const sdk = new MetaMaskSDK({
     shouldShimWeb3: false,
-    communicationServerUrl: 'http://localhost:4000/',
-    logging: {
-      developerMode: false,
-    },
+    // communicationServerUrl: 'http://localhost:4000/',
     dappMetadata: {
       name: 'NodeJS Console',
       url: 'N/A',

--- a/packages/deve2e/src/index.ts
+++ b/packages/deve2e/src/index.ts
@@ -13,6 +13,12 @@ if (target === 'sdk') {
   methodToCall = ECIESEncryptedCommunicaition;
 }
 
-methodToCall().then(() => {
-  console.log(`exiting.`);
-});
+const startAsync = async () => {
+  try {
+    await methodToCall();
+  } catch (err) {
+    console.error(`error: ${err}`);
+  }
+};
+
+startAsync();

--- a/packages/deve2e/tsconfig.json
+++ b/packages/deve2e/tsconfig.json
@@ -7,5 +7,19 @@
     "types": ["node"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    {
+      "path": "../sdk/tsconfig.build.json"
+    },
+    {
+      "path": "../sdk-react/tsconfig.json"
+    },
+    {
+      "path": "../sdk-communication-layer/tsconfig.build.json"
+    },
+    {
+      "path": "../sdk-install-modal-web"
+    }
+  ]
 }

--- a/packages/sdk/src/Platform/PlatfformManager.ts
+++ b/packages/sdk/src/Platform/PlatfformManager.ts
@@ -177,6 +177,10 @@ export class PlatformManager {
     );
   }
 
+  isNodeJS() {
+    return this.isNotBrowser() && !this.isReactNative();
+  }
+
   isBrowser() {
     return !this.isNotBrowser();
   }

--- a/packages/sdk/src/storage-manager/getStorageManager.ts
+++ b/packages/sdk/src/storage-manager/getStorageManager.ts
@@ -3,6 +3,7 @@ import {
   StorageManager,
   StorageManagerProps,
 } from '@metamask/sdk-communication-layer';
+import { PlatformManager } from '../Platform/PlatfformManager';
 
 /* #if _NODEJS
 import { StorageManagerNode as SMDyn } from './StorageManagerNode';
@@ -12,8 +13,14 @@ import { StorageManagerWeb as SMDyn } from './StorageManagerWeb';
 import { StorageManagerAS as SMDyn } from './StorageManagerAS';
 // #endif
 
-export const getStorageManager = (
+export const getStorageManager = async (
+  platformManager: PlatformManager,
   options: StorageManagerProps,
-): StorageManager => {
+): Promise<StorageManager> => {
+  // TODO use similar dynamic imports for each platforms and drop support for JSCC
+  if (platformManager.isNotBrowser()) {
+    const { StorageManagerNode } = await import('./StorageManagerNode');
+    return new StorageManagerNode(options);
+  }
   return new SMDyn(options);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,7 +3875,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/deve2e@workspace:packages/deve2e"
   dependencies:
-    "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/providers": ^10.2.1
     "@metamask/sdk": "workspace:^"
     "@metamask/sdk-communication-layer": "workspace:^"
@@ -3888,6 +3887,7 @@ __metadata:
     rollup: ^3.7.3
     rollup-plugin-serve: ^2.0.2
     rollup-plugin-typescript2: ^0.34.1
+    ts-node: ^10.9.1
     typescript: ^5.0.4
   languageName: unknown
   linkType: soft
@@ -4115,7 +4115,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/sdk-react@workspace:packages/sdk-react":
+"@metamask/sdk-react@workspace:^, @metamask/sdk-react@workspace:packages/sdk-react":
   version: 0.0.0-use.local
   resolution: "@metamask/sdk-react@workspace:packages/sdk-react"
   dependencies:
@@ -10758,6 +10758,7 @@ __metadata:
     "@metamask/sdk": "workspace:^"
     "@metamask/sdk-communication-layer": "workspace:^"
     "@metamask/sdk-install-modal-web": "workspace:^"
+    "@metamask/sdk-react": "workspace:^"
     "@types/eslint": ^8
     "@types/node": 18.15.3
     "@types/react": 18.0.28


### PR DESCRIPTION
- Add dynamic import of platform manager (allow to remove JSCC)
- simplify sdk init process by only using connect()
- update deve2e to match latest sdk format