### PR TITLE
feat: alias terminate to disconnect on sdk

### DIFF
--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -62,16 +62,6 @@ describe('MetaMaskSDK', () => {
       await sdk.terminate();
       expect(terminateSpy).toHaveBeenCalled();
     });
-
-    it('should disconnect correctly', () => {
-      sdk.remoteConnection = {
-        disconnect: jest.fn(),
-      } as unknown as RemoteConnection;
-
-      sdk.disconnect();
-
-      expect(sdk.remoteConnection.disconnect).toHaveBeenCalled();
-    });
   });
 
   describe('Provider Handling', () => {

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -258,8 +258,12 @@ export class MetaMaskSDK extends EventEmitter2 {
     return resume(this);
   }
 
+  /**
+   * DEPRECATED: use terminate() instead.
+   */
   disconnect() {
-    this.remoteConnection?.disconnect();
+    console.warn(`MetaMaskSDK.disconnect() is deprecated, use terminate()`);
+    this.terminate();
   }
 
   isAuthorized() {


### PR DESCRIPTION
Prevent user from using sdk.disconnect() which is now deprecated in favor of terminate().