### PR TITLE
Release 23.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "21.0.0",
+  "version": "23.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-communication-layer/CHANGELOG.md
+++ b/packages/sdk-communication-layer/CHANGELOG.md
@@ -6,15 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.1]
-### Uncategorized
-- feat: force trigger new version ([#305](https://github.com/MetaMask/metamask-sdk/pull/305))
-- Release 20.0.1 ([#303](https://github.com/MetaMask/metamask-sdk/pull/303))
-- Revert "Release 20.0.0" ([#302](https://github.com/MetaMask/metamask-sdk/pull/302))
-- Release 20.0.0 ([#291](https://github.com/MetaMask/metamask-sdk/pull/291))
-- feat: add unit tests to the RemoteConnection class ([#301](https://github.com/MetaMask/metamask-sdk/pull/301))
-- feat: add unit tests to the RemoteCommunication class ([#295](https://github.com/MetaMask/metamask-sdk/pull/295))
-
 ## [0.6.0]
 ### Added
 - feat: improved event tracking ([#298](https://github.com/MetaMask/metamask-sdk/pull/298))
@@ -66,8 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.6.1...HEAD
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.6.0...@metamask/sdk-communication-layer@0.6.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.6.0...HEAD
 [0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.5.3...@metamask/sdk-communication-layer@0.6.0
 [0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.5.2...@metamask/sdk-communication-layer@0.5.3
 [0.5.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.5.0...@metamask/sdk-communication-layer@0.5.2

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.1]
+## [0.6.0]
 ### Uncategorized
-- feat: force trigger new version ([#305](https://github.com/MetaMask/metamask-sdk/pull/305))
+- feat: trigger pipeline detection ([#307](https://github.com/MetaMask/metamask-sdk/pull/307))
 
 ## [0.5.1]
 ### Uncategorized
@@ -35,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub actions workflows ([#102](https://github.com/MetaMask/metamask-sdk/pull/102))
 - [FEAT] Yarn v3 migration ([#100](https://github.com/MetaMask/metamask-sdk/pull/100))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.6.1...HEAD
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.5.1...@metamask/sdk-install-modal-web@0.6.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.6.0...HEAD
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.5.1...@metamask/sdk-install-modal-web@0.6.0
 [0.5.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.3.3...@metamask/sdk-install-modal-web@0.5.1
 [0.3.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.3.2...@metamask/sdk-install-modal-web@0.3.3
 [0.3.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.3.0...@metamask/sdk-install-modal-web@0.3.2

--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-install-modal-web",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "MetaMask SDK Install Modal for Web",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -6,23 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.1]
-### Uncategorized
-- feat: force trigger new version ([#305](https://github.com/MetaMask/metamask-sdk/pull/305))
-
-## [0.6.0]
-### Added
-- feat: remove invalid connect event (should contain chainId) ([#287](https://github.com/MetaMask/metamask-sdk/pull/287))
-- feat: add sideEffects field to sdk package ([#286](https://github.com/MetaMask/metamask-sdk/pull/286))
-- feat: refactor the RemoteConnection class ([#258](https://github.com/MetaMask/metamask-sdk/pull/258))
-- feat: MetaMask SDK initialization process document ([#253](https://github.com/MetaMask/metamask-sdk/pull/253))
-- docs: update example links and rn comments ([#254](https://github.com/MetaMask/metamask-sdk/pull/254))
-- feat: enable commit hooks and video examples  ([#252](https://github.com/MetaMask/metamask-sdk/pull/252))
-- feat: improve Socket.io performance ([#136](https://github.com/MetaMask/metamask-sdk/pull/136))
-- feat: restrict autoconnect desktopweb ([#248](https://github.com/MetaMask/metamask-sdk/pull/248))
-- refactor: move wagmi to sdk-react-ui ([#271](https://github.com/MetaMask/metamask-sdk/pull/271))
-
 ## [0.5.6]
+### Uncategorized
+- feat: force publish ([#311](https://github.com/MetaMask/metamask-sdk/pull/311))
+
 ### Added
 - feat: react hooks with wagmi ([#246](https://github.com/MetaMask/metamask-sdk/pull/246))
 
@@ -43,10 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.1...HEAD
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.0...@metamask/sdk-react-ui@0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.5.6...@metamask/sdk-react-ui@0.6.0
-[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.5.4...@metamask/sdk-react-ui@0.5.6
-[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.5.3...@metamask/sdk-react-ui@0.5.4
-[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.3.1...@metamask/sdk-react-ui@0.5.3
-[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react-ui@0.3.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.6...HEAD
+[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.4...v0.5.6
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/v0.3.1...v0.5.3
+[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.3.1

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.6.0",
+  "version": "0.5.6",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.6.1",
+  "version": "0.5.6",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,14 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.1]
-### Uncategorized
-- feat: force trigger new version ([#305](https://github.com/MetaMask/metamask-sdk/pull/305))
-- Release 20.0.1 ([#303](https://github.com/MetaMask/metamask-sdk/pull/303))
-- Revert "Release 20.0.0" ([#302](https://github.com/MetaMask/metamask-sdk/pull/302))
-- Release 20.0.0 ([#291](https://github.com/MetaMask/metamask-sdk/pull/291))
-- feat: add unit tests to the RemoteConnection class ([#301](https://github.com/MetaMask/metamask-sdk/pull/301))
-
 ## [0.6.0]
 ### Added
 - feat: improved event tracking ([#298](https://github.com/MetaMask/metamask-sdk/pull/298))
@@ -107,8 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.6.1...HEAD
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.6.0...@metamask/sdk@0.6.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.6.0...HEAD
 [0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.6...@metamask/sdk@0.6.0
 [0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.5...@metamask/sdk@0.5.6
 [0.5.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.5.4...@metamask/sdk@0.5.5

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk [0.6.0]
### Added
- feat: improved event tracking ([#298](https://github.com/MetaMask/metamask-sdk/pull/298))
- feat: reinitialize sdk on termination ([#296](https://github.com/MetaMask/metamask-sdk/pull/296))
- feat: remove invalid connect event (should contain chainId) ([#287](https://github.com/MetaMask/metamask-sdk/pull/287))
- feat: add sideEffects field to sdk package ([#286](https://github.com/MetaMask/metamask-sdk/pull/286))
- feat: refactor the RemoteConnection class ([#258](https://github.com/MetaMask/metamask-sdk/pull/258))
- feat: enable commit hooks and video examples  ([#252](https://github.com/MetaMask/metamask-sdk/pull/252))
- feat: restrict autoconnect desktopweb ([#248](https://github.com/MetaMask/metamask-sdk/pull/248))

## sdk-communication-layer [0.6.0]
### Added
- feat: improved event tracking ([#298](https://github.com/MetaMask/metamask-sdk/pull/298))
- feat: add unit tests to the SocketService class ([#294](https://github.com/MetaMask/metamask-sdk/pull/294))
- feat: refactor SocketService class for enhanced modularity and testability ([#292](https://github.com/MetaMask/metamask-sdk/pull/292))
- feat: refactor RemoteCommunication class for enhanced modularity and testability ([#282](https://github.com/MetaMask/metamask-sdk/pull/282))