### PR TITLE
fix: sdk connection request event

### DIFF
--- a/packages/sdk-communication-layer/src/RemoteCommunication.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.ts
@@ -142,6 +142,7 @@ export class RemoteCommunication extends EventEmitter2 {
     this.state.transports = transports;
     this.state.platformType = platformType;
     this.state.analytics = analytics;
+    this.state.isOriginator = !otherPublicKey;
     this.state.communicationServerUrl = communicationServerUrl;
     this.state.context = context;
     this.state.sdkVersion = sdkVersion;


### PR DESCRIPTION
Fix issue that dApp would send `sdk_connect_request_started_mobile` instead of `sdk_connect_request`.