### PR TITLE
feat: prevent sending icon to segment

### DIFF
--- a/packages/sdk-socket-server/api-config.js
+++ b/packages/sdk-socket-server/api-config.js
@@ -67,10 +67,14 @@ app.post('/debug', (_req, res) => {
       },
     };
 
+    // Define properties to be excluded
+    const propertiesToExclude = ['icon'];
+
     for (const property in body) {
       if (
         Object.prototype.hasOwnProperty.call(body, property) &&
-        body[property]
+        body[property] &&
+        !propertiesToExclude.includes(property)
       ) {
         event.properties[property] = body[property];
       }


### PR DESCRIPTION
Fixes issues when sending properties with potential long content like 'icon'