### PR TITLE
fix: account balance not updating when chain changes

### DIFF
--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -138,7 +138,7 @@ const MetaMaskProviderClient = ({
     } else {
       setBalance(undefined);
     }
-  }, [account]);
+  }, [account, chainId]);
 
   useEffect(() => {
     // Prevent sdk double rendering with StrictMode


### PR DESCRIPTION
Make sure the balance hook is updated when chainId changes.