### PR TITLE
feat: send sdk_extension_utilized analytics event when extension is selected from cached choice.

### DIFF
--- a/packages/sdk-communication-layer/src/types/TrackingEvent.ts
+++ b/packages/sdk-communication-layer/src/types/TrackingEvent.ts
@@ -9,6 +9,6 @@ export enum TrackingEvents {
   TERMINATED = 'sdk_connection_terminated',
   DISCONNECTED = 'sdk_disconnected',
   SDK_USE_EXTENSION = 'sdk_use_extension',
-  SDK_USE_UTILIZED = 'sdk_extension_utilized',
+  SDK_EXTENSION_UTILIZED = 'sdk_extension_utilized',
   SDK_USE_INAPP_BROWSER = 'sdk_use_inapp_browser',
 }

--- a/packages/sdk-communication-layer/src/types/TrackingEvent.ts
+++ b/packages/sdk-communication-layer/src/types/TrackingEvent.ts
@@ -9,5 +9,6 @@ export enum TrackingEvents {
   TERMINATED = 'sdk_connection_terminated',
   DISCONNECTED = 'sdk_disconnected',
   SDK_USE_EXTENSION = 'sdk_use_extension',
+  SDK_USE_UTILIZED = 'sdk_extension_utilized',
   SDK_USE_INAPP_BROWSER = 'sdk_use_inapp_browser',
 }

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts
@@ -1,3 +1,4 @@
+import { TrackingEvents } from '@metamask/sdk-communication-layer';
 import { STORAGE_PROVIDER_TYPE } from '../../../config';
 import { MetaMaskSDK } from '../../../sdk';
 import { connectWithExtensionProvider } from '../ProviderManager';
@@ -27,6 +28,8 @@ export async function handleAutoAndExtensionConnections(
         `SDK::performSDKInitialization) preferExtension is detected -- connect with it.`,
       );
     }
+
+    instance.analytics?.send({ event: TrackingEvents.SDK_USE_UTILIZED });
 
     connectWithExtensionProvider(instance).catch((_err) => {
       console.warn(`Can't connect with MetaMask extension...`);

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts
@@ -29,7 +29,7 @@ export async function handleAutoAndExtensionConnections(
       );
     }
 
-    instance.analytics?.send({ event: TrackingEvents.SDK_USE_UTILIZED });
+    instance.analytics?.send({ event: TrackingEvents.SDK_EXTENSION_UTILIZED });
 
     connectWithExtensionProvider(instance).catch((_err) => {
       console.warn(`Can't connect with MetaMask extension...`);


### PR DESCRIPTION
Send `sdk_extension_utilized` analytics event whenever extension is selected from a cached choice.