### PR TITLE
docs: invalid uppercase link to contributing document

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ You can find the full interface in [sdk.ts](./packages/sdk/src/sdk.ts) file but 
 
 ## Contributing
 
-Please see our [contributing guidelines](./docs/CONTRIBUTING.md) for more information.
+Please see our [contributing guidelines](./docs/contributing.md) for more information.


### PR DESCRIPTION
docs: invalid uppercase link to contributing document