### PR TITLE
feat: add 'tw-' prefix to tailwind classes in the sdk-react-ui package

### DIFF
--- a/packages/devnext/tailwind.config.js
+++ b/packages/devnext/tailwind.config.js
@@ -1,16 +1,16 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  prefix: 'tw-',
   content: [
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
     // Or if using `src` directory:
-    "./src/**/*.{js,ts,jsx,tsx,mdx}",
-    "../sdk-react-ui/src/**/*.{ts,tsx}",
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
+    '../sdk-react-ui/src/**/*.{ts,tsx}',
   ],
   theme: {
     extend: {},
   },
   plugins: [],
-}
-
+};

--- a/packages/sdk-react-ui/src/MetaMaskButton/Balance.tsx
+++ b/packages/sdk-react-ui/src/MetaMaskButton/Balance.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { useNetwork, useAccount, useBalance } from '../hooks/MetaMaskWagmiHooks';
+import {
+  useNetwork,
+  useAccount,
+  useBalance,
+} from '../hooks/MetaMaskWagmiHooks';
 import { getBalance } from './utils';
 
 const Balance = ({ theme }: { theme: string }) => {
@@ -17,13 +21,13 @@ const Balance = ({ theme }: { theme: string }) => {
 
   return (
     <div
-      className="pl-4 grid content-center justify-center text-center"
+      className="tw-pl-4 tw-grid tw-content-center tw-justify-center tw-text-center"
       style={{ fontSize: 13 }}
     >
       <span
         className={`${
-          theme === 'light' ? 'bg-neutral-200' : 'bg-neutral-400'
-        } p-1.5 rounded`}
+          theme === 'light' ? 'tw-bg-neutral-200' : 'tw-bg-neutral-400'
+        } tw-p-1.5 tw-rounded`}
       >
         {balance}
       </span>

--- a/packages/sdk-react-ui/src/MetaMaskButton/MetaMaskButton.tsx
+++ b/packages/sdk-react-ui/src/MetaMaskButton/MetaMaskButton.tsx
@@ -91,34 +91,34 @@ Props) => {
   }, [sdk, connected, isConnected, connect]);
 
   const getColors = () => {
-    if (wrongNetwork) return 'from-red-500 to-red-500';
+    if (wrongNetwork) return 'tw-from-red-500 tw-to-red-500';
 
     if (isConnected && theme === 'light') {
-      return 'from-white to-white';
+      return 'tw-from-white tw-to-white';
     } else if (isConnected) {
-      return 'from-neutral-500 to-neutral-500';
+      return 'tw-from-neutral-500 tw-to-neutral-500';
     }
 
-    if (color === 'blue') return 'from-blue-500 to-blue-500';
-    else if (color === 'white') return 'from-white to-white';
+    if (color === 'blue') return 'tw-from-blue-500 tw-to-blue-500';
+    else if (color === 'white') return 'tw-from-white tw-to-white';
 
-    return 'from-orange-500 to-orange-500';
+    return 'tw-from-orange-500 tw-to-orange-500';
   };
 
   const getTextColor = () => {
-    if (color === 'white') return 'text-black';
+    if (color === 'white') return 'tw-text-black';
 
-    return 'text-white';
+    return 'tw-text-white';
   };
 
   const getShape = () => {
     if (shape === 'rectangle') {
       return '';
     } else if (shape === 'rounded-full') {
-      return 'rounded-full';
+      return 'tw-rounded-full';
     }
 
-    return 'rounded-lg';
+    return 'tw-rounded-lg';
   };
 
   const getIcon = () => {
@@ -138,9 +138,9 @@ Props) => {
 
   const getIconMargin = () => {
     if (icon === 'no-icon') return '';
-    else if (iconPosition === 'right') return 'pr-3';
+    else if (iconPosition === 'right') return 'tw-pr-3';
 
-    return 'pl-3';
+    return 'tw-pl-3';
   };
 
   const getText = () => {
@@ -148,12 +148,12 @@ Props) => {
       if (wrongNetworkComponent) return wrongNetworkComponent;
       return (
         <div
-          className={`relative flex content-center ${
-            textAlign !== 'left' ? 'justify-center' : ''
+          className={`tw-relative tw-flex tw-content-center ${
+            textAlign !== 'left' ? 'tw-justify-center' : ''
           } ${getTextColor()}`}
         >
           <IconWrongNetwork style={iconStyle} />{' '}
-          <span style={textStyle} className={'pl-2'}>
+          <span style={textStyle} className={'tw-pl-2'}>
             {wrongNetworkText}
           </span>
         </div>
@@ -164,18 +164,21 @@ Props) => {
       if (connectedComponent) return connectedComponent;
       return (
         <div
-          className={`flex relative content-center ${
-            textAlign !== 'left' ? 'justify-center' : ''
+          className={`tw-flex tw-relative tw-content-center ${
+            textAlign !== 'left' ? 'tw-justify-center' : ''
           } ${getTextColor()}`}
         >
-          <div style={{ width: 30, height: 30 }} className="mt-1 relative">
+          <div
+            style={{ width: 30, height: 30 }}
+            className="tw-mt-1 tw-relative"
+          >
             <div
               style={{
                 fontSize: 8,
                 marginTop: -3,
                 marginRight: -3,
               }}
-              className="flex content-center justify-center absolute right-0"
+              className="tw-flex tw-content-center tw-justify-center tw-absolute tw-right-0"
             >
               <IconNetwork network={chain} />
             </div>
@@ -186,25 +189,25 @@ Props) => {
           </div>
           <div
             style={{ fontSize: 13, lineHeight: '18px' }}
-            className="pl-4 text-left flex flex-col"
+            className="tw-pl-4 tw-text-left tw-flex tw-flex-col"
           >
             {chain && (
               <span
                 style={{ ...textStyle, height: 19.5 }}
-                className={'text-left'}
+                className={'tw-text-left'}
               >
                 <b>{chain?.name || chain?.network}</b>
               </span>
             )}
             <span
               style={{ ...textStyle, fontSize: 11, height: 16.5 }}
-              className={'text-left'}
+              className={'tw-text-left'}
             >
               {truncatedAddress(address)}
             </span>
           </div>
           {isConnected && <Balance theme={theme} />}
-          <div className="pl-2 grid content-center justify-center text-center">
+          <div className="tw-pl-2 tw-grid tw-content-center tw-justify-center tw-text-center">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="14"
@@ -225,8 +228,8 @@ Props) => {
     if (connectComponent) return connectedComponent;
     return (
       <div
-        className={`relative flex ${
-          textAlign !== 'left' ? 'justify-center' : ''
+        className={`tw-relative tw-flex ${
+          textAlign !== 'left' ? 'tw-justify-center' : ''
         } ${getTextColor()}`}
       >
         {iconPosition !== 'right' && getIcon()}{' '}
@@ -254,9 +257,9 @@ Props) => {
     <>
       <button
         style={buttonStyle}
-        className={`${connectedAndRightNetwork ? 'px-3' : 'px-6'} ${
-          connectedAndRightNetwork ? 'py-1' : 'py-2.5'
-        } relative ${getShape()} group font-medium text-white font-medium inline-block text-base`}
+        className={`${connectedAndRightNetwork ? 'tw-px-3' : 'tw-px-6'} ${
+          connectedAndRightNetwork ? 'tw-py-1' : 'tw-py-2.5'
+        } tw-relative ${getShape()} tw-group tw-font-medium tw-text-white tw-font-medium tw-inline-block tw-text-base`}
         onClick={
           isConnected
             ? openModal
@@ -268,13 +271,13 @@ Props) => {
         {!removeDefaultStyles && (
           <>
             <span
-              className={`absolute top-0 left-0 w-full h-full ${getShape()} opacity-50 filter blur-sm bg-gradient-to-br ${getColors()}`}
+              className={`tw-absolute tw-top-0 tw-left-0 tw-w-full tw-h-full ${getShape()} tw-opacity-50 tw-filter tw-blur-sm tw-bg-gradient-to-br ${getColors()}`}
             ></span>
             <span
-              className={`absolute inset-0 w-full h-full transition-all duration-200 ease-out ${getShape()} shadow-xl bg-gradient-to-br filter group-active:opacity-0 group-hover:blur-sm ${getColors()}`}
+              className={`tw-absolute tw-inset-0 tw-w-full tw-h-full tw-transition-all tw-duration-200 tw-ease-out ${getShape()} tw-shadow-xl tw-bg-gradient-to-br tw-filter group-active:tw-opacity-0 group-hover:tw-blur-sm ${getColors()}`}
             ></span>
             <span
-              className={`absolute inset-0 w-full h-full transition duration-200 ease-out ${getShape()} bg-gradient-to-br ${getColors()}`}
+              className={`tw-absolute tw-inset-0 tw-w-full tw-h-full tw-transition tw-duration-200 tw-ease-out ${getShape()} tw-bg-gradient-to-br ${getColors()}`}
             ></span>
           </>
         )}

--- a/packages/sdk-react-ui/src/MetaMaskButton/MetaMaskModal.tsx
+++ b/packages/sdk-react-ui/src/MetaMaskButton/MetaMaskModal.tsx
@@ -52,25 +52,25 @@ export default function Modal({
   const renderNetwork = (chainToRender: Chain) => {
     return (
       <button
-        className="grid w-full"
+        className="tw-grid tw-w-full"
         key={chainToRender.id}
         onClick={() => changeNetwork(chainToRender)}
       >
         <div
-          className={`text-sm p-2 ${
-            chainToRender.id === chain?.id && 'bg-blue-50'
-          } flex rounded`}
+          className={`tw-text-sm tw-p-2 ${
+            chainToRender.id === chain?.id && 'tw-bg-blue-50'
+          } tw-flex tw-rounded`}
         >
           <div
             style={{ width: 4, height: 48 }}
             className={`${
-              chainToRender.id === chain?.id && 'bg-blue-500'
-            } rounded mr-2`}
+              chainToRender.id === chain?.id && 'tw-bg-blue-500'
+            } tw-rounded tw-mr-2`}
           ></div>
-          <div className="grid content-center justify-center text-lg font-semibold">
-            <div className="flex">
+          <div className="tw-grid tw-content-center tw-justify-center tw-text-lg tw-font-semibold">
+            <div className="tw-flex">
               <IconNetwork network={chainToRender} size="big"></IconNetwork>
-              <span className="pl-4">{chainToRender?.name}</span>
+              <span className="tw-pl-4">{chainToRender?.name}</span>
             </div>
           </div>
         </div>
@@ -108,33 +108,33 @@ export default function Modal({
   return (
     <>
       <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-10" onClose={closeModal}>
+        <Dialog as="div" className="tw-relative tw-z-10" onClose={closeModal}>
           <Transition.Child
             as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
+            enter="tw-ease-out tw-duration-300"
+            enterFrom="tw-opacity-0"
+            enterTo="tw-opacity-100"
+            leave="tw-ease-in tw-duration-200"
+            leaveFrom="tw-opacity-100"
+            leaveTo="tw-opacity-0"
           >
-            <div className="fixed inset-0 bg-black bg-opacity-40" />
+            <div className="tw-fixed tw-inset-0 tw-bg-black tw-bg-opacity-40" />
           </Transition.Child>
 
-          <div className="fixed inset-0 overflow-y-auto">
-            <div className="flex min-h-full items-center justify-center p-4 text-center">
+          <div className="tw-fixed tw-inset-0 tw-overflow-y-auto">
+            <div className="tw-flex tw-min-h-full tw-items-center tw-justify-center tw-p-4 tw-text-center">
               <Transition.Child
                 as={Fragment}
-                enter="ease-out duration-300"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
+                enter="tw-ease-out tw-duration-300"
+                enterFrom="tw-opacity-0 tw-scale-95"
+                enterTo="tw-opacity-100 tw-scale-100"
+                leave="tw-ease-in tw-duration-200"
+                leaveFrom="tw-opacity-100 tw-scale-100"
+                leaveTo="tw-opacity-0 tw-scale-95"
               >
-                <Dialog.Panel className="bg-white border w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Panel className="tw-bg-white tw-border tw-w-full tw-max-w-md tw-transform tw-overflow-hidden tw-rounded-2xl tw-bg-white tw-p-6 tw-text-left tw-align-middle tw-shadow-xl tw-transition-all">
                   <div>
-                    <div className="flex justify-end">
+                    <div className="tw-flex tw-justify-end">
                       <button onClick={closeModal}>
                         <svg
                           width="16"
@@ -153,8 +153,8 @@ export default function Modal({
                         </svg>
                       </button>
                     </div>
-                    <div className="flex justify-center content-center flex-col text-center mt-2">
-                      <div className="flex justify-center">
+                    <div className="tw-flex tw-justify-center tw-content-center tw-flex-col tw-text-center tw-mt-2">
+                      <div className="tw-flex tw-justify-center">
                         <div style={{ width: 48, height: 48 }}>
                           <Jazzicon
                             diameter={48}
@@ -162,22 +162,23 @@ export default function Modal({
                           />
                         </div>
                       </div>
-                      <div className="text-2xl font-bold mt-2 flex text-center content-center justify-center">
+
+                      <div className="tw-text-2xl tw-font-bold tw-mt-2 tw-flex tw-text-center tw-content-center tw-justify-center">
                         {copied ? (
-                          <div className="text-lg text-blue-500 grid content-center justify-center">
+                          <div className="tw-text-lg tw-text-blue-500 tw-grid tw-content-center tw-justify-center">
                             {t('META_MASK_MODAL.ADDRESS_COPIED')}
                           </div>
                         ) : (
                           address && (
-                            <div className="flex text-center content-center justify-center">
-                              <span className="mr-2">
+                            <div className="tw-flex tw-text-center tw-content-center tw-justify-center">
+                              <span className="tw-mr-2">
                                 {truncatedAddress(address)}
                               </span>
                               <CopyToClipboard
                                 text={address}
                                 onCopy={copyAddressToClipboard}
                               >
-                                <button className="grid content-center justify-center">
+                                <button className="tw-grid tw-content-center tw-justify-center">
                                   <svg
                                     width="10"
                                     height="11"
@@ -196,9 +197,9 @@ export default function Modal({
                           )
                         )}
                       </div>
-                      <div className="text-base mt-2">{balance}</div>
+                      <div className="tw-text-base tw-mt-2">{balance}</div>
                       <button
-                        className="text-blue-500 mt-2 text-xs flex content-center justify-center items-center"
+                        className="tw-text-blue-500 tw-mt-2 tw-text-xs tw-flex tw-content-center tw-justify-center tw-items-center"
                         onClick={disconnectAndClose}
                       >
                         <svg
@@ -213,16 +214,16 @@ export default function Modal({
                             fill="#037DD6"
                           />
                         </svg>
-                        <span className="ml-1">
+                        <span className="tw-ml-1">
                           {t('META_MASK_MODAL.DISCONNECT')}
                         </span>
                       </button>
                     </div>
                   </div>
-                  <div className="text-sm font-bold	mt-6">
+                  <div className="tw-text-sm tw-font-bold	tw-mt-6">
                     {t('META_MASK_MODAL.ACTIVE_NETWORK')}
                   </div>
-                  <div className="mt-4">{getNetworks()}</div>
+                  <div className="tw-mt-4">{getNetworks()}</div>
                 </Dialog.Panel>
               </Transition.Child>
             </div>

--- a/packages/sdk-react-ui/tailwind.config.js
+++ b/packages/sdk-react-ui/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  prefix: 'tw-',
   corePlugins: {
     preflight: false, // disable to prevent conflict with dapps css
   },


### PR DESCRIPTION
Added a 'tw-' prefix to all Tailwind CSS classes in the `sdk-react-ui` package. This change scopes Tailwind styles, and minimizes conflicts with other CSS or custom styles in applications utilizing our UI components. Ensures more reliable styling across diverse projects.