### PR TITLE
feat: add sideEffects field to sdk package

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,6 +16,7 @@
   "browser": "dist/browser/umd/metamask-sdk.js",
   "react-native": "dist/react-native/es/metamask-sdk.js",
   "types": "dist/browser/es/src/index.d.ts",
+  "sideEffects": false,
   "files": [
     "/dist"
   ],


### PR DESCRIPTION
Without "sideEffects" defined (e.g. "sideEffects": false) build systems aren't able to properly eliminate dead code (e.g. Next.js) and could still load these packages even if they are not used.

More info: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free