### PR TITLE
feat: add pathmapping to deve2e nodejs project

### DIFF
--- a/packages/deve2e/package.json
+++ b/packages/deve2e/package.json
@@ -18,6 +18,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path ../../.gitignore",
     "reset": "rimraf node_modules && yarn clean",
     "start": "yarn build && node dist/deve2e.js ${TARGET:-sdk}",
+    "ts-start": "ts-node -r tsconfig-paths/register --project tsconfig.json src/index.ts ${TARGET:-sdk}",
     "test": "echo 'N/A'",
     "allow-scripts": "echo 'N/A'",
     "test:ci": "echo 'N/A'",
@@ -39,6 +40,7 @@
     "rollup-plugin-serve": "^2.0.2",
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.0.4"
   }
 }

--- a/packages/deve2e/tsconfig.json
+++ b/packages/deve2e/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "module": "ESNext",
+    "module": "CommonJS",
     "target": "es2017",
     "types": ["node"]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,6 +3895,7 @@ __metadata:
     rollup-plugin-serve: ^2.0.2
     rollup-plugin-typescript2: ^0.34.1
     ts-node: ^10.9.1
+    tsconfig-paths: ^4.2.0
     typescript: ^5.0.4
   languageName: unknown
   linkType: soft
@@ -27516,6 +27517,17 @@ __metadata:
     minimist: ^1.2.6
     strip-bom: ^3.0.0
   checksum: a6162eaa1aed680537f93621b82399c7856afd10ec299867b13a0675e981acac4e0ec00896860480efc59fc10fd0b16fdc928c0b885865b52be62cadac692447
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "tsconfig-paths@npm:4.2.0"
+  dependencies:
+    json5: ^2.2.2
+    minimist: ^1.2.6
+    strip-bom: ^3.0.0
+  checksum: 28c5f7bbbcabc9dabd4117e8fdc61483f6872a1c6b02a4b1c4d68c5b79d06896c3cc9547610c4c3ba64658531caa2de13ead1ea1bf321c7b53e969c4752b98c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
feat: add pathmapping to deve2e nodejs project

This allows faster development without recompiling dependencies on each run.