### PR TITLE
feat: allow all react-native peer deps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -68,6 +68,3 @@ body:
   - type: markdown
     attributes:
       value: Before posting the issue go through the steps you've written down to make sure the steps provided are detailed and clear.
-  - type: markdown
-    attributes:
-      value: ' '

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -106,7 +106,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-native": "^0.71.1"
+    "react-native": "*"
   },
   "publishConfig": {
     "access": "public",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4872,7 +4872,7 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     react: ^18.2.0
-    react-native: ^0.71.1
+    react-native: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Allow more recent version of react-native without issuing dependency warning.