### PR TITLE
feat: add unit tests to the RemoteCommunication class

### DIFF
--- a/packages/sdk-communication-layer/src/RemoteCommunication.test.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.test.ts
@@ -1,0 +1,180 @@
+import packageJson from '../package.json';
+import { RemoteCommunication } from './RemoteCommunication';
+import { CommunicationLayer } from './types/CommunicationLayer';
+import { CommunicationLayerPreference } from './types/CommunicationLayerPreference';
+import { ConnectionStatus } from './types/ConnectionStatus';
+import { EventType } from './types/EventType';
+
+jest.mock('./services/RemoteCommunication/ConnectionManager');
+
+describe('RemoteCommunication', () => {
+  let remoteCommunicationInstance: RemoteCommunication;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    remoteCommunicationInstance = new RemoteCommunication({
+      platformType: 'metamask-mobile',
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      context: 'some-context',
+    });
+  });
+
+  describe('constructor', () => {
+    it('should initialize with default values', () => {
+      expect(remoteCommunicationInstance.state.ready).toBe(false);
+      expect(remoteCommunicationInstance.state.authorized).toBe(false);
+      expect(remoteCommunicationInstance.state.platformType).toStrictEqual(
+        'metamask-mobile',
+      );
+    });
+  });
+
+  describe('setConnectionStatus', () => {
+    it('should set connection status and emit events', () => {
+      const emitSpy = jest.spyOn(remoteCommunicationInstance, 'emit');
+      remoteCommunicationInstance.setConnectionStatus(ConnectionStatus.PAUSED);
+
+      expect(remoteCommunicationInstance.state._connectionStatus).toStrictEqual(
+        ConnectionStatus.PAUSED,
+      );
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        EventType.CONNECTION_STATUS,
+        ConnectionStatus.PAUSED,
+      );
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        EventType.SERVICE_STATUS,
+        expect.anything(),
+      );
+    });
+
+    it('should not re-emit if status is same', () => {
+      const emitSpy = jest.spyOn(remoteCommunicationInstance, 'emit');
+      remoteCommunicationInstance.setConnectionStatus(ConnectionStatus.PAUSED);
+      emitSpy.mockClear();
+      remoteCommunicationInstance.setConnectionStatus(ConnectionStatus.PAUSED);
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isReady', () => {
+    it('should return the ready state', () => {
+      expect(remoteCommunicationInstance.isReady()).toBe(false);
+      remoteCommunicationInstance.state.ready = true;
+      expect(remoteCommunicationInstance.isReady()).toBe(true);
+    });
+  });
+
+  describe('isConnected', () => {
+    it('should return false when communicationLayer is undefined', () => {
+      expect(remoteCommunicationInstance.isConnected()).toBeUndefined();
+    });
+
+    it('should return communicationLayer isConnected state', () => {
+      remoteCommunicationInstance.state.communicationLayer = {
+        isConnected: jest.fn().mockReturnValue(true),
+      } as unknown as CommunicationLayer;
+      expect(remoteCommunicationInstance.isConnected()).toBe(true);
+    });
+  });
+
+  describe('isAuthorized', () => {
+    it('should return the authorized state', () => {
+      expect(remoteCommunicationInstance.isAuthorized()).toBe(false);
+      remoteCommunicationInstance.state.authorized = true;
+      expect(remoteCommunicationInstance.isAuthorized()).toBe(true);
+    });
+  });
+
+  describe('isPaused', () => {
+    it('should return the paused state', () => {
+      expect(remoteCommunicationInstance.isPaused()).toBe(false);
+      remoteCommunicationInstance.state.paused = true;
+      expect(remoteCommunicationInstance.isPaused()).toBe(true);
+    });
+  });
+
+  describe('getVersion', () => {
+    it('should return the package version', () => {
+      expect(remoteCommunicationInstance.getVersion()).toBe(
+        packageJson.version,
+      );
+    });
+  });
+
+  describe('getCommunicationLayer', () => {
+    it('should return the communicationLayer state', () => {
+      const mockCommLayer = {} as unknown as CommunicationLayer;
+      remoteCommunicationInstance.state.communicationLayer = mockCommLayer;
+      expect(remoteCommunicationInstance.getCommunicationLayer()).toBe(
+        mockCommLayer,
+      );
+    });
+  });
+
+  describe('ping', () => {
+    it('should call communicationLayer ping method if defined and debug state is true', () => {
+      const pingMock = jest.fn();
+      remoteCommunicationInstance.state.communicationLayer = {
+        ping: pingMock,
+        // ...mock other properties if necessary
+      } as unknown as CommunicationLayer;
+      remoteCommunicationInstance.state.debug = true;
+      remoteCommunicationInstance.ping();
+      expect(pingMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('keyCheck', () => {
+    it('should call communicationLayer keyCheck method if defined and debug state is true', () => {
+      const keyCheckMock = jest.fn();
+      remoteCommunicationInstance.state.communicationLayer = {
+        keyCheck: keyCheckMock,
+      } as unknown as CommunicationLayer;
+      remoteCommunicationInstance.state.debug = true;
+      remoteCommunicationInstance.keyCheck();
+      expect(keyCheckMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('getConnectionStatus', () => {
+    it('should return the current connection status', () => {
+      remoteCommunicationInstance.state._connectionStatus =
+        ConnectionStatus.DISCONNECTED;
+
+      expect(remoteCommunicationInstance.getConnectionStatus()).toBe(
+        ConnectionStatus.DISCONNECTED,
+      );
+    });
+  });
+
+  describe('getServiceStatus', () => {
+    it('should return the service status', () => {
+      const mockServiceStatus = {
+        originatorInfo: undefined,
+        keyInfo: undefined,
+        connectionStatus: ConnectionStatus.DISCONNECTED,
+        channelConfig: undefined,
+        channelId: 'mockChannelId',
+      };
+
+      remoteCommunicationInstance.state.originatorInfo =
+        mockServiceStatus.originatorInfo;
+
+      remoteCommunicationInstance.state.channelConfig =
+        mockServiceStatus.channelConfig;
+      remoteCommunicationInstance.state.channelId = mockServiceStatus.channelId;
+      remoteCommunicationInstance.state._connectionStatus =
+        mockServiceStatus.connectionStatus;
+
+      jest
+        .spyOn(remoteCommunicationInstance, 'getKeyInfo')
+        .mockReturnValue(mockServiceStatus.keyInfo);
+
+      expect(remoteCommunicationInstance.getServiceStatus()).toStrictEqual(
+        mockServiceStatus,
+      );
+    });
+  });
+});

--- a/packages/sdk-communication-layer/src/RemoteCommunication.test.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.test.ts
@@ -118,7 +118,6 @@ describe('RemoteCommunication', () => {
       const pingMock = jest.fn();
       remoteCommunicationInstance.state.communicationLayer = {
         ping: pingMock,
-        // ...mock other properties if necessary
       } as unknown as CommunicationLayer;
       remoteCommunicationInstance.state.debug = true;
       remoteCommunicationInstance.ping();

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ChannelManager/clean.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ChannelManager/clean.test.ts
@@ -1,0 +1,49 @@
+import { RemoteCommunicationState } from '../../../RemoteCommunication';
+import { clean } from './clean';
+
+describe('clean', () => {
+  let state: RemoteCommunicationState;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state = {
+      debug: false,
+      context: 'test',
+      channelConfig: {
+        channelId: 'channelId',
+        validUntil: 12345679,
+      },
+      ready: true,
+      originatorConnectStarted: true,
+    } as RemoteCommunicationState;
+  });
+
+  it('should reset state properties to their default values', () => {
+    clean(state);
+
+    expect(state.channelConfig).toBeUndefined();
+    expect(state.ready).toBe(false);
+    expect(state.originatorConnectStarted).toBe(false);
+  });
+
+  it('should log a debug message if debug is true', () => {
+    jest.spyOn(console, 'debug').mockImplementation();
+
+    state.debug = true;
+
+    clean(state);
+
+    expect(console.debug).toHaveBeenCalledWith(
+      'RemoteCommunication::test::clean()',
+    );
+  });
+
+  it('should not log a debug message if debug is false', () => {
+    jest.spyOn(console, 'debug').mockImplementation();
+
+    clean(state);
+
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ChannelManager/generateChannelIdConnect.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ChannelManager/generateChannelIdConnect.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { RemoteCommunicationState } from '../../../RemoteCommunication';
+import { CommunicationLayer } from '../../../types/CommunicationLayer';
+import { StorageManager } from '../../../types/StorageManager';
+import { generateChannelIdConnect } from './generateChannelIdConnect';
+import { clean } from './clean';
+
+jest.mock('./clean');
+
+describe('generateChannelIdConnect', () => {
+  let state: RemoteCommunicationState;
+
+  const mockClean = clean as jest.MockedFunction<typeof clean>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state = {
+      channelConfig: undefined,
+      communicationLayer: {
+        channelId: 'mockChannelId',
+        pubKey: 'mockPublicKey',
+        createChannel: jest.fn(() => ({
+          channelId: 'mockChannelId',
+          pubKey: 'mockPublicKey',
+        })),
+        isConnected: jest.fn(() => false),
+        getKeyInfo: jest.fn(() => ({ ecies: { public: 'mockPublicKey' } })),
+      } as unknown as CommunicationLayer,
+      ready: false,
+      channelId: undefined,
+      sessionDuration: 1000,
+      debug: false,
+    } as RemoteCommunicationState;
+  });
+
+  it('should throw error if communicationLayer is not initialized', () => {
+    state.communicationLayer = undefined;
+
+    expect(() => {
+      generateChannelIdConnect(state);
+    }).toThrow('communication layer not initialized');
+  });
+
+  it('should throw error if channel is already connected', () => {
+    state.ready = true;
+    state.communicationLayer = {
+      isConnected: jest.fn(() => true),
+    } as unknown as CommunicationLayer;
+
+    expect(() => {
+      generateChannelIdConnect(state);
+    }).toThrow('Channel already connected');
+  });
+
+  it('should generate a new channel ID if none exists', () => {
+    const mockChannel = {
+      channelId: 'mockChannelId',
+      pubKey: 'mockPublicKey',
+      createChannel: jest.fn(() => ({
+        channelId: 'mockChannelId',
+        pubKey: 'mockPublicKey',
+      })),
+      isConnected: jest.fn(() => false),
+      getKeyInfo: jest.fn(() => ({ ecies: { public: 'mockPublicKey' } })),
+    } as unknown as CommunicationLayer;
+
+    state.communicationLayer = mockChannel;
+
+    const result = generateChannelIdConnect(state);
+    expect(result).toStrictEqual({
+      channelId: 'mockChannelId',
+      pubKey: 'mockPublicKey',
+    });
+  });
+
+  it('should persist channelConfig if storageManager exists', () => {
+    const mockChannel = {
+      channelId: 'mockChannelId',
+      pubKey: 'mockPublicKey',
+      createChannel: jest.fn(() => ({
+        channelId: 'mockChannelId',
+        pubKey: 'mockPublicKey',
+      })),
+      isConnected: jest.fn(() => false),
+      getKeyInfo: jest.fn(() => ({ ecies: { public: 'mockPublicKey' } })),
+    } as unknown as CommunicationLayer;
+
+    const mockPersist = jest.fn();
+
+    state.communicationLayer = mockChannel;
+    state.storageManager = {
+      persistChannelConfig: mockPersist,
+    } as unknown as StorageManager;
+
+    generateChannelIdConnect(state);
+
+    expect(mockPersist).toHaveBeenCalledWith({
+      channelId: 'mockChannelId',
+      validUntil: expect.any(Number),
+    });
+  });
+
+  it('should log a warning if a channel already exists', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    state.channelId = 'existingChannelId';
+    state.communicationLayer!.isConnected = () => true;
+
+    const { channelConfig } = state;
+
+    generateChannelIdConnect(state);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      `Channel already exists -- interrupt generateChannelId`,
+      channelConfig,
+    );
+  });
+
+  it('should log debug messages if debug is enabled', () => {
+    jest.spyOn(console, 'debug').mockImplementation();
+
+    state.debug = true;
+
+    generateChannelIdConnect(state);
+
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::generateChannelId()`,
+    );
+
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::generateChannelId() channel created`,
+      expect.anything(),
+    );
+  });
+
+  it('should call clean function if no channelId exists', () => {
+    generateChannelIdConnect(state);
+
+    expect(mockClean).toHaveBeenCalledWith(state);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/connectToChannel.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/connectToChannel.test.ts
@@ -1,0 +1,125 @@
+import { v4 as uuid } from 'uuid';
+import { RemoteCommunicationState } from '../../../RemoteCommunication';
+import { CommunicationLayer } from '../../../types/CommunicationLayer';
+import { StorageManager } from '../../../types/StorageManager';
+import { connectToChannel } from './connectToChannel';
+
+describe('connectToChannel', () => {
+  let state: RemoteCommunicationState;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state = {
+      communicationLayer: {
+        isConnected: jest.fn(() => false),
+        connectToChannel: jest.fn(),
+      } as unknown as CommunicationLayer,
+      channelId: undefined,
+      sessionDuration: 1000,
+      context: 'TestContext',
+      debug: false,
+    } as RemoteCommunicationState;
+  });
+
+  it('should throw error if channel ID is invalid', () => {
+    const channelId = 'invalidChannelId';
+
+    expect(() => {
+      connectToChannel({ channelId, state });
+    }).toThrow(`Invalid channel ${channelId}`);
+  });
+
+  it('should debug log if the channel is already connected', () => {
+    const channelId = uuid();
+    state.communicationLayer = {
+      isConnected: jest.fn(() => true),
+    } as unknown as CommunicationLayer;
+
+    const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+    connectToChannel({ channelId, state });
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      `RemoteCommunication::TestContext::connectToChannel() already connected - interrup connection.`,
+    );
+
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should connect to a valid channel', () => {
+    const channelId = uuid();
+    const mockConnect = jest.fn();
+    state.communicationLayer = {
+      isConnected: jest.fn(() => false),
+      connectToChannel: mockConnect,
+    } as unknown as CommunicationLayer;
+
+    connectToChannel({ channelId, state });
+
+    expect(mockConnect).toHaveBeenCalledWith({
+      channelId,
+      withKeyExchange: undefined,
+    });
+  });
+
+  it('should persist channelConfig if storageManager exists', () => {
+    const channelId = uuid();
+    const mockPersist = jest.fn();
+
+    state.communicationLayer = {
+      isConnected: jest.fn(() => false),
+      connectToChannel: jest.fn(),
+    } as unknown as CommunicationLayer;
+
+    state.storageManager = {
+      persistChannelConfig: mockPersist,
+    } as unknown as StorageManager;
+
+    connectToChannel({ channelId, state });
+
+    expect(mockPersist).toHaveBeenCalledWith({
+      channelId,
+      validUntil: expect.any(Number),
+    });
+  });
+
+  it('should connect with key exchange when provided', () => {
+    const channelId = uuid();
+    const mockConnect = jest.fn();
+    state.communicationLayer = {
+      isConnected: jest.fn(() => false),
+      connectToChannel: mockConnect,
+    } as unknown as CommunicationLayer;
+
+    connectToChannel({ channelId, withKeyExchange: true, state });
+
+    expect(mockConnect).toHaveBeenCalledWith({
+      channelId,
+      withKeyExchange: true,
+    });
+  });
+
+  it('should debug log a valid channelId if debug is enabled', () => {
+    const channelId = uuid();
+    state.debug = true;
+
+    const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+    connectToChannel({ channelId, state });
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      `RemoteCommunication::${state.context}::connectToChannel() channelId=${channelId}`,
+    );
+
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should set the new channelId in the state', () => {
+    const channelId = uuid();
+
+    connectToChannel({ channelId, state });
+
+    expect(state.channelId).toStrictEqual(channelId);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/disconnect.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/disconnect.test.ts
@@ -1,0 +1,196 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { ConnectionStatus } from '../../../types/ConnectionStatus';
+import { CommunicationLayer } from '../../../types/CommunicationLayer';
+import { StorageManager } from '../../../types/StorageManager';
+import { MessageType } from '../../../types/MessageType';
+import { disconnect } from './disconnect';
+
+describe('disconnect', () => {
+  let instance: RemoteCommunication;
+  const mockSetConnectionStatus = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        communicationLayer: {
+          getKeyInfo: jest.fn(() => ({ keysExchanged: false })),
+          sendMessage: jest.fn(),
+          disconnect: jest.fn(),
+        } as unknown as CommunicationLayer,
+        debug: false,
+        channelId: 'sampleChannelId',
+      },
+      setConnectionStatus: mockSetConnectionStatus,
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should disconnect without termination if no options are provided', () => {
+    disconnect({ instance });
+
+    expect(instance.state.communicationLayer?.disconnect).toHaveBeenCalledWith(
+      undefined,
+    );
+
+    expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.DISCONNECTED,
+    );
+  });
+
+  it('should terminate connection and send message if terminate option is provided', () => {
+    instance.state.communicationLayer = {
+      ...instance.state.communicationLayer,
+      getKeyInfo: jest.fn(() => ({ keysExchanged: true })),
+    } as unknown as CommunicationLayer;
+
+    const options = {
+      terminate: true,
+      sendMessage: true,
+    };
+
+    disconnect({ options, instance });
+
+    expect(instance.state.communicationLayer?.sendMessage).toHaveBeenCalledWith(
+      {
+        type: MessageType.TERMINATE,
+      },
+    );
+
+    expect(instance.state.communicationLayer?.disconnect).toHaveBeenCalledWith(
+      options,
+    );
+
+    expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.TERMINATED,
+    );
+  });
+
+  it('should remove channel config from persistence layer if terminate option is provided', () => {
+    const mockTerminate = jest.fn();
+
+    instance.state.storageManager = {
+      terminate: mockTerminate,
+    } as unknown as StorageManager;
+
+    const options = {
+      terminate: true,
+    };
+
+    disconnect({ options, instance });
+
+    expect(mockTerminate).toHaveBeenCalledWith('sampleChannelId');
+  });
+
+  it('should generate a new channel ID on termination', () => {
+    const options = {
+      terminate: true,
+    };
+
+    disconnect({ options, instance });
+
+    expect(instance.state.channelId).not.toStrictEqual('sampleChannelId');
+  });
+
+  it('should not send a termination message if keysExchanged is false', () => {
+    const options = {
+      terminate: true,
+      sendMessage: true,
+    };
+
+    disconnect({ options, instance });
+
+    expect(
+      instance.state.communicationLayer?.sendMessage,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should reset ready and paused states', () => {
+    instance.state.ready = true;
+    instance.state.paused = true;
+
+    disconnect({ instance });
+
+    expect(instance.state.ready).toBe(false);
+    expect(instance.state.paused).toBe(false);
+  });
+
+  it('should not regenerate channelId if the terminate option is not provided', () => {
+    disconnect({ instance });
+
+    expect(instance.state.channelId).toStrictEqual('sampleChannelId');
+  });
+
+  it('should set connection to TERMINATED only if terminate option is true', () => {
+    const options = {
+      terminate: false,
+    };
+
+    disconnect({ options, instance });
+
+    expect(mockSetConnectionStatus).not.toHaveBeenCalledWith(
+      ConnectionStatus.TERMINATED,
+    );
+  });
+
+  it('should log debug information if debug is enabled', () => {
+    instance.state.debug = true;
+    const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+    disconnect({ instance });
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      `RemoteCommunication::disconnect() channel=${instance.state.channelId}`,
+      undefined,
+    );
+
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should reset originatorConnectStarted on termination', () => {
+    const options = {
+      terminate: true,
+    };
+
+    disconnect({ options, instance });
+
+    expect(instance.state.originatorConnectStarted).toBe(false);
+  });
+
+  it('should undefine the channelConfig on termination', () => {
+    instance.state.channelConfig = {
+      channelId: 'sampleChannelId',
+      validUntil: 123456789,
+    };
+
+    const options = {
+      terminate: true,
+    };
+
+    disconnect({ options, instance });
+
+    expect(instance.state.channelConfig).toBeUndefined();
+  });
+
+  it('should not call storageManager.terminate if terminate option is not provided', () => {
+    const mockTerminate = jest.fn();
+
+    instance.state.storageManager = {
+      terminate: mockTerminate,
+    } as unknown as StorageManager;
+
+    disconnect({ instance });
+
+    expect(mockTerminate).not.toHaveBeenCalled();
+  });
+
+  it('should set the channelId in the options during termination', () => {
+    const options = {
+      terminate: true,
+    };
+
+    disconnect({ options, instance });
+
+    expect(instance.state.channelId).toStrictEqual(instance.state.channelId);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/handleAuthorization.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/handleAuthorization.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerMessage } from '../../../types/CommunicationLayerMessage';
+import { EventType } from '../../../types/EventType';
+import { handleAuthorization } from './handleAuthorization';
+
+describe('handleAuthorization', () => {
+  let instance: RemoteCommunication;
+  let message: CommunicationLayerMessage;
+
+  const mockOnce = jest.fn();
+  const mockSendMessage = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: false,
+        context: 'testContext',
+        ready: true,
+        authorized: false,
+        isOriginator: true,
+        walletInfo: {
+          version: '7.3',
+        },
+        communicationLayer: {
+          sendMessage: mockSendMessage,
+        },
+      },
+      once: mockOnce,
+    } as unknown as RemoteCommunication;
+
+    message = {
+      method: 'sampleMethod',
+      data: 'sampleData',
+    };
+  });
+
+  it('should send message immediately if wallet version is less than 7.3', async () => {
+    instance.state.walletInfo!.version = '7.2';
+
+    await handleAuthorization(instance, message);
+
+    expect(instance.state.communicationLayer?.sendMessage).toHaveBeenCalledWith(
+      message,
+    );
+    expect(instance.once).not.toHaveBeenCalled();
+  });
+
+  it('should send message immediately if isOriginator is false or authorized is true', async () => {
+    instance.state.isOriginator = false;
+
+    await handleAuthorization(instance, message);
+
+    expect(instance.state.communicationLayer?.sendMessage).toHaveBeenCalledWith(
+      message,
+    );
+    expect(instance.once).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+    instance.state.isOriginator = true;
+    instance.state.authorized = true;
+
+    await handleAuthorization(instance, message);
+
+    expect(instance.state.communicationLayer?.sendMessage).toHaveBeenCalledWith(
+      message,
+    );
+    expect(instance.once).not.toHaveBeenCalled();
+  });
+
+  it('should wait for the AUTHORIZED event if neither of the above conditions are met before sending the message', async () => {
+    mockOnce.mockImplementation((_, callback) => callback());
+
+    await handleAuthorization(instance, message);
+
+    expect(instance.state.communicationLayer?.sendMessage).toHaveBeenCalledWith(
+      message,
+    );
+
+    expect(instance.once).toHaveBeenCalledWith(
+      EventType.AUTHORIZED,
+      expect.any(Function),
+    );
+  });
+
+  it('should log debug information if debug is enabled', async () => {
+    instance.state.debug = true;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+    await handleAuthorization(instance, message);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `RemoteCommunication::${instance.state.context}::sendMessage::handleAuthorization ready=${instance.state.ready} authorized=${instance.state.authorized} method=${message.method}`,
+    );
+
+    consoleLogSpy.mockRestore();
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should correctly handle wallet versions like 7.10 vs 7.9', async () => {
+    instance.state.walletInfo!.version = '7.10';
+
+    await handleAuthorization(instance, message);
+
+    expect(instance.state.communicationLayer?.sendMessage).toHaveBeenCalledWith(
+      message,
+    );
+    expect(instance.once).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/initCommunicationLayer.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/initCommunicationLayer.test.ts
@@ -1,0 +1,220 @@
+import { CommunicationLayerPreference } from '../../../types/CommunicationLayerPreference';
+import { SocketService } from '../../../SocketService';
+import { DEFAULT_SERVER_URL } from '../../../config';
+import { ECIESProps } from '../../../ECIES';
+import { initCommunicationLayer } from './initCommunicationLayer';
+
+jest.mock('../../../SocketService');
+
+describe('initCommunicationLayer', () => {
+  let instance: any;
+
+  const mockOn = jest.fn();
+
+  (SocketService as jest.MockedFunction<any>).mockImplementation(() => {
+    return {
+      on: mockOn,
+    };
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        context: 'testContext',
+        transports: {},
+        logging: false,
+        dappMetadata: {
+          url: 'https://sample-app.com',
+          name: 'Sample App',
+        },
+        platformType: 'web',
+        communicationLayer: {
+          on: mockOn,
+        },
+      },
+    };
+  });
+
+  it('should throw error for invalid communication protocol', () => {
+    expect(() => {
+      initCommunicationLayer({
+        communicationLayerPreference: 'UNKNOWN' as CommunicationLayerPreference,
+        instance,
+      });
+    }).toThrow('Invalid communication protocol');
+  });
+
+  it('should initialize socket service for SOCKET communication preference', () => {
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+    });
+
+    expect(SocketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+        context: 'testContext',
+      }),
+    );
+  });
+
+  it('should populate originatorInfo using dappMetadata', () => {
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+    });
+
+    expect(instance.state.originatorInfo).toStrictEqual(
+      expect.objectContaining({
+        url: 'https://sample-app.com',
+        title: 'Sample App',
+      }),
+    );
+  });
+
+  it('should populate originatorInfo using document.URL and document.title if dappMetadata is not available', () => {
+    delete instance.state.dappMetadata;
+    Object.defineProperty(global, 'document', {
+      value: {
+        URL: 'https://test-url.com',
+        title: 'Test Title',
+      },
+      writable: true,
+    });
+
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+    });
+
+    expect(instance.state.originatorInfo).toStrictEqual(
+      expect.objectContaining({
+        url: 'https://test-url.com',
+        title: 'Test Title',
+      }),
+    );
+  });
+
+  it('should use DEFAULT_SERVER_URL if communicationServerUrl is not provided', () => {
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+    });
+
+    expect(SocketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        communicationServerUrl: DEFAULT_SERVER_URL,
+      }),
+    );
+  });
+
+  it('should forward ecies props if provided', () => {
+    const eciesProps: ECIESProps = {
+      debug: true,
+      pkey: 'mockPrivateKey',
+    };
+
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+      ecies: eciesProps,
+    });
+
+    expect(SocketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ecies: eciesProps,
+      }),
+    );
+  });
+
+  it('should register event listeners for the communication layer', () => {
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+    });
+
+    expect(mockOn).toHaveBeenCalledTimes(9); // because we have 9 events to listen to
+  });
+
+  it('should pass otherPublicKey to SocketService if provided', () => {
+    const publicKey = 'samplePublicKey';
+
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      otherPublicKey: publicKey,
+      instance,
+    });
+
+    expect(SocketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        otherPublicKey: publicKey,
+      }),
+    );
+  });
+
+  it('should enable reconnect in SocketService if reconnect is true', () => {
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      reconnect: true,
+      instance,
+    });
+
+    expect(SocketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reconnect: true,
+      }),
+    );
+  });
+
+  it('should pass logging option to SocketService', () => {
+    instance.state.logging = true;
+
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+    });
+
+    expect(SocketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logging: true,
+      }),
+    );
+  });
+
+  it('should catch and log errors during event listener registration', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockOn.mockImplementationOnce(() => {
+      throw new Error('Mock Event Listener Error');
+    });
+
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      instance,
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error registering handler'),
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should use provided communicationServerUrl', () => {
+    const customServerUrl = 'https://custom-server-url.com';
+
+    initCommunicationLayer({
+      communicationLayerPreference: CommunicationLayerPreference.SOCKET,
+      communicationServerUrl: customServerUrl,
+      instance,
+    });
+
+    expect(SocketService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        communicationServerUrl: customServerUrl,
+      }),
+    );
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/originatorSessionConnect.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/originatorSessionConnect.test.ts
@@ -1,0 +1,101 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { originatorSessionConnect } from './originatorSessionConnect';
+
+describe('originatorSessionConnect', () => {
+  let instance: RemoteCommunication;
+  const mockIsConnected = jest.fn();
+  const mockGetPersistedChannelConfig = jest.fn();
+  const mockConnectToChannel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        storageManager: {
+          getPersistedChannelConfig: mockGetPersistedChannelConfig,
+        },
+        communicationLayer: {
+          isConnected: mockIsConnected,
+          connectToChannel: mockConnectToChannel,
+        },
+      },
+    } as unknown as RemoteCommunication;
+
+    jest.spyOn(console, 'debug').mockImplementation();
+    jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  it('should skip if no storage manager is defined', async () => {
+    delete instance.state.storageManager;
+    const result = await originatorSessionConnect(instance);
+    expect(result).toBeUndefined();
+    expect(console.debug).toHaveBeenCalledWith(
+      'RemoteCommunication::connect() no storage manager defined - skip',
+    );
+  });
+
+  it('should skip if the socket is already connected', async () => {
+    mockIsConnected.mockReturnValueOnce(true);
+    const result = await originatorSessionConnect(instance);
+    expect(result).toBeUndefined();
+    expect(console.debug).toHaveBeenCalledWith(
+      'RemoteCommunication::connect() socket already connected - skip',
+    );
+  });
+
+  it('should attempt to connect if there is a valid stored channel config', async () => {
+    const mockConfig = {
+      validUntil: Date.now() + 100000, // future date to ensure the session is valid
+      channelId: 'mockChannelId',
+    };
+    mockGetPersistedChannelConfig.mockResolvedValueOnce(mockConfig);
+
+    const result = await originatorSessionConnect(instance);
+    expect(result).toBe(mockConfig);
+    expect(mockConnectToChannel).toHaveBeenCalledWith({
+      channelId: mockConfig.channelId,
+      isOriginator: true,
+    });
+  });
+
+  it('should skip if the stored channel config is expired', async () => {
+    const mockConfig = {
+      validUntil: Date.now() - 100000, // past date to ensure the session is expired
+      channelId: 'mockChannelId',
+    };
+    mockGetPersistedChannelConfig.mockResolvedValueOnce(mockConfig);
+
+    const result = await originatorSessionConnect(instance);
+    expect(result).toBeUndefined();
+    expect(console.log).toHaveBeenCalledWith(
+      'RemoteCommunication::autoConnect Session has expired',
+    );
+  });
+
+  it('should handle null channel configuration', async () => {
+    mockGetPersistedChannelConfig.mockResolvedValueOnce(null);
+
+    const result = await originatorSessionConnect(instance);
+    expect(result).toBeUndefined();
+  });
+
+  it('should set originatorConnectStarted to false when no channel config is found', async () => {
+    mockGetPersistedChannelConfig.mockResolvedValueOnce(undefined);
+
+    await originatorSessionConnect(instance);
+    expect(instance.state.originatorConnectStarted).toBe(false);
+  });
+
+  it('should set originatorConnectStarted to false when session is expired', async () => {
+    const mockConfig = {
+      validUntil: Date.now() - 100000,
+      channelId: 'mockChannelId',
+    };
+    mockGetPersistedChannelConfig.mockResolvedValueOnce(mockConfig);
+
+    await originatorSessionConnect(instance);
+    expect(instance.state.originatorConnectStarted).toBe(false);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/resume.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/resume.test.ts
@@ -1,0 +1,90 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { ConnectionStatus } from '../../../types/ConnectionStatus';
+import { resume } from './resume';
+
+describe('resume', () => {
+  let instance: RemoteCommunication;
+  const mockResume = jest.fn();
+  const mockSetConnectionStatus = jest.fn();
+
+  jest.spyOn(console, 'debug').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        channelId: 'testChannel',
+        communicationLayer: {
+          resume: mockResume,
+        },
+      },
+      setConnectionStatus: mockSetConnectionStatus,
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should log channel being resumed when debug is true', () => {
+    resume(instance);
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::resume() channel=testChannel`,
+    );
+  });
+
+  it('should not log when debug is false', () => {
+    instance.state.debug = false;
+    resume(instance);
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+
+  it('should call resume on the communication layer', () => {
+    resume(instance);
+    expect(mockResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('should set connection status to LINKED', () => {
+    resume(instance);
+    expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.LINKED,
+    );
+  });
+
+  it('should handle when communicationLayer is not defined', () => {
+    delete instance.state.communicationLayer;
+
+    expect(() => {
+      resume(instance);
+    }).not.toThrow();
+
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::resume() channel=testChannel`,
+    );
+  });
+
+  it('should set connection status to LINKED even when communicationLayer is not defined', () => {
+    delete instance.state.communicationLayer;
+
+    resume(instance);
+    expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.LINKED,
+    );
+  });
+
+  it('should handle when channelId is not defined', () => {
+    instance.state.channelId = undefined;
+
+    resume(instance);
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::resume() channel=undefined`,
+    );
+  });
+
+  it('should handle when channelId is undefined', () => {
+    instance.state.channelId = undefined;
+
+    resume(instance);
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::resume() channel=undefined`,
+    );
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleAuthorizedEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleAuthorizedEvent.test.ts
@@ -1,0 +1,102 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { EventType } from '../../../types/EventType';
+import { PlatformType } from '../../../types/PlatformType';
+import { WalletInfo } from '../../../types/WalletInfo';
+import { wait } from '../../../utils/wait';
+import { handleAuthorizedEvent } from './handleAuthorizedEvent';
+
+jest.mock('../../../utils/wait');
+
+describe('handleAuthorizedEvent', () => {
+  let instance: RemoteCommunication;
+  const mockEmit = jest.fn();
+
+  jest.spyOn(console, 'debug').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        platformType: PlatformType.MobileWeb,
+        channelId: 'testChannel',
+        walletInfo: {
+          version: '7.2',
+        },
+      },
+      emit: mockEmit,
+    } as unknown as RemoteCommunication;
+
+    (wait as jest.MockedFunction<typeof wait>).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should skip if already authorized', async () => {
+    instance.state.authorized = true;
+    const handler = handleAuthorizedEvent(instance);
+    await handler();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('should wait for wallet version if not available', async () => {
+    instance.state.walletInfo = undefined;
+    const handler = handleAuthorizedEvent(instance);
+    const promise = handler();
+    expect(wait).toHaveBeenCalled();
+    instance.state.walletInfo = { version: '7.2' } as WalletInfo;
+    await promise;
+  });
+
+  it('should not handle the authorized event for wallet version 7.3+', async () => {
+    instance.state.walletInfo = { version: '7.3' } as WalletInfo;
+    const handler = handleAuthorizedEvent(instance);
+    await handler();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('should emit AUTHORIZED event for secure platform and wallet version less than 7.3', async () => {
+    instance.state.walletInfo = { version: '7.2' } as WalletInfo;
+    const handler = handleAuthorizedEvent(instance);
+    await handler();
+    expect(mockEmit).toHaveBeenCalledWith(EventType.AUTHORIZED);
+  });
+
+  it('should not emit AUTHORIZED event for insecure platform', async () => {
+    instance.state.platformType = PlatformType.DesktopWeb;
+    instance.state.walletInfo = { version: '7.2' } as WalletInfo;
+    const handler = handleAuthorizedEvent(instance);
+    await handler();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('should skip processing for wallet version 7.3', async () => {
+    instance.state.walletInfo = { version: '7.3' } as WalletInfo;
+
+    const handler = handleAuthorizedEvent(instance);
+    await handler();
+
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('should emit AUTHORIZED event for ReactNative platform', async () => {
+    instance.state.platformType = PlatformType.ReactNative;
+
+    const handler = handleAuthorizedEvent(instance);
+    await handler();
+
+    expect(mockEmit).toHaveBeenCalledWith(EventType.AUTHORIZED);
+  });
+
+  it('should emit AUTHORIZED event for MetaMaskMobileWebview platform', async () => {
+    instance.state.platformType = PlatformType.MetaMaskMobileWebview;
+
+    const handler = handleAuthorizedEvent(instance);
+    await handler();
+
+    expect(mockEmit).toHaveBeenCalledWith(EventType.AUTHORIZED);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleChannelCreatedEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleChannelCreatedEvent.test.ts
@@ -1,0 +1,50 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { EventType } from '../../../types/EventType';
+import { handleChannelCreatedEvent } from './handleChannelCreatedEvent';
+
+describe('handleChannelCreatedEvent', () => {
+  let instance: RemoteCommunication;
+  const mockEmit = jest.fn();
+
+  jest.spyOn(console, 'debug').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        context: 'testContext',
+      },
+      emit: mockEmit,
+    } as unknown as RemoteCommunication;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should log the channel creation event details if debugging is enabled', () => {
+    const channelId = 'sampleChannelId';
+    const handler = handleChannelCreatedEvent(instance);
+    handler(channelId);
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::testContext::on 'channel_created' channelId=${channelId}`,
+    );
+  });
+
+  it('should not log the event details if debugging is disabled', () => {
+    instance.state.debug = false;
+    const channelId = 'sampleChannelId';
+    const handler = handleChannelCreatedEvent(instance);
+    handler(channelId);
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+
+  it('should emit CHANNEL_CREATED event with the channel ID', () => {
+    const channelId = 'sampleChannelId';
+    const handler = handleChannelCreatedEvent(instance);
+    handler(channelId);
+    expect(mockEmit).toHaveBeenCalledWith(EventType.CHANNEL_CREATED, channelId);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsConnectedEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsConnectedEvent.test.ts
@@ -47,7 +47,7 @@ describe('handleClientsConnectedEvent', () => {
     const handler = handleClientsConnectedEvent(
       instance,
       CommunicationLayerPreference.SOCKET,
-    ); // You might need to specify the correct preference here
+    );
     handler();
     expect(console.debug).toHaveBeenCalledWith(
       `RemoteCommunication::on 'clients_connected' channel=testChannel keysExchanged=true`,

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsConnectedEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsConnectedEvent.test.ts
@@ -1,0 +1,168 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerPreference } from '../../../types/CommunicationLayerPreference';
+import { EventType } from '../../../types/EventType';
+import { SendAnalytics } from '../../../Analytics';
+import packageJson from '../../../../package.json';
+import { handleClientsConnectedEvent } from './handleClientsConnectedEvent';
+
+jest.mock('../../../Analytics', () => ({
+  SendAnalytics: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('handleClientsConnectedEvent', () => {
+  let instance: RemoteCommunication;
+  const mockEmit = jest.fn();
+  const mockGetKeyInfo = jest.fn();
+
+  // Mock console.debug and console.error
+  jest.spyOn(console, 'debug').mockImplementation();
+  jest.spyOn(console, 'error').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        channelId: 'testChannel',
+        analytics: true,
+        communicationLayer: {
+          getKeyInfo: mockGetKeyInfo,
+        },
+        sdkVersion: '1.0',
+        originatorInfo: {
+          someKey: 'someValue',
+        },
+        communicationServerUrl: 'http://mock-url.com',
+      },
+      emit: mockEmit,
+    } as unknown as RemoteCommunication;
+
+    mockGetKeyInfo.mockReturnValue({
+      keysExchanged: true,
+    });
+  });
+
+  it('should log the event details if debugging is enabled', () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    ); // You might need to specify the correct preference here
+    handler();
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::on 'clients_connected' channel=testChannel keysExchanged=true`,
+    );
+  });
+
+  it('should send analytics data if analytics tracking is enabled', async () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    await handler();
+    expect(SendAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'testChannel',
+        commLayer: CommunicationLayerPreference.SOCKET,
+        sdkVersion: '1.0',
+        commLayerVersion: packageJson.version,
+      }),
+      'http://mock-url.com',
+    );
+  });
+
+  it('should update the state of the instance correctly', () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    expect(instance.state.clientsConnected).toBe(true);
+    expect(instance.state.originatorInfoSent).toBe(false);
+  });
+
+  it('should emit CLIENTS_CONNECTED event', () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    expect(mockEmit).toHaveBeenCalledWith(EventType.CLIENTS_CONNECTED);
+  });
+
+  it('should handle analytics send error gracefully', async () => {
+    (SendAnalytics as jest.Mock).mockRejectedValueOnce(
+      new Error('Failed to send analytics'),
+    );
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    await handler();
+    expect(console.error).toHaveBeenCalledWith(
+      'Cannot send analytics',
+      expect.any(Error),
+    );
+  });
+
+  it('should not log event details if debugging is disabled', () => {
+    instance.state.debug = false;
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+
+  it('should not send analytics data if analytics tracking is disabled', async () => {
+    instance.state.analytics = false;
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    await handler();
+    expect(SendAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('should handle missing channelId gracefully', async () => {
+    delete instance.state.channelId;
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    await handler();
+    expect(SendAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({ id: '' }),
+      'http://mock-url.com',
+    );
+  });
+
+  it('should handle missing communicationLayer gracefully', () => {
+    delete instance.state.communicationLayer;
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    // No errors should be thrown
+    expect(mockEmit).toHaveBeenCalledWith(EventType.CLIENTS_CONNECTED);
+  });
+
+  it('should send analytics data correctly if originatorInfo is missing', async () => {
+    delete instance.state.originatorInfo;
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    await handler();
+    expect(SendAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commLayer: CommunicationLayerPreference.SOCKET,
+        sdkVersion: '1.0',
+        commLayerVersion: packageJson.version,
+      }),
+      'http://mock-url.com',
+    );
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsDisconnectedEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsDisconnectedEvent.test.ts
@@ -1,0 +1,94 @@
+import { SendAnalytics } from '../../../Analytics';
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerPreference } from '../../../types/CommunicationLayerPreference';
+import { EventType } from '../../../types/EventType';
+import { handleClientsConnectedEvent } from './handleClientsConnectedEvent';
+
+jest.mock('../../../../package.json', () => ({
+  version: 'mockVersion',
+}));
+
+jest.mock('../../../Analytics', () => ({
+  SendAnalytics: jest.fn(() => Promise.resolve()),
+}));
+
+describe('handleClientsConnectedEvent', () => {
+  let instance: RemoteCommunication;
+  const mockEmit = jest.fn();
+  const mockGetKeyInfo = jest.fn();
+
+  jest.spyOn(console, 'debug').mockImplementation();
+  jest.spyOn(console, 'error').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        channelId: 'testChannel',
+        analytics: true,
+        communicationLayer: {
+          getKeyInfo: mockGetKeyInfo,
+        },
+        sdkVersion: 'mockSdkVersion',
+        originatorInfo: {},
+        communicationServerUrl: 'mockUrl',
+      },
+      emit: mockEmit,
+    } as unknown as RemoteCommunication;
+
+    mockGetKeyInfo.mockReturnValue({
+      keysExchanged: true,
+    });
+  });
+
+  it('should log event details if debug is enabled', () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::on 'clients_connected' channel=testChannel keysExchanged=true`,
+    );
+  });
+
+  it('should send analytics data when analytics tracking is enabled', () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    expect(SendAnalytics).toHaveBeenCalledWith(
+      {
+        id: 'testChannel',
+        event: expect.any(String),
+        commLayer: CommunicationLayerPreference.SOCKET,
+        sdkVersion: 'mockSdkVersion',
+        walletVersion: undefined,
+        commLayerVersion: 'mockVersion',
+      },
+      'mockUrl',
+    );
+  });
+
+  it('should update state correctly', () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    expect(instance.state.clientsConnected).toBe(true);
+    expect(instance.state.originatorInfoSent).toBe(false);
+  });
+
+  it('should emit CLIENTS_CONNECTED event', () => {
+    const handler = handleClientsConnectedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler();
+    expect(mockEmit).toHaveBeenCalledWith(EventType.CLIENTS_CONNECTED);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsWaitingEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleClientsWaitingEvent.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { ConnectionStatus } from '../../../types/ConnectionStatus';
+import { EventType } from '../../../types/EventType';
+import { handleClientsWaitingEvent } from './handleClientsWaitingEvent';
+
+jest.useFakeTimers();
+
+describe('handleClientsWaitingEvent', () => {
+  let instance: RemoteCommunication;
+  const mockEmit = jest.fn();
+  const mockSetConnectionStatus = jest.fn();
+
+  jest.spyOn(console, 'debug').mockImplementation();
+
+  const spyClearTimeout = jest.spyOn(global, 'clearTimeout');
+  const spySetTimeout = jest.spyOn(global, 'setTimeout');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        context: 'mockContext',
+        originatorConnectStarted: true,
+        ready: false,
+        autoConnectOptions: {
+          timeout: 4000,
+        },
+      },
+      emit: mockEmit,
+      setConnectionStatus: mockSetConnectionStatus,
+    } as unknown as RemoteCommunication;
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should log event details if debug is enabled', () => {
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+    expect(console.debug).toHaveBeenCalledWith(
+      `RemoteCommunication::mockContext::on 'clients_waiting' numberUsers=5 ready=false autoStarted=true`,
+    );
+  });
+
+  it('should update instance state to WAITING', () => {
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+    expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.WAITING,
+    );
+  });
+
+  it('should emit CLIENTS_WAITING event with number of waiting users', () => {
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+    expect(mockEmit).toHaveBeenCalledWith(EventType.CLIENTS_WAITING, 5);
+  });
+
+  it('should set a timer if originator connection started automatically', () => {
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+    expect(spySetTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      instance.state.autoConnectOptions!.timeout,
+    );
+  });
+
+  it('should update state to TIMEOUT after timer expires and client is not ready', () => {
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+
+    jest.runAllTimers();
+
+    expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.TIMEOUT,
+    );
+  });
+
+  it('should clear timer after executing', () => {
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+
+    const timeoutId = (setTimeout as unknown as jest.Mock).mock.results[0]
+      .value;
+    jest.runAllTimers();
+    expect(spyClearTimeout).toHaveBeenCalledWith(timeoutId);
+  });
+
+  it('should not set a timer if originator connection was not auto started', () => {
+    instance.state.originatorConnectStarted = false;
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+    expect(spySetTimeout).not.toHaveBeenCalled();
+  });
+
+  it('should default to a 3-second timeout if no specific timeout is provided', () => {
+    instance.state.autoConnectOptions!.timeout = undefined;
+    const handler = handleClientsWaitingEvent(instance);
+    handler(5);
+    expect(spySetTimeout).toHaveBeenCalledWith(expect.any(Function), 3000);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleKeysExchangedEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleKeysExchangedEvent.test.ts
@@ -1,0 +1,172 @@
+import { SendAnalytics } from '../../../Analytics';
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerPreference } from '../../../types/CommunicationLayerPreference';
+import { ConnectionStatus } from '../../../types/ConnectionStatus';
+import { MessageType } from '../../../types/MessageType';
+import { OriginatorInfo } from '../../../types/OriginatorInfo';
+import { setLastActiveDate } from '../StateManger';
+import { handleKeysExchangedEvent } from './handleKeysExchangedEvent';
+
+jest.mock('../../../Analytics', () => {
+  return {
+    SendAnalytics: jest.fn().mockResolvedValue(undefined),
+  };
+});
+jest.mock('../StateManger');
+
+describe('handleKeysExchangedEvent', () => {
+  let instance: RemoteCommunication;
+
+  const mockSetConnectionStatus = jest.fn();
+  const mockSendMessage = jest.fn();
+
+  jest.spyOn(console, 'debug').mockImplementation();
+  jest.spyOn(console, 'error').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: true,
+        context: 'mockContext',
+        channelId: 'mockChannel',
+        analytics: true,
+        sdkVersion: '1.0',
+        walletInfo: { version: '1.0' },
+        communicationLayer: {
+          sendMessage: mockSendMessage,
+          getKeyInfo: () => ({ keysExchanged: true }),
+        },
+        communicationServerUrl: 'mockUrl',
+      },
+      setConnectionStatus: mockSetConnectionStatus,
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should log diagnostic information when debug is enabled', () => {
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: true,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+    expect(console.debug).toHaveBeenCalled();
+  });
+
+  it('should update the instance connection status to LINKED', () => {
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: true,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+
+    expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.LINKED,
+    );
+  });
+
+  it('should send a READY message if the instance is not the originator', () => {
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: false,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+    expect(mockSendMessage).toHaveBeenCalledWith({ type: MessageType.READY });
+    expect(instance.state.ready).toBe(true);
+    expect(instance.state.paused).toBe(false);
+  });
+
+  it('should send an ORIGINATOR_INFO message if the instance is the originator and originatorInfo has not been sent', () => {
+    instance.state.originatorInfoSent = false;
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: true,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+
+    expect(mockSendMessage).toHaveBeenCalledWith({
+      type: MessageType.ORIGINATOR_INFO,
+      originatorInfo: instance.state.originatorInfo,
+      originator: instance.state.originatorInfo,
+    });
+    expect(instance.state.originatorInfoSent).toBe(true);
+  });
+
+  it('should attempt to send analytics when analytics is enabled', () => {
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: true,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+
+    expect(SendAnalytics).toHaveBeenCalled();
+  });
+
+  it('should not attempt to send analytics when analytics is disabled', () => {
+    instance.state.analytics = false;
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: true,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+
+    expect(SendAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('should set the last active date', () => {
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: true,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+
+    expect(setLastActiveDate).toHaveBeenCalledWith(instance, expect.any(Date));
+  });
+
+  it('should log an error when sending analytics fails', async () => {
+    (SendAnalytics as jest.Mock).mockRejectedValue(new Error('Mock error'));
+    const handler = handleKeysExchangedEvent(
+      instance,
+      CommunicationLayerPreference.SOCKET,
+    );
+    handler({
+      isOriginator: true,
+      originatorInfo: {} as OriginatorInfo,
+      originator: {} as OriginatorInfo,
+    });
+
+    await expect(SendAnalytics).rejects.toThrow('Mock error');
+    expect(console.error).toHaveBeenCalledWith(
+      'Cannot send analytics',
+      expect.anything(),
+    );
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleMessageEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleMessageEvent.test.ts
@@ -1,0 +1,46 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { onCommunicationLayerMessage } from '../MessageHandlers';
+import { handleMessageEvent } from './handleMessageEvent';
+
+jest.mock('../MessageHandlers');
+
+describe('handleMessageEvent', () => {
+  let instance: RemoteCommunication;
+
+  const mockOnCommunicationLayerMessage =
+    onCommunicationLayerMessage as jest.MockedFunction<
+      typeof onCommunicationLayerMessage
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {} as unknown as RemoteCommunication;
+  });
+
+  it('should forward messages directly if they are not encapsulated', () => {
+    const handler = handleMessageEvent(instance);
+    const mockMessage = { type: 'mockType' } as any;
+
+    handler(mockMessage);
+    expect(mockOnCommunicationLayerMessage).toHaveBeenCalledWith(
+      mockMessage,
+      instance,
+    );
+  });
+
+  it('should extract and forward encapsulated messages', () => {
+    const handler = handleMessageEvent(instance);
+    const encapsulatedMockMessage = {
+      type: 'outerType',
+      message: { type: 'innerType' },
+    } as any;
+
+    handler(encapsulatedMockMessage);
+
+    expect(mockOnCommunicationLayerMessage).toHaveBeenCalledWith(
+      encapsulatedMockMessage.message,
+      instance,
+    );
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleSocketDisconnectedEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleSocketDisconnectedEvent.test.ts
@@ -1,0 +1,45 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { handleSocketDisconnectedEvent } from './handleSocketDisconnectedEvent';
+
+describe('handleSocketDisconnectedEvent', () => {
+  let instance: RemoteCommunication;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        ready: true,
+        debug: false,
+      },
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should set the ready state to false upon socket disconnection', () => {
+    const handler = handleSocketDisconnectedEvent(instance);
+    handler();
+    expect(instance.state.ready).toBe(false);
+  });
+
+  it('should log a debug message when debug is true', () => {
+    instance.state.debug = true;
+    const mockConsoleDebug = jest.spyOn(console, 'debug').mockImplementation();
+    const handler = handleSocketDisconnectedEvent(instance);
+
+    handler();
+
+    expect(mockConsoleDebug).toHaveBeenCalledWith(
+      `RemoteCommunication::on 'socket_Disconnected' set ready to false`,
+    );
+    mockConsoleDebug.mockRestore();
+  });
+
+  it('should not log a debug message when debug is false', () => {
+    instance.state.debug = false;
+    const mockConsoleDebug = jest.spyOn(console, 'debug').mockImplementation();
+    const handler = handleSocketDisconnectedEvent(instance);
+    handler();
+    expect(mockConsoleDebug).not.toHaveBeenCalled();
+    mockConsoleDebug.mockRestore();
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleSocketReconnectEvent.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/EventListeners/handleSocketReconnectEvent.test.ts
@@ -1,0 +1,44 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { clean } from '../ChannelManager';
+import { handleSocketReconnectEvent } from './handleSocketReconnectEvent';
+
+jest.mock('../ChannelManager');
+
+describe('handleSocketReconnectEvent', () => {
+  let instance: RemoteCommunication;
+  const mockClean = clean as jest.MockedFunction<typeof clean>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        ready: true,
+        debug: false,
+      },
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should set the ready state to false upon socket reconnection', () => {
+    const handler = handleSocketReconnectEvent(instance);
+    handler();
+    expect(instance.state.ready).toBe(false);
+  });
+
+  it('should call the clean function from ChannelManager', () => {
+    const handler = handleSocketReconnectEvent(instance);
+    handler();
+    expect(mockClean).toHaveBeenCalledWith(instance.state);
+  });
+
+  it('should log a debug message when debug is true', () => {
+    instance.state.debug = true;
+    const mockConsoleDebug = jest.spyOn(console, 'debug').mockImplementation();
+    const handler = handleSocketReconnectEvent(instance);
+    handler();
+    expect(mockConsoleDebug).toHaveBeenCalledWith(
+      `RemoteCommunication::on 'socket_reconnect' -- reset key exchange status / set ready to false`,
+    );
+    mockConsoleDebug.mockRestore();
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleAuthorizedMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleAuthorizedMessage.test.ts
@@ -1,0 +1,28 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { EventType } from '../../../types/EventType';
+import { handleAuthorizedMessage } from './handleAuthorizedMessage';
+
+describe('handleAuthorizedMessage', () => {
+  let instance: RemoteCommunication;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        authorized: false,
+      },
+      emit: jest.fn(),
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should set the authorized state to true', () => {
+    handleAuthorizedMessage(instance);
+    expect(instance.state.authorized).toBe(true);
+  });
+
+  it('should emit an AUTHORIZED event', () => {
+    handleAuthorizedMessage(instance);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.AUTHORIZED);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleOriginatorInfoMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleOriginatorInfoMessage.test.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerMessage } from '../../../types/CommunicationLayerMessage';
+import { EventType } from '../../../types/EventType';
+import { MessageType } from '../../../types/MessageType';
+import { handleOriginatorInfoMessage } from './handleOriginatorInfoMessage';
+
+describe('handleOriginatorInfoMessage', () => {
+  let instance: RemoteCommunication;
+  const mockMessage = {
+    originatorInfo: 'testOriginatorInfo',
+    originator: 'testOriginator',
+  } as unknown as CommunicationLayerMessage;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        walletInfo: 'testWalletInfo',
+        communicationLayer: {
+          sendMessage: jest.fn(),
+        },
+        originatorInfo: null,
+        isOriginator: true,
+        paused: true,
+      },
+      emit: jest.fn(),
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should send a WALLET_INFO message with wallet details', () => {
+    handleOriginatorInfoMessage(instance, mockMessage);
+    expect(instance.state.communicationLayer!.sendMessage).toHaveBeenCalledWith(
+      {
+        type: MessageType.WALLET_INFO,
+        walletInfo: 'testWalletInfo',
+      },
+    );
+  });
+
+  it('should update the originatorInfo state', () => {
+    handleOriginatorInfoMessage(instance, mockMessage);
+    expect(instance.state.originatorInfo).toBe('testOriginatorInfo');
+  });
+
+  it('should emit a CLIENTS_READY event', () => {
+    handleOriginatorInfoMessage(instance, mockMessage);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.CLIENTS_READY, {
+      isOriginator: true,
+      originatorInfo: 'testOriginatorInfo',
+    });
+  });
+
+  it('should set the paused state to false', () => {
+    handleOriginatorInfoMessage(instance, mockMessage);
+    expect(instance.state.paused).toBe(false);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleOtpMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleOtpMessage.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerMessage } from '../../../types/CommunicationLayerMessage';
+import { EventType } from '../../../types/EventType';
+import { handleOtpMessage } from './handleOtpMessage';
+
+describe('handleOtpMessage', () => {
+  let instance: RemoteCommunication;
+  const mockMessage = {
+    otpAnswer: '123456',
+  } as unknown as CommunicationLayerMessage;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        walletInfo: {
+          version: '6.5',
+        },
+      },
+      emit: jest.fn(),
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should emit the correct OTP', () => {
+    handleOtpMessage(instance, mockMessage);
+    expect(instance.emit).toHaveBeenCalledWith(
+      EventType.OTP,
+      mockMessage.otpAnswer,
+    );
+  });
+
+  it('should trigger backward compatibility for wallet versions <6.6', () => {
+    handleOtpMessage(instance, mockMessage);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.SDK_RPC_CALL, {
+      method: 'eth_requestAccounts',
+      params: [],
+    });
+  });
+
+  it('should not trigger backward compatibility for wallet versions >=6.6', () => {
+    instance.state.walletInfo!.version = '6.6';
+    handleOtpMessage(instance, mockMessage);
+    expect(instance.emit).not.toHaveBeenCalledWith(EventType.SDK_RPC_CALL, {
+      method: 'eth_requestAccounts',
+      params: [],
+    });
+  });
+
+  it('should trigger backward compatibility when walletInfo.version is an empty string', () => {
+    instance.state.walletInfo!.version = '';
+    handleOtpMessage(instance, mockMessage);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.SDK_RPC_CALL, {
+      method: 'eth_requestAccounts',
+      params: [],
+    });
+  });
+
+  it('should ignore OTP message if otpAnswer is not provided', () => {
+    const incompleteMessage = {} as unknown as CommunicationLayerMessage;
+    handleOtpMessage(instance, incompleteMessage);
+    expect(instance.emit).not.toHaveBeenCalledWith(
+      EventType.OTP,
+      expect.anything(),
+    );
+  });
+
+  it('should log a warning when backward compatibility is triggered', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+    instance.state.walletInfo!.version = '6.5';
+    handleOtpMessage(instance, mockMessage);
+    expect(console.warn).toHaveBeenCalledWith(
+      `RemoteCommunication::on 'otp' -- backward compatibility <6.6 -- triger eth_requestAccounts`,
+    );
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handlePauseMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handlePauseMessage.test.ts
@@ -1,0 +1,30 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { ConnectionStatus } from '../../../types/ConnectionStatus';
+import { handlePauseMessage } from './handlePauseMessage';
+
+describe('handlePauseMessage', () => {
+  let instance: RemoteCommunication;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        paused: false,
+      },
+      setConnectionStatus: jest.fn(),
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should set the communication as paused', () => {
+    handlePauseMessage(instance);
+    expect(instance.state.paused).toBe(true);
+  });
+
+  it('should update the connection status to PAUSED', () => {
+    handlePauseMessage(instance);
+    expect(instance.setConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.PAUSED,
+    );
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleReadyMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleReadyMessage.test.ts
@@ -1,0 +1,67 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { ConnectionStatus } from '../../../types/ConnectionStatus';
+import { EventType } from '../../../types/EventType';
+import { handleReadyMessage } from './handleReadyMessage';
+
+describe('handleReadyMessage', () => {
+  let instance: RemoteCommunication;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        paused: false,
+        isOriginator: true,
+        walletInfo: {},
+      },
+      setConnectionStatus: jest.fn(),
+      emit: jest.fn(),
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should set the connection status to LINKED', () => {
+    handleReadyMessage(instance);
+    expect(instance.setConnectionStatus).toHaveBeenCalledWith(
+      ConnectionStatus.LINKED,
+    );
+  });
+
+  it('should emit CLIENTS_READY event with correct data', () => {
+    handleReadyMessage(instance);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.CLIENTS_READY, {
+      isOriginator: instance.state.isOriginator,
+      walletInfo: instance.state.walletInfo,
+    });
+  });
+
+  it('should reset paused status to false', () => {
+    instance.state.paused = true;
+    handleReadyMessage(instance);
+    expect(instance.state.paused).toBe(false);
+  });
+
+  it('should set authorized status and emit AUTHORIZED event on resumed connection', () => {
+    instance.state.paused = true;
+    handleReadyMessage(instance);
+    expect(instance.state.authorized).toBe(true);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.AUTHORIZED);
+  });
+
+  it('should not set authorized status and not emit AUTHORIZED event when not paused', () => {
+    instance.state.paused = false;
+    handleReadyMessage(instance);
+    expect(instance.state.authorized).not.toBe(true);
+    expect(instance.emit).not.toHaveBeenCalledWith(EventType.AUTHORIZED);
+  });
+
+  it('should handle missing isOriginator or walletInfo state information', () => {
+    instance.state.isOriginator = false;
+    instance.state.walletInfo = undefined;
+    handleReadyMessage(instance);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.CLIENTS_READY, {
+      isOriginator: false,
+      walletInfo: undefined,
+    });
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleTerminateMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleTerminateMessage.test.ts
@@ -1,0 +1,55 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { EventType } from '../../../types/EventType';
+import { disconnect } from '../ConnectionManager';
+import { handleTerminateMessage } from './handleTerminateMessage';
+
+jest.mock('../ConnectionManager', () => {
+  return {
+    disconnect: jest.fn(),
+  };
+});
+
+describe('handleTerminateMessage', () => {
+  let instance: RemoteCommunication;
+  const mockDisconnect = disconnect as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        isOriginator: false,
+      },
+      emit: jest.fn(),
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should not terminate if the instance is not the originator', () => {
+    handleTerminateMessage(instance);
+    expect(mockDisconnect).not.toHaveBeenCalled();
+    expect(instance.emit).not.toHaveBeenCalledWith(EventType.TERMINATE);
+  });
+
+  it('should terminate the communication channel if the instance is the originator', () => {
+    instance.state.isOriginator = true;
+
+    handleTerminateMessage(instance);
+
+    expect(mockDisconnect).toHaveBeenCalledWith({
+      options: { terminate: true, sendMessage: false },
+      instance,
+    });
+    expect(instance.emit).toHaveBeenCalledWith(EventType.TERMINATE);
+  });
+
+  it('should output a debug message during termination', () => {
+    const consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+    instance.state.isOriginator = true;
+    handleTerminateMessage(instance);
+
+    expect(consoleDebugSpy).toHaveBeenCalled();
+
+    consoleDebugSpy.mockRestore();
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleWalletInfoMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleWalletInfoMessage.test.ts
@@ -1,0 +1,35 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerMessage } from '../../../types/CommunicationLayerMessage';
+import { handleWalletInfoMessage } from './handleWalletInfoMessage';
+
+describe('handleWalletInfoMessage', () => {
+  let instance: RemoteCommunication;
+  let message: CommunicationLayerMessage;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        walletInfo: null,
+        paused: true,
+      },
+    } as unknown as RemoteCommunication;
+
+    message = {
+      walletInfo: {
+        version: '7.0',
+      },
+    } as unknown as CommunicationLayerMessage;
+  });
+
+  it('should update the walletInfo in the instance state', () => {
+    handleWalletInfoMessage(instance, message);
+    expect(instance.state.walletInfo).toBe(message.walletInfo);
+  });
+
+  it('should set the paused status to false', () => {
+    handleWalletInfoMessage(instance, message);
+    expect(instance.state.paused).toBe(false);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/onCommunicationLayerMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/onCommunicationLayerMessage.test.ts
@@ -77,8 +77,6 @@ describe('onCommunicationLayerMessage', () => {
     expect(instance.state.ready).toBe(true);
   });
 
-  // ... more similar tests for each handler function ...
-
   it('should invoke handleOriginatorInfoMessage for ORIGINATOR_INFO messages when not originator', () => {
     message = { type: MessageType.ORIGINATOR_INFO };
 

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/onCommunicationLayerMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/onCommunicationLayerMessage.test.ts
@@ -1,0 +1,163 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerMessage } from '../../../types/CommunicationLayerMessage';
+import { MessageType } from '../../../types/MessageType';
+import { EventType } from '../../../types/EventType';
+import { onCommunicationLayerMessage } from './onCommunicationLayerMessage';
+import { handleOriginatorInfoMessage } from './handleOriginatorInfoMessage';
+import { handleAuthorizedMessage } from './handleAuthorizedMessage';
+import { handleOtpMessage } from './handleOtpMessage';
+import { handlePauseMessage } from './handlePauseMessage';
+import { handleReadyMessage } from './handleReadyMessage';
+import { handleTerminateMessage } from './handleTerminateMessage';
+import { handleWalletInfoMessage } from './handleWalletInfoMessage';
+
+jest.mock('./handleOriginatorInfoMessage');
+jest.mock('./handleAuthorizedMessage');
+jest.mock('./handleOtpMessage');
+jest.mock('./handlePauseMessage');
+jest.mock('./handleReadyMessage');
+jest.mock('./handleTerminateMessage');
+jest.mock('./handleWalletInfoMessage');
+
+const mockHandleAuthorizedMessage =
+  handleAuthorizedMessage as jest.MockedFunction<
+    typeof handleAuthorizedMessage
+  >;
+const mockHandleOtpMessage = handleOtpMessage as jest.MockedFunction<
+  typeof handleOtpMessage
+>;
+const mockHandlePauseMessage = handlePauseMessage as jest.MockedFunction<
+  typeof handlePauseMessage
+>;
+const mockHandleReadyMessage = handleReadyMessage as jest.MockedFunction<
+  typeof handleReadyMessage
+>;
+const mockHandleTerminateMessage =
+  handleTerminateMessage as jest.MockedFunction<typeof handleTerminateMessage>;
+const mockHandleWalletInfoMessage =
+  handleWalletInfoMessage as jest.MockedFunction<
+    typeof handleWalletInfoMessage
+  >;
+
+describe('onCommunicationLayerMessage', () => {
+  let instance: RemoteCommunication;
+  let message: CommunicationLayerMessage;
+
+  const mockHandleOriginatorInfoMessage =
+    handleOriginatorInfoMessage as jest.MockedFunction<
+      typeof handleOriginatorInfoMessage
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: false,
+        isOriginator: false,
+        ready: false,
+        context: 'test-context',
+      },
+      emit: jest.fn(),
+    } as unknown as RemoteCommunication;
+  });
+
+  it('should log the message if debug mode is enabled', () => {
+    instance.state.debug = true;
+    const consoleDebugSpy = jest.spyOn(console, 'debug');
+    message = { type: MessageType.READY }; // Any arbitrary message type
+    onCommunicationLayerMessage(message, instance);
+    expect(consoleDebugSpy).toHaveBeenCalled();
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should set the ready status to true', () => {
+    message = { type: MessageType.READY };
+    onCommunicationLayerMessage(message, instance);
+    expect(instance.state.ready).toBe(true);
+  });
+
+  // ... more similar tests for each handler function ...
+
+  it('should invoke handleOriginatorInfoMessage for ORIGINATOR_INFO messages when not originator', () => {
+    message = { type: MessageType.ORIGINATOR_INFO };
+
+    onCommunicationLayerMessage(message, instance);
+
+    expect(mockHandleOriginatorInfoMessage).toHaveBeenCalled();
+  });
+
+  it('should invoke handleWalletInfoMessage for WALLET_INFO messages when originator', () => {
+    instance.state.isOriginator = true;
+    message = { type: MessageType.WALLET_INFO };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleWalletInfoMessage).toHaveBeenCalled();
+  });
+
+  it('should invoke handleTerminateMessage for TERMINATE messages', () => {
+    message = { type: MessageType.TERMINATE };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleTerminateMessage).toHaveBeenCalled();
+  });
+
+  it('should invoke handlePauseMessage for PAUSE messages', () => {
+    message = { type: MessageType.PAUSE };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandlePauseMessage).toHaveBeenCalled();
+  });
+
+  it('should invoke handleReadyMessage for READY messages when originator', () => {
+    instance.state.isOriginator = true;
+    message = { type: MessageType.READY };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleReadyMessage).toHaveBeenCalled();
+  });
+
+  it('should invoke handleOtpMessage for OTP messages when originator', () => {
+    instance.state.isOriginator = true;
+    message = { type: MessageType.OTP };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleOtpMessage).toHaveBeenCalled();
+  });
+
+  it('should invoke handleAuthorizedMessage for AUTHORIZED messages when originator', () => {
+    instance.state.isOriginator = true;
+    message = { type: MessageType.AUTHORIZED };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleAuthorizedMessage).toHaveBeenCalled();
+  });
+
+  it('should emit a MESSAGE event for unrecognized message types', () => {
+    message = { type: 'UNRECOGNIZED_TYPE' as MessageType };
+    onCommunicationLayerMessage(message, instance);
+    expect(instance.emit).toHaveBeenCalledWith(EventType.MESSAGE, message);
+  });
+
+  it('should NOT invoke handleWalletInfoMessage for WALLET_INFO messages when not originator', () => {
+    instance.state.isOriginator = false;
+    message = { type: MessageType.WALLET_INFO };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleWalletInfoMessage).not.toHaveBeenCalled();
+  });
+
+  it('should NOT invoke handleReadyMessage for READY messages when not originator', () => {
+    instance.state.isOriginator = false;
+    message = { type: MessageType.READY };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleReadyMessage).not.toHaveBeenCalled();
+  });
+
+  it('should NOT invoke handleOtpMessage for OTP messages when not originator', () => {
+    instance.state.isOriginator = false;
+    message = { type: MessageType.OTP };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleOtpMessage).not.toHaveBeenCalled();
+  });
+
+  it('should NOT invoke handleAuthorizedMessage for AUTHORIZED messages when not originator', () => {
+    instance.state.isOriginator = false;
+    message = { type: MessageType.AUTHORIZED };
+    onCommunicationLayerMessage(message, instance);
+    expect(mockHandleAuthorizedMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/sendMessage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/sendMessage.test.ts
@@ -1,0 +1,82 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { CommunicationLayerMessage } from '../../../types/CommunicationLayerMessage';
+import { EventType } from '../../../types/EventType';
+import { MessageType } from '../../../types/MessageType';
+import { handleAuthorization } from '../ConnectionManager';
+import { sendMessage } from './sendMessage';
+
+jest.mock('../ConnectionManager');
+
+describe('sendMessage', () => {
+  let instance: RemoteCommunication;
+  let message: CommunicationLayerMessage;
+
+  const mockHandleAuthorization = handleAuthorization as jest.Mock;
+  const mockOnce = jest.fn(
+    (_: EventType, callback: (data: unknown) => void) => {
+      callback({});
+    },
+  );
+  const mockEmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: false,
+        paused: false,
+        ready: true,
+        authorized: true,
+        communicationLayer: {
+          isConnected: jest.fn().mockReturnValue(true),
+        },
+        clientsConnected: true,
+        _connectionStatus: 'connected',
+        context: 'test-context',
+      },
+      once: mockOnce,
+      emit: mockEmit,
+    } as unknown as RemoteCommunication;
+
+    message = {
+      type: MessageType.PING,
+    } as unknown as CommunicationLayerMessage;
+  });
+
+  it('should log if debug mode is enabled', async () => {
+    instance.state.debug = true;
+    const consoleLogSpy = jest.spyOn(console, 'log');
+    await sendMessage(instance, message);
+    expect(consoleLogSpy).toHaveBeenCalled();
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should wait for CLIENTS_READY event if conditions are not favorable', async () => {
+    instance.state.ready = false;
+    await sendMessage(instance, message);
+    expect(instance.once).toHaveBeenCalledWith(
+      EventType.CLIENTS_READY,
+      expect.any(Function),
+    );
+  });
+
+  it('should not wait for CLIENTS_READY event if conditions are favorable', async () => {
+    await sendMessage(instance, message);
+    expect(instance.once).not.toHaveBeenCalledWith(
+      EventType.CLIENTS_READY,
+      expect.any(Function),
+    );
+  });
+
+  it('should handle authorization errors correctly', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+    const mockError = new Error('Authorization Error');
+    mockHandleAuthorization.mockRejectedValueOnce(mockError);
+
+    await expect(sendMessage(instance, message)).rejects.toThrow(mockError);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/StateManger/setLastActiveDate.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/StateManger/setLastActiveDate.test.ts
@@ -1,0 +1,72 @@
+import { RemoteCommunication } from '../../../RemoteCommunication';
+import { ChannelConfig } from '../../../types/ChannelConfig';
+import { setLastActiveDate } from './setLastActiveDate';
+
+describe('setLastActiveDate', () => {
+  let instance: RemoteCommunication;
+  let lastActiveDate: Date;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    instance = {
+      state: {
+        debug: false,
+        channelId: 'test-channel-id',
+        channelConfig: {
+          validUntil: 1629820440000,
+        },
+        storageManager: {
+          persistChannelConfig: jest.fn(),
+        },
+      },
+    } as unknown as RemoteCommunication;
+
+    lastActiveDate = new Date('2023-01-01T12:00:00Z');
+  });
+
+  it('should log if debug mode is enabled', () => {
+    instance.state.debug = true;
+    const consoleDebugSpy = jest.spyOn(console, 'debug');
+
+    setLastActiveDate(instance, lastActiveDate);
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      `RemoteCommunication::setLastActiveDate() channel=${instance.state.channelId}`,
+      lastActiveDate,
+    );
+
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should set the lastActive attribute correctly', () => {
+    setLastActiveDate(instance, lastActiveDate);
+
+    const expectedChannelConfig: ChannelConfig = {
+      channelId: 'test-channel-id',
+      validUntil: 1629820440000,
+      lastActive: lastActiveDate.getTime(),
+    };
+
+    expect(
+      instance.state.storageManager?.persistChannelConfig,
+    ).toHaveBeenCalledWith(expectedChannelConfig);
+  });
+
+  it('should handle case when channelId or validUntil are undefined', () => {
+    instance.state.channelId = undefined;
+    instance.state.channelConfig = undefined;
+
+    setLastActiveDate(instance, lastActiveDate);
+
+    const expectedChannelConfig: ChannelConfig = {
+      channelId: '',
+      validUntil: 0,
+      lastActive: lastActiveDate.getTime(),
+    };
+
+    expect(
+      instance.state.storageManager?.persistChannelConfig,
+    ).toHaveBeenCalledWith(expectedChannelConfig);
+  });
+});

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/StorageManager/testStorage.test.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/StorageManager/testStorage.test.ts
@@ -1,0 +1,51 @@
+import { RemoteCommunicationState } from '../../../RemoteCommunication';
+import { testStorage } from './testStorage';
+
+describe('testStorage', () => {
+  let state: RemoteCommunicationState;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state = {
+      channelId: 'test-channel-id',
+      storageManager: {
+        getPersistedChannelConfig: jest.fn().mockResolvedValue({}),
+      },
+      debug: false,
+    } as unknown as RemoteCommunicationState;
+  });
+
+  it('should call getPersistedChannelConfig with correct channel ID', async () => {
+    await testStorage(state);
+    expect(
+      state.storageManager?.getPersistedChannelConfig,
+    ).toHaveBeenCalledWith(state.channelId);
+  });
+
+  it('should log the result', async () => {
+    const consoleDebugSpy = jest.spyOn(console, 'debug');
+    await testStorage(state);
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      'RemoteCommunication.testStorage() res',
+      expect.any(Object),
+    );
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should handle case when storageManager is not defined', async () => {
+    state.storageManager = undefined;
+    const consoleDebugSpy = jest.spyOn(console, 'debug');
+
+    const res = await testStorage(state);
+
+    expect(res).toBeUndefined();
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      'RemoteCommunication.testStorage() res',
+      undefined,
+    );
+    consoleDebugSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
This PR introduces unit tests for the RemoteCommunication class to ensure the stability and reliability of its methods and behaviors.
By adding these tests, we aim to catch potential issues and maintain the robustness of the SocketService functionalities.


That's the coverage results:
<img width="1273" alt="Screenshot 2023-08-28 at 11 08 26" src="https://github.com/MetaMask/metamask-sdk/assets/61094771/bf54a17e-c735-42cb-ac63-a2f855b4a811">
