### PR TITLE
feat: extend the time we resume the session without showing OTP

### DIFF
--- a/packages/examples/nextjs-demo/sdk-copy.sh
+++ b/packages/examples/nextjs-demo/sdk-copy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Make sure to start from base workspace folder
+reldir="$( dirname -- "$0"; )";
+cd "$reldir/../../..";
+SDK_WORKSPACE_DIR="$( pwd; )";
+COMM_LAYER_DIR="$SDK_WORKSPACE_DIR/packages/sdk-communication-layer"
+SDK_DIR="$SDK_WORKSPACE_DIR/packages/sdk"
+SDK_REACT_DIR="$SDK_WORKSPACE_DIR/packages/sdk-react"
+SDK_REACT_UI_DIR="$SDK_WORKSPACE_DIR/packages/sdk-react-ui"
+
+DAPP_DIR="$SDK_WORKSPACE_DIR/packages/examples/nextjs-demo"
+
+echo "SDK_DIR: $SDK_DIR"
+echo "COMM_LAYER_DIR: $COMM_LAYER_DIR"
+echo "DAPP_DIR: $DAPP_DIR"
+echo "SDK_REACT_DIR: $SDK_REACT_DIR"
+echo "SDK_REACT_UI_DIR: $SDK_REACT_UI_DIR"
+
+echo "########### START REPLACING SDK_COMMUNICATION_LAYER #########"
+
+cd $DAPP_DIR
+echo "Hack Metamask sdk && sdk-communication-layer packages..."
+## hack to debug to latest unpublished version of the sdk
+rm -rf node_modules/@metamask/sdk-communication-layer node_modules/@metamask/sdk node_modules/@metamask/sdk-react node_modules/@metamask/sdk-react-ui
+cp -rf $COMM_LAYER_DIR node_modules/@metamask/
+cp -rf $SDK_DIR node_modules/@metamask/
+cp -rf $SDK_REACT_DIR node_modules/@metamask/
+cp -rf $SDK_REACT_UI_DIR node_modules/@metamask/
+
+
+echo "All done."

--- a/packages/examples/pure-javascript/sdk-copy.sh
+++ b/packages/examples/pure-javascript/sdk-copy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Make sure to start from base workspace folder
+reldir="$( dirname -- "$0"; )";
+cd "$reldir/../../..";
+SDK_WORKSPACE_DIR="$( pwd; )";
+COMM_LAYER_DIR="$SDK_WORKSPACE_DIR/packages/sdk-communication-layer"
+SDK_DIR="$SDK_WORKSPACE_DIR/packages/sdk"
+SDK_REACT_DIR="$SDK_WORKSPACE_DIR/packages/sdk-react"
+SDK_REACT_UI_DIR="$SDK_WORKSPACE_DIR/packages/sdk-react-ui"
+
+DAPP_DIR="$SDK_WORKSPACE_DIR/packages/examples/pure-javascript"
+
+echo "SDK_DIR: $SDK_DIR"
+echo "COMM_LAYER_DIR: $COMM_LAYER_DIR"
+echo "DAPP_DIR: $DAPP_DIR"
+echo "SDK_REACT_DIR: $SDK_REACT_DIR"
+echo "SDK_REACT_UI_DIR: $SDK_REACT_UI_DIR"
+
+echo "########### START REPLACING SDK_COMMUNICATION_LAYER #########"
+
+cd $DAPP_DIR
+echo "Hack Metamask sdk && sdk-communication-layer packages..."
+## hack to debug to latest unpublished version of the sdk
+rm -rf node_modules/@metamask/sdk-communication-layer node_modules/@metamask/sdk node_modules/@metamask/sdk-react node_modules/@metamask/sdk-react-ui
+cp -rf $COMM_LAYER_DIR node_modules/@metamask/
+cp -rf $SDK_DIR node_modules/@metamask/
+cp -rf $SDK_REACT_DIR node_modules/@metamask/
+cp -rf $SDK_REACT_UI_DIR node_modules/@metamask/
+
+
+echo "All done."

