### PR TITLE
feat: restrict autoconnect desktopweb

### DIFF
--- a/packages/devnext/src/pages/_app.tsx
+++ b/packages/devnext/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import '../styles/globals.css';
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <MetaMaskProvider debug={true} sdkOptions={{
+      communicationServerUrl: process.env.NEXT_PUBLIC_COMM_SERVER_URL,
       logging: {
         developerMode: true,
         sdk: false,

--- a/packages/sdk/src/Platform/PlatfformManager.ts
+++ b/packages/sdk/src/Platform/PlatfformManager.ts
@@ -140,6 +140,10 @@ export class PlatformManager {
     return eth?.isMetaMask && eth?.isConnected();
   }
 
+  isDesktopWeb() {
+    return this.isBrowser() && !this.isMobileWeb();
+  }
+
   isMobile() {
     const browser = Bowser.parse(window.navigator.userAgent);
     return (

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -33,7 +33,7 @@ export interface MetaMaskSDKOptions {
   injectProvider?: boolean;
   forceInjectProvider?: boolean;
   forceDeleteProvider?: boolean;
-  // Tries to autoconnect on startup
+  // Tries to autoconnect on startup (only for Desktop WEB)
   checkInstallationImmediately?: boolean;
   checkInstallationOnAllCalls?: boolean;
   preferDesktop?: boolean;
@@ -350,7 +350,10 @@ export class MetaMaskSDK extends EventEmitter2 {
         // Clean preferences
         localStorage.removeItem(STORAGE_PROVIDER_TYPE);
       });
-    } else if (checkInstallationImmediately) {
+    } else if (
+      checkInstallationImmediately &&
+      this.platformManager.isDesktopWeb()
+    ) {
       // This will check if the connection was correctly done or if the user needs to install MetaMask
       try {
         if (this.debug) {
@@ -366,6 +369,10 @@ export class MetaMaskSDK extends EventEmitter2 {
       } catch (err: unknown) {
         // ignore error on autorocnnect
       }
+    } else if (checkInstallationImmediately && this.debug) {
+      console.warn(
+        `SDK::_doInit() checkInstallationImmediately --- IGNORED --- only for web desktop`,
+      );
     }
 
     this._initialized = true;

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -350,32 +350,24 @@ export class MetaMaskSDK extends EventEmitter2 {
         // Clean preferences
         localStorage.removeItem(STORAGE_PROVIDER_TYPE);
       });
-    } else if (
-      checkInstallationImmediately &&
-      this.platformManager.isDesktopWeb()
-    ) {
-      // This will check if the connection was correctly done or if the user needs to install MetaMask
-      try {
+    } else if (checkInstallationImmediately) {
+      if (this.platformManager.isDesktopWeb()) {
         if (this.debug) {
           console.debug(`SDK::_doInit() checkInstallationImmediately`);
         }
 
+        // Don't block /await initialization on autoconnect
         this.connect().catch((_err) => {
           // ignore error on autoconnect
           if (this.debug) {
             console.warn(`error during autoconnect`, _err);
           }
         });
-      } catch (err: unknown) {
-        // ignore error on autorocnnect
+      } else {
+        console.warn(
+          `SDK::_doInit() checkInstallationImmediately --- IGNORED --- only for web desktop`,
+        );
       }
-    } else if (
-      checkInstallationImmediately &&
-      !this.platformManager.isDesktopWeb()
-    ) {
-      console.warn(
-        `SDK::_doInit() checkInstallationImmediately --- IGNORED --- only for web desktop`,
-      );
     }
 
     this._initialized = true;

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -369,7 +369,10 @@ export class MetaMaskSDK extends EventEmitter2 {
       } catch (err: unknown) {
         // ignore error on autorocnnect
       }
-    } else if (checkInstallationImmediately && this.debug) {
+    } else if (
+      checkInstallationImmediately &&
+      !this.platformManager.isDesktopWeb()
+    ) {
       console.warn(
         `SDK::_doInit() checkInstallationImmediately --- IGNORED --- only for web desktop`,
       );


### PR DESCRIPTION
Disable auto connect feature on mobile because it doesn't make sense to automatically tries to deeplink and gives an inconsistent ux between platforms.