### PR TITLE
fix: initialize state in _initializeStateAsync to address uninitialized properties issue

### DIFF
--- a/packages/sdk/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts
+++ b/packages/sdk/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts
@@ -16,6 +16,21 @@ import { SDKProvider } from '../../../provider/SDKProvider';
  * @throws Error if the initialization fails.
  */
 export async function initializeStateAsync(instance: SDKProvider) {
+  // Don't remove this logic, it's required to initialize the state in some cases.
+  if (instance.state === undefined) {
+    /**
+     * The Workaround: Initializing the state here to address an issue where properties
+     * were not set before this method was invoked, possibly by the parent class, leading to
+     * unexpected behavior.
+     *
+     */
+    instance.state = {
+      debug: false,
+      autoRequestAccounts: false,
+      providerStateRequested: false,
+    };
+  }
+
   const { state } = instance;
 
   if (state.debug) {


### PR DESCRIPTION
This PR aims to fix an issue where properties of **SDKProvider**, such as `this.debug`, were not initialized before `_initializeStateAsync` was invoked. This led to unexpected behavior and potential bugs in the application logic. 
Furthermore, this issue existed even before the recent refactor after investigation, but it was hidden because `this.debug` didn't throw a JS error.

Issue:

When `_initializeStateAsync` is invoked, properties like `this.debug` are still `undefined`. This suggests that the method is called before the class is fully initialized. The likely indicted is the parent class `AbstractStreamProvider`, which appears to invoke this method prematurely. This behavior was observed even before the recent code refactor.

Workaround:

To remedy this, the PR adds a check within `_initializeStateAsync` to ensure that `instance.state` is initialized if it's undefined. This acts as a safeguard to make sure all essential properties are initialized before executing any further logic.

```typescript
if (instance.state === undefined) {
  instance.state = {
    debug: false,
    autoRequestAccounts: false,
    providerStateRequested: false,
  };
}
``` 

Why this is a workaround:
Since we have not found a proper solution to the initialization issue, this is considered a workaround. However, this approach does not affect the method's core logic, making it acceptable.
In the ideal world, the initialization flow would work correctly, but we were not able to achieve it after deep research and modifications to the code.