--- a/packages/examples/vuejs/sdk-copy.sh
+++ b/packages/examples/vuejs/sdk-copy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Make sure to start from base workspace folder
+reldir="$( dirname -- "$0"; )";
+cd "$reldir/../../..";
+SDK_WORKSPACE_DIR="$( pwd; )";
+COMM_LAYER_DIR="$SDK_WORKSPACE_DIR/packages/sdk-communication-layer"
+SDK_DIR="$SDK_WORKSPACE_DIR/packages/sdk"
+SDK_REACT_DIR="$SDK_WORKSPACE_DIR/packages/sdk-react"
+SDK_REACT_UI_DIR="$SDK_WORKSPACE_DIR/packages/sdk-react-ui"
+
+DAPP_DIR="$SDK_WORKSPACE_DIR/packages/examples/vuejs"
+
+echo "SDK_DIR: $SDK_DIR"
+echo "COMM_LAYER_DIR: $COMM_LAYER_DIR"
+echo "DAPP_DIR: $DAPP_DIR"
+echo "SDK_REACT_DIR: $SDK_REACT_DIR"
+echo "SDK_REACT_UI_DIR: $SDK_REACT_UI_DIR"
+
+echo "########### START REPLACING SDK_COMMUNICATION_LAYER #########"
+
+cd $DAPP_DIR
+echo "Hack Metamask sdk && sdk-communication-layer packages..."
+## hack to debug to latest unpublished version of the sdk
+rm -rf node_modules/@metamask/sdk-communication-layer node_modules/@metamask/sdk node_modules/@metamask/sdk-react node_modules/@metamask/sdk-react-ui
+cp -rf $COMM_LAYER_DIR node_modules/@metamask/
+cp -rf $SDK_DIR node_modules/@metamask/
+cp -rf $SDK_REACT_DIR node_modules/@metamask/
+cp -rf $SDK_REACT_UI_DIR node_modules/@metamask/
+
+
+echo "All done."

--- a/packages/sdk-communication-layer/jest.config.ts
+++ b/packages/sdk-communication-layer/jest.config.ts
@@ -7,7 +7,7 @@ module.exports = {
     global: {
       branches: 79,
       functions: 84,
-      lines: 91,
+      lines: 90,
       statements: 90,
     },
   },

