### PR TITLE
fix: modal cleanup and otp selection

### DIFF
--- a/packages/sdk-install-modal-web/src/ModalLoader.tsx
+++ b/packages/sdk-install-modal-web/src/ModalLoader.tsx
@@ -88,7 +88,7 @@ export class ModalLoader {
       console.debug(`ModalLoader: updateOTPValue`, otpValue);
     }
     const otpNode =
-      this.pendingContainer?.querySelector<HTMLElement>('#sdk-mm-otp-value') ?? document.querySelector<HTMLElement>('#sdk-mm-otp-value');
+      this.pendingContainer?.querySelector<HTMLElement>('#sdk-mm-otp-value') ?? document.getElementById('sdk-mm-otp-value');
     if (otpNode) {
       otpNode.textContent = otpValue;
       otpNode.style.display = 'block';
@@ -104,7 +104,7 @@ export class ModalLoader {
     // TODO use scoped elem
     const qrCodeNode = this.selectContainer?.querySelector(
       '#sdk-qrcode-container',
-    ) ?? document.querySelector('#sdk-qrcode-container');
+    ) ?? document.getElementById('sdk-qrcode-container');
     if (qrCodeNode) {
       qrCodeNode.innerHTML = '';
       // Prevent nextjs import issue: https://github.com/kozakdenys/qr-code-styling/issues/38

--- a/packages/sdk/src/services/RemoteConnection/EventListeners/setupListeners.ts
+++ b/packages/sdk/src/services/RemoteConnection/EventListeners/setupListeners.ts
@@ -129,8 +129,11 @@ export function setupListeners(
       console.info(`SDK Connection has been terminated`);
     }
     state.pendingModal?.unmount?.();
+    state.installModal?.unmount?.(true);
     state.pendingModal = undefined;
+    state.installModal = undefined;
     state.otpAnswer = undefined;
+    state.connector?.disconnect({ terminate: true });
     state.authorized = false;
 
     const provider = Ethereum.getProvider();


### PR DESCRIPTION
- Fix the modal query selection when the pendingContainer is non existant which allow to always displays OTP value.
- Cleanup modal when user click outside the action button on the wallet ( previously it would keep the connection open ).

Fixes https://github.com/MetaMask/metamask-sdk/issues/327