### PR TITLE
fix: flightwind css leaking with preflight

### DIFF
--- a/packages/sdk-react-ui/tailwind.config.js
+++ b/packages/sdk-react-ui/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  corePlugins: {
+    preflight: false,
+  },
   theme: {
     extend: {
       colors: {

--- a/packages/sdk-react-ui/tailwind.config.js
+++ b/packages/sdk-react-ui/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   corePlugins: {
-    preflight: false,
+    preflight: false, // disable to prevent conflict with dapps css
   },
   theme: {
     extend: {


### PR DESCRIPTION
Prevent tailwind css preflight to reset overall styles that can be conflicting with dapps styles.