### PR TITLE
fix: edge case when modal not fully resetting after termination

### DIFF
--- a/packages/devnext/src/pages/index.tsx
+++ b/packages/devnext/src/pages/index.tsx
@@ -267,6 +267,9 @@ try {
           </div>
         ) : connecting ? <>
           <div>Connecting...</div>
+          <button style={{ padding: 10, margin: 10 }} onClick={connect}>
+            Connect
+          </button>
         </> : (
           <button style={{ padding: 10, margin: 10 }} onClick={connect}>
             Connect

--- a/packages/sdk-install-modal-web/src/ModalLoader.tsx
+++ b/packages/sdk-install-modal-web/src/ModalLoader.tsx
@@ -35,6 +35,9 @@ export class ModalLoader {
 
     if (this.installContainer) {
       // Already rendered
+      if(this.debug) {
+        console.debug(`ModalLoader: renderInstallModal: already rendered`)
+      }
       return;
     }
 
@@ -56,6 +59,9 @@ export class ModalLoader {
     }
 
     if(this.selectContainer) {
+      if(this.debug) {
+        console.debug(`ModalLoader: renderSelectModal: already rendered`)
+      }
       return;
     }
     this.selectContainer = props.parentElement;
@@ -81,7 +87,9 @@ export class ModalLoader {
     }
 
     if (this.pendingContainer) {
-      // Already rendered
+      if(this.debug) {
+        console.debug(`ModalLoader: renderPendingModal: already rendered`)
+      }
       return;
     }
     this.pendingContainer = props.parentElement;

--- a/packages/sdk-install-modal-web/src/ModalLoader.tsx
+++ b/packages/sdk-install-modal-web/src/ModalLoader.tsx
@@ -22,8 +22,17 @@ export class ModalLoader {
   private installContainer?: Element;
   private pendingContainer?: Element;
   private selectContainer?: Element;
+  private debug = false;
+
+  constructor(debug?: boolean) {
+    this.debug = debug ?? false;
+  }
 
   renderInstallModal(props: InstallWidgetProps) {
+    if(this.debug) {
+      console.debug(`ModalLoader: renderInstallModal`, props)
+    }
+
     if (this.installContainer) {
       // Already rendered
       return;
@@ -42,6 +51,10 @@ export class ModalLoader {
   }
 
   renderSelectModal(props: SelectWidgetProps) {
+    if(this.debug) {
+      console.debug(`ModalLoader: renderSelectModal`, props)
+    }
+
     if(this.selectContainer) {
       return;
     }
@@ -63,6 +76,10 @@ export class ModalLoader {
   }
 
   renderPendingModal(props: PendingWidgetProps) {
+    if(this.debug) {
+      console.debug(`ModalLoader: renderPendingModal`, props)
+    }
+
     if (this.pendingContainer) {
       // Already rendered
       return;
@@ -80,6 +97,9 @@ export class ModalLoader {
   }
 
   updateOTPValue = (otpValue: string) => {
+    if(this.debug) {
+      console.debug(`ModalLoader: updateOTPValue`, otpValue)
+    }
     const otpNode = this.pendingContainer?.querySelector<HTMLElement>('#sdk-mm-otp-value');
     if (otpNode) {
       otpNode.textContent = otpValue;
@@ -88,6 +108,9 @@ export class ModalLoader {
   };
 
   updateQRCode = (link: string) => {
+    if(this.debug) {
+      console.debug(`ModalLoader: updateQRCode`, link)
+    }
     // TODO use scoped elem
     const qrCodeNode = this.selectContainer?.querySelector('#sdk-qrcode-container');
     if (qrCodeNode) {

--- a/packages/sdk-install-modal-web/src/SelectModal.tsx
+++ b/packages/sdk-install-modal-web/src/SelectModal.tsx
@@ -1,10 +1,10 @@
 import React, { CSSProperties, useState } from 'react';
+import { WidgetWrapper } from './WidgetWrapper';
 import CloseButton from './components/CloseButton';
 import ConnectIcon from './components/ConnectIcon';
 import Logo from './components/Logo';
 import { MetamaskExtensionImage } from './components/MetamaskExtensionImage';
 import styles from './styles';
-import { WidgetWrapper } from './WidgetWrapper';
 
 export interface SelectModalProps {
   onClose: () => void;

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
@@ -51,7 +51,4 @@ export function terminate(instance: MetaMaskSDK) {
     terminate: true,
     sendMessage: true,
   });
-
-  instance._initialized = false;
-  instance.sdkInitPromise = undefined;
 }

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
@@ -53,4 +53,5 @@ export function terminate(instance: MetaMaskSDK) {
   });
 
   instance._initialized = false;
+  instance.sdkInitPromise = undefined;
 }

--- a/packages/sdk/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts
@@ -28,11 +28,14 @@ export async function connectWithExtensionProvider(instance: MetaMaskSDK) {
 
   try {
     // always create initial query to connect the account
-    await instance.activeProvider?.request({
+    const accounts = await instance.activeProvider?.request({
       method: 'eth_requestAccounts',
     });
+    if (instance.debug) {
+      console.debug(`SDK::connectWithExtensionProvider() accounts`, accounts);
+    }
   } catch (err) {
-    // ignore error˝
+    // ignore error
     console.warn(
       `SDK::connectWithExtensionProvider() can't request accounts error`,
       err,

--- a/packages/sdk/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts
@@ -1,7 +1,7 @@
 import { EventType, TrackingEvents } from '@metamask/sdk-communication-layer';
+import { STORAGE_PROVIDER_TYPE } from '../../../config';
 import { MetaMaskSDK } from '../../../sdk';
 import { PROVIDER_UPDATE_TYPE } from '../../../types/ProviderUpdateType';
-import { STORAGE_PROVIDER_TYPE } from '../../../config';
 
 /**
  * Connects the MetaMaskSDK instance to the MetaMask browser extension as the active provider.
@@ -18,8 +18,9 @@ import { STORAGE_PROVIDER_TYPE } from '../../../config';
  */
 export async function connectWithExtensionProvider(instance: MetaMaskSDK) {
   if (instance.debug) {
-    console.debug(`SDK::connectWithExtensionProvider()`);
+    console.debug(`SDK::connectWithExtensionProvider()`, instance);
   }
+
   // save a copy of the instance before it gets overwritten
   instance.sdkProvider = instance.activeProvider;
   instance.activeProvider = window.extension as any;

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/connectWithModalInstaller.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/connectWithModalInstaller.ts
@@ -25,6 +25,13 @@ export async function connectWithModalInstaller(
       return;
     }
 
+    if (state.developerMode) {
+      console.debug(`connectWithModalInstaller()`, {
+        state,
+        options,
+        linkParams,
+      });
+    }
     const universalLink = `${METAMASK_CONNECT_BASE_URL}?${linkParams}`;
     showInstallModal(state, options, universalLink);
 

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
@@ -49,7 +49,9 @@ export async function startConnection(
   }
 
   const linkParams = encodeURI(
-    `channelId=${channelId}&comm=${state.communicationLayerPreference}&pubkey=${pubKey}`,
+    `channelId=${channelId}&comm=${
+      state.communicationLayerPreference ?? ''
+    }&pubkey=${pubKey}`,
   );
   const universalLink = `${METAMASK_CONNECT_BASE_URL}?${linkParams}`;
   state.universalLink = universalLink;

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts
@@ -19,9 +19,10 @@ export async function reconnectWithModalOTP(
   if (state.pendingModal) {
     state.pendingModal?.mount?.();
   } else {
-    state.pendingModal = options.modals.otp?.(() =>
-      onOTPModalDisconnect(options, state),
-    );
+    state.pendingModal = options.modals.otp?.({
+      debug: state.developerMode,
+      onDisconnect: () => onOTPModalDisconnect(options, state),
+    });
   }
 
   const otp = await waitForOTPAnswer(state);

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.ts
@@ -14,18 +14,6 @@ export function showInstallModal(
   options: RemoteConnectionProps,
   link: string,
 ): void {
-  // prevent double initialization
-  if (state.installModal) {
-    if (state.developerMode) {
-      console.debug(
-        `RemoteConnection::showInstallModal() install modal already initialized`,
-        state.installModal,
-      );
-    }
-    state.installModal.mount?.(link);
-    return;
-  }
-
   state.installModal = options.modals.install?.({
     link,
     installer: options.getMetaMaskInstaller(),

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -54,7 +54,13 @@ export interface RemoteConnectionProps {
       unmount?: (shouldTerminate?: boolean) => void;
       mount?: (link: string) => void;
     };
-    otp?: (onDisconnect?: () => void) => {
+    otp?: ({
+      debug,
+      onDisconnect,
+    }: {
+      debug?: boolean;
+      onDisconnect?: () => void;
+    }) => {
       mount?: () => void;
       updateOTPValue?: (otpValue: string) => void;
       unmount?: () => void;

--- a/packages/sdk/src/services/SDKProvider/ConnectionManager/handleDisconnect.ts
+++ b/packages/sdk/src/services/SDKProvider/ConnectionManager/handleDisconnect.ts
@@ -24,6 +24,16 @@ export function handleDisconnect({
 }) {
   const { state } = instance;
 
+  const connected = instance.isConnected();
+  if (!connected) {
+    if (state.debug) {
+      console.debug(
+        `SDKProvider::handleDisconnect() not connected --- interrup disconnection`,
+      );
+    }
+    return;
+  }
+
   if (state.debug) {
     console.debug(
       `SDKProvider::handleDisconnect() cleaning up provider state terminate=${terminate}`,

--- a/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
@@ -56,7 +56,7 @@ const sdkWebInstallModal = ({
       return;
     }
 
-    modalLoader = new ModalLoader();
+    modalLoader = new ModalLoader(debug);
     div = document.createElement('div');
     document.body.appendChild(div);
     if (window.extension) {

--- a/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
@@ -15,11 +15,8 @@ const sdkWebInstallModal = ({
   terminate?: () => void;
   connectWithExtension?: () => void;
 }) => {
-  const div = document.createElement('div');
-  document.body.appendChild(div);
-  let mounted = false;
-
-  const modalLoader = new ModalLoader();
+  let modalLoader: ModalLoader | null = null;
+  let div: HTMLDivElement | null = null;
 
   if (debug) {
     console.debug(`################## Installing Modal #################`);
@@ -32,22 +29,36 @@ const sdkWebInstallModal = ({
   }
 
   const unmount = (shouldTerminate?: boolean) => {
-    if (div) {
-      div.style.display = 'none';
+    if (debug) {
+      console.info('installModal-web unmounting install modal', div);
     }
 
+    if (div) {
+      // div.style.display = 'none';
+      // remove div node from dom
+      div.parentNode?.removeChild(div);
+    }
+    div = null;
+    modalLoader = null;
     if (shouldTerminate === true) {
       terminate?.();
     }
   };
 
   const mount = (qrcodeLink: string) => {
-    if (mounted) {
+    if (debug) {
+      console.info('installModal-web mounting install modal', div);
+    }
+
+    if (div) {
       div.style.display = 'block';
-      modalLoader.updateQRCode(qrcodeLink);
+      modalLoader?.updateQRCode(qrcodeLink);
       return;
     }
 
+    modalLoader = new ModalLoader();
+    div = document.createElement('div');
+    document.body.appendChild(div);
     if (window.extension) {
       // When extension is available, we allow switching between extension and mobile
       modalLoader.renderSelectModal({
@@ -67,7 +78,6 @@ const sdkWebInstallModal = ({
         onClose: unmount,
       });
     }
-    mounted = true;
   };
 
   return { mount, unmount };

--- a/packages/sdk/src/ui/InstallModal/pendingModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/pendingModal-web.ts
@@ -42,7 +42,7 @@ const sdkWebPendingModal = ({
       return;
     }
 
-    modalLoader = new ModalLoader();
+    modalLoader = new ModalLoader(debug);
     div = document.createElement('div');
     document.body.appendChild(div);
 

--- a/packages/sdk/src/ui/InstallModal/pendingModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/pendingModal-web.ts
@@ -1,27 +1,50 @@
 import { ModalLoader } from '@metamask/sdk-install-modal-web';
 
-const sdkWebPendingModal = (onDisconnect?: () => void) => {
-  const div = document.createElement('div');
-  document.body.appendChild(div);
-  let mounted = false;
-
-  const modalLoader = new ModalLoader();
+const sdkWebPendingModal = ({
+  debug,
+  onDisconnect,
+}: {
+  debug?: boolean;
+  onDisconnect?: () => void;
+}) => {
+  let div: HTMLDivElement | null = null;
+  let modalLoader: ModalLoader | null = null;
 
   const unmount = () => {
-    div.style.display = 'none';
+    if (debug) {
+      console.log(`pendingModal-web unmount`, div);
+    }
+
+    if (div) {
+      div.style.display = 'none';
+    }
+    div = null;
+    modalLoader = null;
   };
 
   const updateOTPValue = (otpValue: string) => {
+    if (debug) {
+      console.log(`pendingModal-web updateOTPValue`, otpValue);
+    }
+
     if (modalLoader) {
       modalLoader.updateOTPValue(otpValue);
     }
   };
 
   const mount = () => {
-    if (mounted) {
+    if (debug) {
+      console.log(`pendingModal-web mount`, div);
+    }
+
+    if (div) {
       div.style.display = 'block';
       return;
     }
+
+    modalLoader = new ModalLoader();
+    div = document.createElement('div');
+    document.body.appendChild(div);
 
     modalLoader.renderPendingModal({
       parentElement: div,
@@ -29,7 +52,6 @@ const sdkWebPendingModal = (onDisconnect?: () => void) => {
       onDisconnect,
       updateOTPValue,
     });
-    mounted = true;
   };
 
   // Auto mount on initialization


### PR DESCRIPTION
- improve logging details
- prevent re-initializing the sdk on connection termination (especially useful when integrating with external provider: web3-onboard)
- fix: issue when the modals were not properly displaying after connection is terminated after switching provider.