### PR TITLE
feat: connection recovery edge case

### DIFF
--- a/packages/sdk-communication-layer/src/KeyExchange.ts
+++ b/packages/sdk-communication-layer/src/KeyExchange.ts
@@ -230,6 +230,10 @@ export class KeyExchange extends EventEmitter2 {
     }
   }
 
+  setKeysExchanged(keysExchanged: boolean) {
+    this.keysExchanged = keysExchanged;
+  }
+
   areKeysExchanged() {
     return this.keysExchanged;
   }


### PR DESCRIPTION
Sometime the keyExchange status can be into an incorrect state (usually due to metamask being killed while connection is paused --> there is no way to detect this edge case), the connection gets restored but it can lead to a missing rpc call.
This PR fixes the above described rare edge case.