### PR TITLE
feat: detect qrcode origin on wallet

### DIFF
--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
@@ -231,8 +231,8 @@ describe('write function', () => {
       );
 
       expect(mockOpenDeeplink).toHaveBeenCalledWith(
-        'https://metamask.app.link/connect?channelId=some_channel_id&pubkey=&comm=socket',
-        'metamask://connect?channelId=some_channel_id&pubkey=&comm=socket',
+        'https://metamask.app.link/connect?channelId=some_channel_id&pubkey=&comm=socket&t=q',
+        'metamask://connect?channelId=some_channel_id&pubkey=&comm=socket&t=q',
         '_self',
       );
     });
@@ -249,8 +249,8 @@ describe('write function', () => {
       );
 
       expect(mockOpenDeeplink).toHaveBeenCalledWith(
-        'https://metamask.app.link/connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket',
-        'metamask://connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket',
+        'https://metamask.app.link/connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket&t=q',
+        'metamask://connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket&t=q',
         '_self',
       );
     });

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -91,7 +91,7 @@ export async function write(
     const pubKey = instance.state.remote?.getKeyInfo()?.ecies.public ?? '';
 
     const urlParams = encodeURI(
-      `channelId=${channelId}&pubkey=${pubKey}&comm=socket`,
+      `channelId=${channelId}&pubkey=${pubKey}&comm=socket&t=q`,
     );
 
     if (METHODS_TO_REDIRECT[targetMethod]) {


### PR DESCRIPTION
Allow to detect the origin as qrcode on the wallet to prevent scanning using a photo app and metamask thinking it is a deeplink