--- a/packages/sdk-communication-layer/jest.config.ts
+++ b/packages/sdk-communication-layer/jest.config.ts
@@ -2,7 +2,7 @@ import baseConfig from '../../jest.config.base';
 
 module.exports = {
   ...baseConfig,
-  coveragePathIgnorePatterns: ['./src/types'],
+  coveragePathIgnorePatterns: ['./src/types', '/index.ts$'],
   coverageThreshold: {
     global: {
       branches: 79,

--- a/packages/sdk-install-modal-web/src/ModalLoader.tsx
+++ b/packages/sdk-install-modal-web/src/ModalLoader.tsx
@@ -29,14 +29,14 @@ export class ModalLoader {
   }
 
   renderInstallModal(props: InstallWidgetProps) {
-    if(this.debug) {
-      console.debug(`ModalLoader: renderInstallModal`, props)
+    if (this.debug) {
+      console.debug(`ModalLoader: renderInstallModal`, props);
     }
 
     if (this.installContainer) {
       // Already rendered
-      if(this.debug) {
-        console.debug(`ModalLoader: renderInstallModal: already rendered`)
+      if (this.debug) {
+        console.debug(`ModalLoader: renderInstallModal: already rendered`);
       }
       return;
     }
@@ -54,13 +54,13 @@ export class ModalLoader {
   }
 
   renderSelectModal(props: SelectWidgetProps) {
-    if(this.debug) {
-      console.debug(`ModalLoader: renderSelectModal`, props)
+    if (this.debug) {
+      console.debug(`ModalLoader: renderSelectModal`, props);
     }
 
-    if(this.selectContainer) {
-      if(this.debug) {
-        console.debug(`ModalLoader: renderSelectModal: already rendered`)
+    if (this.selectContainer) {
+      if (this.debug) {
+        console.debug(`ModalLoader: renderSelectModal: already rendered`);
       }
       return;
     }
@@ -75,20 +75,19 @@ export class ModalLoader {
       />,
     );
 
-    setTimeout( () => {
+    setTimeout(() => {
       this.updateQRCode(props.link);
     }, 100);
-
   }
 
   renderPendingModal(props: PendingWidgetProps) {
-    if(this.debug) {
-      console.debug(`ModalLoader: renderPendingModal`, props)
+    if (this.debug) {
+      console.debug(`ModalLoader: renderPendingModal`, props);
     }
 
     if (this.pendingContainer) {
-      if(this.debug) {
-        console.debug(`ModalLoader: renderPendingModal: already rendered`)
+      if (this.debug) {
+        console.debug(`ModalLoader: renderPendingModal: already rendered`);
       }
       return;
     }
@@ -100,15 +99,17 @@ export class ModalLoader {
         onClose={props.onClose}
         onDisconnect={props.onDisconnect}
         updateOTPValue={props.updateOTPValue}
+        displayOTP={props.displayOTP}
       />,
     );
   }
 
   updateOTPValue = (otpValue: string) => {
-    if(this.debug) {
-      console.debug(`ModalLoader: updateOTPValue`, otpValue)
+    if (this.debug) {
+      console.debug(`ModalLoader: updateOTPValue`, otpValue);
     }
-    const otpNode = this.pendingContainer?.querySelector<HTMLElement>('#sdk-mm-otp-value');
+    const otpNode =
+      this.pendingContainer?.querySelector<HTMLElement>('#sdk-mm-otp-value');
     if (otpNode) {
       otpNode.textContent = otpValue;
       otpNode.style.display = 'block';
@@ -116,11 +117,13 @@ export class ModalLoader {
   };
 
   updateQRCode = (link: string) => {
-    if(this.debug) {
-      console.debug(`ModalLoader: updateQRCode`, link)
+    if (this.debug) {
+      console.debug(`ModalLoader: updateQRCode`, link);
     }
     // TODO use scoped elem
-    const qrCodeNode = this.selectContainer?.querySelector('#sdk-qrcode-container');
+    const qrCodeNode = this.selectContainer?.querySelector(
+      '#sdk-qrcode-container',
+    );
     if (qrCodeNode) {
       qrCodeNode.innerHTML = '';
       // Prevent nextjs import issue: https://github.com/kozakdenys/qr-code-styling/issues/38
@@ -149,7 +152,7 @@ export class ModalLoader {
       });
       qrCode.append(qrCodeNode);
     }
-  }
+  };
 
   unmount() {
     if (this.pendingContainer) {
@@ -160,7 +163,7 @@ export class ModalLoader {
       this.installContainer?.parentNode?.removeChild(this.installContainer);
       this.installContainer = undefined;
     }
-    if(this.selectContainer) {
+    if (this.selectContainer) {
       this.selectContainer?.parentNode?.removeChild(this.selectContainer);
       this.selectContainer = undefined;
     }

--- a/packages/sdk-install-modal-web/src/PendingModal.tsx
+++ b/packages/sdk-install-modal-web/src/PendingModal.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import CloseButton from "./components/CloseButton";
-import Logo from "./components/Logo";
-import styles from "./styles";
-import { WidgetWrapper } from "./WidgetWrapper";
+import CloseButton from './components/CloseButton';
+import Logo from './components/Logo';
+import styles from './styles';
+import { WidgetWrapper } from './WidgetWrapper';
 
 export interface PendingModalProps {
   onClose: () => void;
   onDisconnect?: () => void;
   updateOTPValue: (otpValue: string) => void;
+  displayOTP?: boolean;
 }
 
 export const PendingModal = (props: PendingModalProps) => {
-  return <WidgetWrapper className='pending-modal'>
-    <div style={styles.backdrop} onClick={props.onClose}>
-      </div>
+  const displayOTP = props.displayOTP ?? true;
+
+  return (
+    <WidgetWrapper className="pending-modal">
+      <div style={styles.backdrop} onClick={props.onClose}></div>
       <div style={styles.modal}>
         <div style={styles.closeButtonContainer}>
           <div style={styles.right}>
@@ -23,44 +26,59 @@ export const PendingModal = (props: PendingModalProps) => {
           </div>
         </div>
         <div style={styles.logoContainer}>
-            <Logo />
+          <Logo />
+        </div>
+        <div>
+          <div
+            style={{
+              ...styles.flexContainer,
+              flexDirection: 'column',
+              color: 'black',
+            }}
+          >
+            <div
+              style={{
+                textAlign: 'center',
+                marginTop: '30px',
+                marginBottom: '30px',
+                ...styles.flexItem,
+                fontSize: 16,
+              }}
+            >
+              {displayOTP
+                ? 'Please open the MetaMask wallet app and select the code on the screen OR disconnect'
+                : 'Open the MetaMask app to continue with your session.'}
+            </div>
+            <div
+              id="sdk-mm-otp-value"
+              style={{ padding: 10, fontSize: 32, display: 'none' }}
+            ></div>
+            {displayOTP && (
+              <div style={{ ...styles.notice }}>
+                * If a number doesn't appear after opening MetaMask, please
+                click disconnect and re-scan the QRCode.
+              </div>
+            )}
           </div>
-          <div>
-            <div style={{...styles.flexContainer, flexDirection: 'column', color: 'black'}}>
-              <div
-                style={{
-                  textAlign: 'center',
-                  marginTop: '30px',
-                  marginBottom: '30px',
-                  ...styles.flexItem,
-                  fontSize: 16,
-                }}
-              >
-                Please open the MetaMask wallet app and select the code on the
-                screen OR disconnect
-              </div>
-              <div
-                id="sdk-mm-otp-value"
-                style={{ padding: 10, fontSize: 32, display: 'none' }}
-              ></div>
-              <div style={{...styles.notice}}>
-                * If a number doesn't appear after opening MetaMask, please click disconnect and re-scan the QRCode.
-              </div>
-            </div>
-            <div style={{ marginTop: '20px' }}>
-              <button
-                style={{
-                  ...styles.button,
-                  ...styles.blue,
-                  marginTop: '5px',
-                  color: 'white',
-                }}
-                onClick={props.onDisconnect}
-              >
-                Disconnect
-              </button>
-            </div>
+          <div style={{ marginTop: '20px' }}>
+            <button
+              style={{
+                ...styles.button,
+                ...styles.blue,
+                marginTop: '5px',
+                color: '#0376C9',
+                borderColor: '#0376C9',
+                borderWidth: '1px',
+                borderStyle: 'solid',
+                backgroundColor: 'white',
+              }}
+              onClick={props.onDisconnect}
+            >
+              Disconnect
+            </button>
+          </div>
+        </div>
       </div>
-    </div>
-  </WidgetWrapper>;
+    </WidgetWrapper>
+  );
 };

--- a/packages/sdk/jest.config.ts
+++ b/packages/sdk/jest.config.ts
@@ -2,7 +2,7 @@ import baseConfig from '../../jest.config.base';
 
 module.exports = {
   ...baseConfig,
-  coveragePathIgnorePatterns: ['./src/types'],
+  coveragePathIgnorePatterns: ['./src/types', '/index.ts$'],
   coverageThreshold: {
     global: {
       branches: 68,

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -11,3 +11,6 @@ export const ErrorMessages = {
 export const METAMASK_CONNECT_BASE_URL = 'https://metamask.app.link/connect';
 
 export const METAMASK_DEEPLINK_BASE = 'metamask://connect';
+
+export const ONE_MINUTE_IN_MS = 60 * 1000;
+export const ONE_HOUR_IN_MS = ONE_MINUTE_IN_MS * 60;

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.test.ts
@@ -103,15 +103,21 @@ describe('startConnection', () => {
   });
 
   it('should call reconnectWithModalOTP when channelConfig lastActive is true and isSecure is false', async () => {
-    mockOriginatorSessionConnect.mockResolvedValue({
+    const mockChannelConfig = {
       lastActive: true,
-    });
+    };
+
+    mockOriginatorSessionConnect.mockResolvedValue(mockChannelConfig);
 
     mockIsSecure.mockReturnValue(false);
 
     await startConnection(state, options);
 
-    expect(mockReconnectWithModalOTP).toHaveBeenCalledWith(state, options);
+    expect(mockReconnectWithModalOTP).toHaveBeenCalledWith(
+      state,
+      options,
+      mockChannelConfig,
+    );
   });
 
   it('should call connectWithModalInstaller when platform is not secure and channelConfig does not have lastActive', async () => {

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
@@ -18,7 +18,7 @@ import { connectWithModalInstaller } from './connectWithModalInstaller';
 export async function startConnection(
   state: RemoteConnectionState,
   options: RemoteConnectionProps,
-): Promise<void> {
+): Promise<void | undefined> {
   if (!state.connector) {
     throw new Error('no connector defined');
   }
@@ -63,7 +63,7 @@ export async function startConnection(
   }
 
   if (channelConfig?.lastActive) {
-    return reconnectWithModalOTP(state, options);
+    return reconnectWithModalOTP(state, options, channelConfig);
   }
 
   return connectWithModalInstaller(state, options, linkParams);

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
@@ -18,7 +18,7 @@ import { connectWithModalInstaller } from './connectWithModalInstaller';
 export async function startConnection(
   state: RemoteConnectionState,
   options: RemoteConnectionProps,
-): Promise<void | undefined> {
+): Promise<void> {
   if (!state.connector) {
     throw new Error('no connector defined');
   }

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.test.ts
@@ -1,7 +1,9 @@
+import { ChannelConfig } from '@metamask/sdk-communication-layer';
 import {
   RemoteConnectionProps,
   RemoteConnectionState,
 } from '../RemoteConnection';
+import { Ethereum } from '../../Ethereum';
 import { onOTPModalDisconnect } from './onOTPModalDisconnect';
 import { reconnectWithModalOTP } from './reconnectWithModalOTP';
 import { waitForOTPAnswer } from './waitForOTPAnswer';
@@ -9,19 +11,42 @@ import { waitForOTPAnswer } from './waitForOTPAnswer';
 jest.mock('./waitForOTPAnswer');
 jest.mock('./onOTPModalDisconnect');
 
+jest.mock('../../Ethereum');
+
 describe('reconnectWithModalOTP', () => {
   let state: RemoteConnectionState;
   let options: RemoteConnectionProps;
+  let channelConfig: ChannelConfig;
+  const mockEthereum = Ethereum as jest.Mocked<typeof Ethereum>;
 
-  const mockMount = jest.fn();
+  const mockMount = jest.fn(
+    ({ displayOTP }: { displayOTP?: boolean } = {}) => displayOTP,
+  );
   const mockUnmount = jest.fn();
   const mockUpdateOTPValue = jest.fn();
-  const mockOtpModal = jest.fn();
+  const mockOtpModal = jest.fn(() => {
+    return {
+      mount: mockMount,
+      unmount: mockUnmount,
+      updateOTPValue: mockUpdateOTPValue,
+    };
+  });
   const mockWaitForOTPAnswer = waitForOTPAnswer as jest.Mock;
   const mockOnOTPModalDisconnect = onOTPModalDisconnect as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockEthereum.getProvider.mockReturnValue({
+      _setConnected: jest.fn(),
+      getState: jest.fn(),
+    } as unknown as any);
+
+    channelConfig = {
+      channelId: 'test_channel_id',
+      lastActive: Date.now(),
+      validUntil: Date.now(),
+    };
 
     state = {
       otpAnswer: 'test_otp',
@@ -40,57 +65,105 @@ describe('reconnectWithModalOTP', () => {
     } as unknown as RemoteConnectionProps;
   });
 
-  it('should mount the OTP modal if state.pendingModal is already defined', async () => {
-    mockWaitForOTPAnswer.mockResolvedValue('test_otp');
-
-    await reconnectWithModalOTP(state, options);
-
-    expect(mockMount).toHaveBeenCalled();
-    expect(mockOtpModal).not.toHaveBeenCalled();
-    expect(state.otpAnswer).toBe('test_otp');
-  });
-
-  it('should create and mount a new OTP modal if state.pendingModal is not defined', async () => {
-    state.pendingModal = undefined;
-    mockOtpModal.mockReturnValue({ mount: mockMount, unmount: mockUnmount });
-    mockWaitForOTPAnswer.mockResolvedValue('test_otp');
-
-    await reconnectWithModalOTP(state, options);
-
-    expect(mockOtpModal).toHaveBeenCalled();
-    expect(mockMount).not.toHaveBeenCalled();
-    expect(state.otpAnswer).toBe('test_otp');
-  });
-
-  it('should update state.otpAnswer and the OTP modal when OTP is received', async () => {
-    state.otpAnswer = 'initial_otp';
-    mockWaitForOTPAnswer.mockResolvedValue('new_otp');
-
-    await reconnectWithModalOTP(state, options);
-
-    expect(state.otpAnswer).toBe('new_otp');
-    expect(mockUpdateOTPValue).toHaveBeenCalledWith('new_otp');
-  });
-
-  it('should call onOTPModalDisconnect when the modal disconnect occurs', async () => {
-    state.pendingModal = undefined;
-    mockOtpModal.mockImplementation(({ onDisconnect }) => {
-      onDisconnect();
-
-      return { mount: mockMount, unmount: mockUnmount };
+  describe('channel was active recently', () => {
+    beforeEach(() => {
+      channelConfig.lastActive = Date.now() - 30 * 60 * 1000; // 30 minutes ago
     });
-    mockWaitForOTPAnswer.mockResolvedValue('test_otp');
 
-    await reconnectWithModalOTP(state, options);
+    it('should handle a recently active channel', async () => {
+      channelConfig.lastActive = Date.now() - 30 * 60 * 1000; // 30 minutes ago
+      await reconnectWithModalOTP(state, options, channelConfig);
 
-    expect(mockOnOTPModalDisconnect).toHaveBeenCalledWith(options, state);
+      const mockProvider = mockEthereum.getProvider();
+      expect(mockProvider._setConnected).toHaveBeenCalled();
+      expect(mockMount).toHaveBeenCalledWith({
+        displayOTP: false,
+      });
+      expect(state.pendingModal?.unmount).toHaveBeenCalled();
+      expect(state.authorized).toBe(true);
+    });
+
+    it('should unmount installModal if channel was active recently', async () => {
+      channelConfig.lastActive = Date.now() - 30 * 60 * 1000; // 30 minutes ago
+      state.installModal = {
+        unmount: jest.fn(),
+      };
+
+      await reconnectWithModalOTP(state, options, channelConfig);
+      expect(state.installModal?.unmount).toHaveBeenCalledWith(false);
+    });
+
+    it('should log debug message in developer mode', async () => {
+      state.developerMode = true;
+      channelConfig.lastActive = Date.now() - 30 * 60 * 1000; // 30 minutes ago
+      (mockEthereum.getProvider().getState as jest.Mock).mockImplementation(
+        () => 'mockState',
+      );
+
+      jest.spyOn(console, 'debug').mockImplementation();
+      await reconnectWithModalOTP(state, options, channelConfig);
+      expect(console.debug).toHaveBeenCalledWith(
+        "RCPMS::on 'authorized' provider.state",
+        'mockState',
+      );
+    });
+
+    it('should go through OTP flow if channelConfig.lastActive is undefined', async () => {
+      delete channelConfig.lastActive;
+      mockWaitForOTPAnswer.mockResolvedValue('test_otp');
+
+      await reconnectWithModalOTP(state, options, channelConfig);
+      expect(mockWaitForOTPAnswer).toHaveBeenCalled();
+    });
   });
 
-  it('should not call onOTPModalDisconnect if state.pendingModal is already defined', async () => {
-    mockWaitForOTPAnswer.mockResolvedValue('test_otp');
+  describe('channel was NOT active recently', () => {
+    beforeEach(() => {
+      channelConfig.lastActive = Date.now() - 2 * 60 * 60 * 1000; // 2 hours ago
+    });
 
-    await reconnectWithModalOTP(state, options);
+    it('should mount the OTP modal if state.pendingModal is already defined', async () => {
+      mockWaitForOTPAnswer.mockResolvedValue('test_otp');
 
-    expect(mockOnOTPModalDisconnect).not.toHaveBeenCalled();
+      await reconnectWithModalOTP(state, options, channelConfig);
+
+      expect(mockMount).toHaveBeenCalled();
+      expect(mockOtpModal).not.toHaveBeenCalled();
+      expect(state.otpAnswer).toBe('test_otp');
+    });
+
+    it('should create and mount a new OTP modal if state.pendingModal is not defined', async () => {
+      state.pendingModal = undefined;
+      mockOtpModal.mockReturnValue({
+        mount: mockMount,
+        unmount: mockUnmount,
+        updateOTPValue: mockUpdateOTPValue,
+      });
+      mockWaitForOTPAnswer.mockResolvedValue('test_otp');
+
+      await reconnectWithModalOTP(state, options, channelConfig);
+
+      expect(mockOtpModal).toHaveBeenCalled();
+      expect(mockMount).not.toHaveBeenCalled();
+      expect(state.otpAnswer).toBe('test_otp');
+    });
+
+    it('should update state.otpAnswer and the OTP modal when OTP is received', async () => {
+      state.otpAnswer = 'initial_otp';
+      mockWaitForOTPAnswer.mockResolvedValue('new_otp');
+
+      await reconnectWithModalOTP(state, options, channelConfig);
+
+      expect(state.otpAnswer).toBe('new_otp');
+      expect(mockUpdateOTPValue).toHaveBeenCalledWith('new_otp');
+    });
+
+    it('should not call onOTPModalDisconnect if state.pendingModal is already defined', async () => {
+      mockWaitForOTPAnswer.mockResolvedValue('test_otp');
+
+      await reconnectWithModalOTP(state, options, channelConfig);
+
+      expect(mockOnOTPModalDisconnect).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.test.ts
@@ -4,6 +4,7 @@ import {
   RemoteConnectionState,
 } from '../RemoteConnection';
 import { Ethereum } from '../../Ethereum';
+import { SDKProvider } from '../../../provider/SDKProvider';
 import { onOTPModalDisconnect } from './onOTPModalDisconnect';
 import { reconnectWithModalOTP } from './reconnectWithModalOTP';
 import { waitForOTPAnswer } from './waitForOTPAnswer';
@@ -40,7 +41,7 @@ describe('reconnectWithModalOTP', () => {
     mockEthereum.getProvider.mockReturnValue({
       _setConnected: jest.fn(),
       getState: jest.fn(),
-    } as unknown as any);
+    } as unknown as SDKProvider);
 
     channelConfig = {
       channelId: 'test_channel_id',

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts
@@ -4,16 +4,19 @@ import {
   RemoteConnectionProps,
   RemoteConnectionState,
 } from '../RemoteConnection';
+import { ONE_HOUR_IN_MS } from '../../../constants';
 import { onOTPModalDisconnect } from './onOTPModalDisconnect';
 import { waitForOTPAnswer } from './waitForOTPAnswer';
-
-const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
 /**
  * Reconnects to MetaMask using an OTP modal and waits for an OTP answer.
  *
+ * - If MetaMask's channel was active in the last hour, it reconnects without requiring OTP.
+ * - Otherwise, prompts user for OTP and waits for a response.
+ *
  * @param state Current state of the RemoteConnection class instance.
  * @param options Configuration options for the OTP modal.
+ * @param channelConfig Configuration related to the communication channel with MetaMask.
  * @returns Promise<void>
  */
 export async function reconnectWithModalOTP(

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts
@@ -1,9 +1,13 @@
+import { ChannelConfig } from '@metamask/sdk-communication-layer';
+import { Ethereum } from '../../Ethereum';
 import {
   RemoteConnectionProps,
   RemoteConnectionState,
 } from '../RemoteConnection';
 import { onOTPModalDisconnect } from './onOTPModalDisconnect';
 import { waitForOTPAnswer } from './waitForOTPAnswer';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
 /**
  * Reconnects to MetaMask using an OTP modal and waits for an OTP answer.
@@ -15,7 +19,41 @@ import { waitForOTPAnswer } from './waitForOTPAnswer';
 export async function reconnectWithModalOTP(
   state: RemoteConnectionState,
   options: RemoteConnectionProps,
+  channelConfig: ChannelConfig,
 ): Promise<void> {
+  const provider = Ethereum.getProvider();
+
+  const currentTime = Date.now();
+  const channelWasActiveRecently =
+    channelConfig.lastActive !== undefined &&
+    currentTime - channelConfig.lastActive < ONE_HOUR_IN_MS;
+
+  if (channelWasActiveRecently) {
+    provider._setConnected();
+
+    state.pendingModal = options.modals.otp?.({
+      debug: state.developerMode,
+    });
+
+    state.installModal?.unmount?.(false);
+    state.pendingModal?.unmount?.();
+
+    state.pendingModal?.mount?.({
+      displayOTP: false,
+    });
+
+    state.authorized = true;
+
+    if (state.developerMode) {
+      console.debug(
+        `RCPMS::on 'authorized' provider.state`,
+        provider.getState(),
+      );
+    }
+
+    return;
+  }
+
   if (state.pendingModal) {
     state.pendingModal?.mount?.();
   } else {

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.test.ts
@@ -127,7 +127,7 @@ describe('showInstallModal', () => {
   it('should not throw error if mount is not defined', () => {
     const link = 'http://example.com/newqrcode';
     state.installModal = undefined;
-    mockModalsInstall.mockReturnValueOnce({} as any);
+    mockModalsInstall.mockReturnValueOnce({});
 
     expect(() => {
       showInstallModal(state, options, link);

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.test.ts
@@ -8,14 +8,16 @@ describe('showInstallModal', () => {
   let state: RemoteConnectionState;
   let options: RemoteConnectionProps;
   const mockInstallModalMount = jest.fn();
-  const mockModalsInstall = jest.fn(() => {
-    return {
-      mount: mockInstallModalMount,
-    };
-  });
+  const mockModalsInstall = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockModalsInstall.mockImplementation(() => {
+      return {
+        mount: mockInstallModalMount,
+      };
+    });
 
     state = {
       developerMode: false,
@@ -63,13 +65,10 @@ describe('showInstallModal', () => {
         // do nothing
       });
 
-    // when developerMode is true
     state.developerMode = true;
 
     showInstallModal(state, options, link);
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     const terminateCall = mockModalsInstall.mock.calls[0][0]
       .terminate as () => void;
 
@@ -101,10 +100,9 @@ describe('showInstallModal', () => {
 
     showInstallModal(state, options, link);
 
-    const connectWithExtensionCall =
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      mockModalsInstall.mock.calls[0][0].connectWithExtension as () => boolean;
+    const connectWithExtensionCall = mockModalsInstall.mock.calls[0][0]
+      .connectWithExtension as () => boolean;
+
     const result = connectWithExtensionCall();
 
     expect(options.connectWithExtensionProvider).toHaveBeenCalledTimes(1);
@@ -118,10 +116,9 @@ describe('showInstallModal', () => {
 
     showInstallModal(state, options, link);
 
-    const connectWithExtensionCall =
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      mockModalsInstall.mock.calls[0][0].connectWithExtension as () => boolean;
+    const connectWithExtensionCall = mockModalsInstall.mock.calls[0][0]
+      .connectWithExtension as () => boolean;
+
     const result = connectWithExtensionCall();
 
     expect(result).toBe(false);

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -78,7 +78,7 @@ export interface RemoteConnectionState {
   communicationLayerPreference?: CommunicationLayerPreference;
   platformManager?: PlatformManager;
   pendingModal?: {
-    mount?: () => void;
+    mount?: ({ displayOTP }?: { displayOTP?: boolean }) => void;
     updateOTPValue?: (otpValue: string) => void;
     unmount?: () => void;
   };

--- a/packages/sdk/src/ui/InstallModal/pendingModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/pendingModal-web.ts
@@ -32,7 +32,15 @@ const sdkWebPendingModal = ({
     }
   };
 
-  const mount = () => {
+  const mount = (
+    {
+      displayOTP,
+    }: {
+      displayOTP: boolean;
+    } = {
+      displayOTP: true,
+    },
+  ) => {
     if (debug) {
       console.log(`pendingModal-web mount`, div);
     }
@@ -51,6 +59,7 @@ const sdkWebPendingModal = ({
       onClose: unmount,
       onDisconnect,
       updateOTPValue,
+      displayOTP,
     });
   };
 


### PR DESCRIPTION
Extended the session persistence time to one hour without showing OTP.

For the first hour after connecting, the session will remain active without requesting an OTP.

The following tests are conducted to ensure that everything is working properly:

Apps tested include:

- [x] vuejs
- [x] create-react-app
- [x] devnext
- [x] pure-javascript

All of the apps tested on IOS and Android with a new wallet build that includes the new OTP changes.

The cases that have been checked were when the channel was active recently and when the channel was NOT active recently in order to test both flows.

Everything appears to be working as expected.