### PR TITLE
build: improve sdk bundle to work with nodejs strictmode

### DIFF
--- a/packages/devnext/next.config.js
+++ b/packages/devnext/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
+  reactStrictMode: true,
   transpilePackages: [
     '@metamask/sdk-communication-layer',
     '@metamask/sdk',

--- a/packages/sdk-communication-layer/rollup.config.js
+++ b/packages/sdk-communication-layer/rollup.config.js
@@ -8,7 +8,7 @@ import nativePlugin from 'rollup-plugin-natives';
 import jscc from 'rollup-plugin-jscc';
 import terser from '@rollup/plugin-terser';
 import { visualizer } from 'rollup-plugin-visualizer';
-import pkgJson from './package.json'; // Ensure this path is correct
+import packageJson from './package.json'; // Ensure this path is correct
 
 // Check if environment variable is set to 'dev'
 const isDev = process.env.NODE_ENV === 'dev';
@@ -43,7 +43,7 @@ const config = [
     input: 'src/index.ts',
     output: [
       {
-        file: pkgJson.browser,
+        file: packageJson.browser,
         format: 'es',
         sourcemap: true,
       },
@@ -72,7 +72,7 @@ const config = [
       terser(),
       // Visualize the bundle to analyze its composition and size
       isDev && visualizer({
-        filename: `bundle_stats/browser-es-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/browser-es-stats-${packageJson.version}.html`,
       }),
     ],
   },
@@ -84,7 +84,7 @@ const config = [
     output: [
       {
         name: 'browser',
-        file: pkgJson.unpkg,
+        file: packageJson.unpkg,
         format: 'umd',
         sourcemap: true,
       },
@@ -111,7 +111,7 @@ const config = [
       json(),
       terser(),
       isDev && visualizer({
-        filename: `bundle_stats/browser-umd-iife-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/browser-umd-iife-stats-${packageJson.version}.html`,
       }),
     ],
   },
@@ -120,7 +120,7 @@ const config = [
     input: 'src/index.ts',
     output: [
       {
-        file: pkgJson['react-native'],
+        file: packageJson['react-native'],
         format: 'es',
         sourcemap: true,
       },
@@ -140,7 +140,7 @@ const config = [
       json(),
       terser(),
       isDev && visualizer({
-        filename: `bundle_stats/react-native-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/react-native-stats-${packageJson.version}.html`,
       }),
     ],
   },
@@ -149,12 +149,12 @@ const config = [
     input: 'src/index.ts',
     output: [
       {
-        file: pkgJson.main,
+        file: packageJson.main,
         format: 'cjs',
         sourcemap: true,
       },
       {
-        file: pkgJson.module,
+        file: packageJson.module,
         format: 'es',
         sourcemap: true,
       },
@@ -180,7 +180,7 @@ const config = [
       json(),
       terser(),
       isDev && visualizer({
-        filename: `bundle_stats/node-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/node-stats-${packageJson.version}.html`,
       }),
     ],
   },

--- a/packages/sdk/bundle_stats/browser-es-stats-0.11.0.html
+++ b/packages/sdk/bundle_stats/browser-es-stats-0.11.0.html
@@ -1,0 +1,4838 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <title>Rollup Visualizer</title>
+  <style>
+:root {
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --background-color: #2b2d42;
+  --text-color: #edf2f4;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+html {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: var(--font-family);
+}
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+svg {
+  vertical-align: middle;
+  width: 100%;
+  height: 100%;
+  max-height: 100vh;
+}
+
+main {
+  flex-grow: 1;
+  height: 100vh;
+  padding: 20px;
+}
+
+.tooltip {
+  position: absolute;
+  z-index: 1070;
+  border: 2px solid;
+  border-radius: 5px;
+  padding: 5px;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.tooltip-hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  font-size: 0.7rem;
+  align-items: center;
+  margin: 0 50px;
+  height: 20px;
+}
+
+.size-selectors {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.size-selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+}
+.size-selector input {
+  margin: 0 0.3rem 0 0;
+}
+
+.filters {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.module-filters {
+  display: flex;
+  flex-grow: 1;
+}
+
+.module-filter {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+.module-filter input {
+  flex: 1;
+  height: 1rem;
+  padding: 0.01rem;
+  font-size: 0.7rem;
+  margin-left: 0.3rem;
+}
+.module-filter + .module-filter {
+  margin-left: 0.5rem;
+}
+  </style>
+</head>
+<body>
+  <main></main>
+  <script>
+  /*<!--*/
+var drawChart = (function (exports) {
+  'use strict';
+
+  var n,l$1,u$1,t$1,o$2,r$1,f$1,e$1,c$1={},s$1=[],a$1=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,v$1=Array.isArray;function h$1(n,l){for(var u in l)n[u]=l[u];return n}function p$1(n){var l=n.parentNode;l&&l.removeChild(n);}function y$1(l,u,i){var t,o,r,f={};for(r in u)"key"==r?t=u[r]:"ref"==r?o=u[r]:f[r]=u[r];if(arguments.length>2&&(f.children=arguments.length>3?n.call(arguments,2):i),"function"==typeof l&&null!=l.defaultProps)for(r in l.defaultProps)void 0===f[r]&&(f[r]=l.defaultProps[r]);return d$1(l,f,t,o,null)}function d$1(n,i,t,o,r){var f={type:n,props:i,key:t,ref:o,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:null==r?++u$1:r};return null==r&&null!=l$1.vnode&&l$1.vnode(f),f}function k$1(n){return n.children}function b$1(n,l){this.props=n,this.context=l;}function g$1(n,l){if(null==l)return n.__?g$1(n.__,n.__.__k.indexOf(n)+1):null;for(var u;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e)return u.__e;return "function"==typeof n.type?g$1(n):null}function m$1(n){var l,u;if(null!=(n=n.__)&&null!=n.__c){for(n.__e=n.__c.base=null,l=0;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e){n.__e=n.__c.base=u.__e;break}return m$1(n)}}function w$1(n){(!n.__d&&(n.__d=!0)&&t$1.push(n)&&!x.__r++||o$2!==l$1.debounceRendering)&&((o$2=l$1.debounceRendering)||r$1)(x);}function x(){var n,l,u,i,o,r,e,c;for(t$1.sort(f$1);n=t$1.shift();)n.__d&&(l=t$1.length,i=void 0,o=void 0,e=(r=(u=n).__v).__e,(c=u.__P)&&(i=[],(o=h$1({},r)).__v=r.__v+1,L(c,r,o,u.__n,void 0!==c.ownerSVGElement,null!=r.__h?[e]:null,i,null==e?g$1(r):e,r.__h),M(i,r),r.__e!=e&&m$1(r)),t$1.length>l&&t$1.sort(f$1));x.__r=0;}function P(n,l,u,i,t,o,r,f,e,a){var h,p,y,_,b,m,w,x=i&&i.__k||s$1,P=x.length;for(u.__k=[],h=0;h<l.length;h++)if(null!=(_=u.__k[h]=null==(_=l[h])||"boolean"==typeof _||"function"==typeof _?null:"string"==typeof _||"number"==typeof _||"bigint"==typeof _?d$1(null,_,null,null,_):v$1(_)?d$1(k$1,{children:_},null,null,null):_.__b>0?d$1(_.type,_.props,_.key,_.ref?_.ref:null,_.__v):_)){if(_.__=u,_.__b=u.__b+1,null===(y=x[h])||y&&_.key==y.key&&_.type===y.type)x[h]=void 0;else for(p=0;p<P;p++){if((y=x[p])&&_.key==y.key&&_.type===y.type){x[p]=void 0;break}y=null;}L(n,_,y=y||c$1,t,o,r,f,e,a),b=_.__e,(p=_.ref)&&y.ref!=p&&(w||(w=[]),y.ref&&w.push(y.ref,null,_),w.push(p,_.__c||b,_)),null!=b?(null==m&&(m=b),"function"==typeof _.type&&_.__k===y.__k?_.__d=e=C(_,e,n):e=$(n,_,y,x,b,e),"function"==typeof u.type&&(u.__d=e)):e&&y.__e==e&&e.parentNode!=n&&(e=g$1(y));}for(u.__e=m,h=P;h--;)null!=x[h]&&("function"==typeof u.type&&null!=x[h].__e&&x[h].__e==u.__d&&(u.__d=A(i).nextSibling),q$1(x[h],x[h]));if(w)for(h=0;h<w.length;h++)O(w[h],w[++h],w[++h]);}function C(n,l,u){for(var i,t=n.__k,o=0;t&&o<t.length;o++)(i=t[o])&&(i.__=n,l="function"==typeof i.type?C(i,l,u):$(u,i,i,t,i.__e,l));return l}function $(n,l,u,i,t,o){var r,f,e;if(void 0!==l.__d)r=l.__d,l.__d=void 0;else if(null==u||t!=o||null==t.parentNode)n:if(null==o||o.parentNode!==n)n.appendChild(t),r=null;else {for(f=o,e=0;(f=f.nextSibling)&&e<i.length;e+=1)if(f==t)break n;n.insertBefore(t,o),r=o;}return void 0!==r?r:t.nextSibling}function A(n){var l,u,i;if(null==n.type||"string"==typeof n.type)return n.__e;if(n.__k)for(l=n.__k.length-1;l>=0;l--)if((u=n.__k[l])&&(i=A(u)))return i;return null}function H(n,l,u,i,t){var o;for(o in u)"children"===o||"key"===o||o in l||T$1(n,o,null,u[o],i);for(o in l)t&&"function"!=typeof l[o]||"children"===o||"key"===o||"value"===o||"checked"===o||u[o]===l[o]||T$1(n,o,l[o],u[o],i);}function I(n,l,u){"-"===l[0]?n.setProperty(l,null==u?"":u):n[l]=null==u?"":"number"!=typeof u||a$1.test(l)?u:u+"px";}function T$1(n,l,u,i,t){var o;n:if("style"===l)if("string"==typeof u)n.style.cssText=u;else {if("string"==typeof i&&(n.style.cssText=i=""),i)for(l in i)u&&l in u||I(n.style,l,"");if(u)for(l in u)i&&u[l]===i[l]||I(n.style,l,u[l]);}else if("o"===l[0]&&"n"===l[1])o=l!==(l=l.replace(/Capture$/,"")),l=l.toLowerCase()in n?l.toLowerCase().slice(2):l.slice(2),n.l||(n.l={}),n.l[l+o]=u,u?i||n.addEventListener(l,o?z$1:j$1,o):n.removeEventListener(l,o?z$1:j$1,o);else if("dangerouslySetInnerHTML"!==l){if(t)l=l.replace(/xlink(H|:h)/,"h").replace(/sName$/,"s");else if("width"!==l&&"height"!==l&&"href"!==l&&"list"!==l&&"form"!==l&&"tabIndex"!==l&&"download"!==l&&"rowSpan"!==l&&"colSpan"!==l&&l in n)try{n[l]=null==u?"":u;break n}catch(n){}"function"==typeof u||(null==u||!1===u&&"-"!==l[4]?n.removeAttribute(l):n.setAttribute(l,u));}}function j$1(n){return this.l[n.type+!1](l$1.event?l$1.event(n):n)}function z$1(n){return this.l[n.type+!0](l$1.event?l$1.event(n):n)}function L(n,u,i,t,o,r,f,e,c){var s,a,p,y,d,_,g,m,w,x,C,S,$,A,H,I=u.type;if(void 0!==u.constructor)return null;null!=i.__h&&(c=i.__h,e=u.__e=i.__e,u.__h=null,r=[e]),(s=l$1.__b)&&s(u);try{n:if("function"==typeof I){if(m=u.props,w=(s=I.contextType)&&t[s.__c],x=s?w?w.props.value:s.__:t,i.__c?g=(a=u.__c=i.__c).__=a.__E:("prototype"in I&&I.prototype.render?u.__c=a=new I(m,x):(u.__c=a=new b$1(m,x),a.constructor=I,a.render=B$1),w&&w.sub(a),a.props=m,a.state||(a.state={}),a.context=x,a.__n=t,p=a.__d=!0,a.__h=[],a._sb=[]),null==a.__s&&(a.__s=a.state),null!=I.getDerivedStateFromProps&&(a.__s==a.state&&(a.__s=h$1({},a.__s)),h$1(a.__s,I.getDerivedStateFromProps(m,a.__s))),y=a.props,d=a.state,a.__v=u,p)null==I.getDerivedStateFromProps&&null!=a.componentWillMount&&a.componentWillMount(),null!=a.componentDidMount&&a.__h.push(a.componentDidMount);else {if(null==I.getDerivedStateFromProps&&m!==y&&null!=a.componentWillReceiveProps&&a.componentWillReceiveProps(m,x),!a.__e&&null!=a.shouldComponentUpdate&&!1===a.shouldComponentUpdate(m,a.__s,x)||u.__v===i.__v){for(u.__v!==i.__v&&(a.props=m,a.state=a.__s,a.__d=!1),a.__e=!1,u.__e=i.__e,u.__k=i.__k,u.__k.forEach(function(n){n&&(n.__=u);}),C=0;C<a._sb.length;C++)a.__h.push(a._sb[C]);a._sb=[],a.__h.length&&f.push(a);break n}null!=a.componentWillUpdate&&a.componentWillUpdate(m,a.__s,x),null!=a.componentDidUpdate&&a.__h.push(function(){a.componentDidUpdate(y,d,_);});}if(a.context=x,a.props=m,a.__P=n,S=l$1.__r,$=0,"prototype"in I&&I.prototype.render){for(a.state=a.__s,a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),A=0;A<a._sb.length;A++)a.__h.push(a._sb[A]);a._sb=[];}else do{a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),a.state=a.__s;}while(a.__d&&++$<25);a.state=a.__s,null!=a.getChildContext&&(t=h$1(h$1({},t),a.getChildContext())),p||null==a.getSnapshotBeforeUpdate||(_=a.getSnapshotBeforeUpdate(y,d)),P(n,v$1(H=null!=s&&s.type===k$1&&null==s.key?s.props.children:s)?H:[H],u,i,t,o,r,f,e,c),a.base=u.__e,u.__h=null,a.__h.length&&f.push(a),g&&(a.__E=a.__=null),a.__e=!1;}else null==r&&u.__v===i.__v?(u.__k=i.__k,u.__e=i.__e):u.__e=N(i.__e,u,i,t,o,r,f,c);(s=l$1.diffed)&&s(u);}catch(n){u.__v=null,(c||null!=r)&&(u.__e=e,u.__h=!!c,r[r.indexOf(e)]=null),l$1.__e(n,u,i);}}function M(n,u){l$1.__c&&l$1.__c(u,n),n.some(function(u){try{n=u.__h,u.__h=[],n.some(function(n){n.call(u);});}catch(n){l$1.__e(n,u.__v);}});}function N(l,u,i,t,o,r,f,e){var s,a,h,y=i.props,d=u.props,_=u.type,k=0;if("svg"===_&&(o=!0),null!=r)for(;k<r.length;k++)if((s=r[k])&&"setAttribute"in s==!!_&&(_?s.localName===_:3===s.nodeType)){l=s,r[k]=null;break}if(null==l){if(null===_)return document.createTextNode(d);l=o?document.createElementNS("http://www.w3.org/2000/svg",_):document.createElement(_,d.is&&d),r=null,e=!1;}if(null===_)y===d||e&&l.data===d||(l.data=d);else {if(r=r&&n.call(l.childNodes),a=(y=i.props||c$1).dangerouslySetInnerHTML,h=d.dangerouslySetInnerHTML,!e){if(null!=r)for(y={},k=0;k<l.attributes.length;k++)y[l.attributes[k].name]=l.attributes[k].value;(h||a)&&(h&&(a&&h.__html==a.__html||h.__html===l.innerHTML)||(l.innerHTML=h&&h.__html||""));}if(H(l,d,y,o,e),h)u.__k=[];else if(P(l,v$1(k=u.props.children)?k:[k],u,i,t,o&&"foreignObject"!==_,r,f,r?r[0]:i.__k&&g$1(i,0),e),null!=r)for(k=r.length;k--;)null!=r[k]&&p$1(r[k]);e||("value"in d&&void 0!==(k=d.value)&&(k!==l.value||"progress"===_&&!k||"option"===_&&k!==y.value)&&T$1(l,"value",k,y.value,!1),"checked"in d&&void 0!==(k=d.checked)&&k!==l.checked&&T$1(l,"checked",k,y.checked,!1));}return l}function O(n,u,i){try{"function"==typeof n?n(u):n.current=u;}catch(n){l$1.__e(n,i);}}function q$1(n,u,i){var t,o;if(l$1.unmount&&l$1.unmount(n),(t=n.ref)&&(t.current&&t.current!==n.__e||O(t,null,u)),null!=(t=n.__c)){if(t.componentWillUnmount)try{t.componentWillUnmount();}catch(n){l$1.__e(n,u);}t.base=t.__P=null,n.__c=void 0;}if(t=n.__k)for(o=0;o<t.length;o++)t[o]&&q$1(t[o],u,i||"function"!=typeof n.type);i||null==n.__e||p$1(n.__e),n.__=n.__e=n.__d=void 0;}function B$1(n,l,u){return this.constructor(n,u)}function D(u,i,t){var o,r,f;l$1.__&&l$1.__(u,i),r=(o="function"==typeof t)?null:t&&t.__k||i.__k,f=[],L(i,u=(!o&&t||i).__k=y$1(k$1,null,[u]),r||c$1,c$1,void 0!==i.ownerSVGElement,!o&&t?[t]:r?null:i.firstChild?n.call(i.childNodes):null,f,!o&&t?t:r?r.__e:i.firstChild,o),M(f,u);}function G(n,l){var u={__c:l="__cC"+e$1++,__:n,Consumer:function(n,l){return n.children(l)},Provider:function(n){var u,i;return this.getChildContext||(u=[],(i={})[l]=this,this.getChildContext=function(){return i},this.shouldComponentUpdate=function(n){this.props.value!==n.value&&u.some(function(n){n.__e=!0,w$1(n);});},this.sub=function(n){u.push(n);var l=n.componentWillUnmount;n.componentWillUnmount=function(){u.splice(u.indexOf(n),1),l&&l.call(n);};}),n.children}};return u.Provider.__=u.Consumer.contextType=u}n=s$1.slice,l$1={__e:function(n,l,u,i){for(var t,o,r;l=l.__;)if((t=l.__c)&&!t.__)try{if((o=t.constructor)&&null!=o.getDerivedStateFromError&&(t.setState(o.getDerivedStateFromError(n)),r=t.__d),null!=t.componentDidCatch&&(t.componentDidCatch(n,i||{}),r=t.__d),r)return t.__E=t}catch(l){n=l;}throw n}},u$1=0,b$1.prototype.setState=function(n,l){var u;u=null!=this.__s&&this.__s!==this.state?this.__s:this.__s=h$1({},this.state),"function"==typeof n&&(n=n(h$1({},u),this.props)),n&&h$1(u,n),null!=n&&this.__v&&(l&&this._sb.push(l),w$1(this));},b$1.prototype.forceUpdate=function(n){this.__v&&(this.__e=!0,n&&this.__h.push(n),w$1(this));},b$1.prototype.render=k$1,t$1=[],r$1="function"==typeof Promise?Promise.prototype.then.bind(Promise.resolve()):setTimeout,f$1=function(n,l){return n.__v.__b-l.__v.__b},x.__r=0,e$1=0;
+
+  var _$1=0;function o$1(o,e,n,t,f,l){var s,u,a={};for(u in e)"ref"==u?s=e[u]:a[u]=e[u];var i={type:o,props:a,key:n,ref:s,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:--_$1,__source:f,__self:l};if("function"==typeof o&&(s=o.defaultProps))for(u in s)void 0===a[u]&&(a[u]=s[u]);return l$1.vnode&&l$1.vnode(i),i}
+
+  function count$1(node) {
+    var sum = 0,
+        children = node.children,
+        i = children && children.length;
+    if (!i) sum = 1;
+    else while (--i >= 0) sum += children[i].value;
+    node.value = sum;
+  }
+
+  function node_count() {
+    return this.eachAfter(count$1);
+  }
+
+  function node_each(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_eachBefore(callback, that) {
+    var node = this, nodes = [node], children, i, index = -1;
+    while (node = nodes.pop()) {
+      callback.call(that, node, ++index, this);
+      if (children = node.children) {
+        for (i = children.length - 1; i >= 0; --i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    return this;
+  }
+
+  function node_eachAfter(callback, that) {
+    var node = this, nodes = [node], next = [], children, i, n, index = -1;
+    while (node = nodes.pop()) {
+      next.push(node);
+      if (children = node.children) {
+        for (i = 0, n = children.length; i < n; ++i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    while (node = next.pop()) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_find(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      if (callback.call(that, node, ++index, this)) {
+        return node;
+      }
+    }
+  }
+
+  function node_sum(value) {
+    return this.eachAfter(function(node) {
+      var sum = +value(node.data) || 0,
+          children = node.children,
+          i = children && children.length;
+      while (--i >= 0) sum += children[i].value;
+      node.value = sum;
+    });
+  }
+
+  function node_sort(compare) {
+    return this.eachBefore(function(node) {
+      if (node.children) {
+        node.children.sort(compare);
+      }
+    });
+  }
+
+  function node_path(end) {
+    var start = this,
+        ancestor = leastCommonAncestor(start, end),
+        nodes = [start];
+    while (start !== ancestor) {
+      start = start.parent;
+      nodes.push(start);
+    }
+    var k = nodes.length;
+    while (end !== ancestor) {
+      nodes.splice(k, 0, end);
+      end = end.parent;
+    }
+    return nodes;
+  }
+
+  function leastCommonAncestor(a, b) {
+    if (a === b) return a;
+    var aNodes = a.ancestors(),
+        bNodes = b.ancestors(),
+        c = null;
+    a = aNodes.pop();
+    b = bNodes.pop();
+    while (a === b) {
+      c = a;
+      a = aNodes.pop();
+      b = bNodes.pop();
+    }
+    return c;
+  }
+
+  function node_ancestors() {
+    var node = this, nodes = [node];
+    while (node = node.parent) {
+      nodes.push(node);
+    }
+    return nodes;
+  }
+
+  function node_descendants() {
+    return Array.from(this);
+  }
+
+  function node_leaves() {
+    var leaves = [];
+    this.eachBefore(function(node) {
+      if (!node.children) {
+        leaves.push(node);
+      }
+    });
+    return leaves;
+  }
+
+  function node_links() {
+    var root = this, links = [];
+    root.each(function(node) {
+      if (node !== root) { // Don’t include the root’s parent, if any.
+        links.push({source: node.parent, target: node});
+      }
+    });
+    return links;
+  }
+
+  function* node_iterator() {
+    var node = this, current, next = [node], children, i, n;
+    do {
+      current = next.reverse(), next = [];
+      while (node = current.pop()) {
+        yield node;
+        if (children = node.children) {
+          for (i = 0, n = children.length; i < n; ++i) {
+            next.push(children[i]);
+          }
+        }
+      }
+    } while (next.length);
+  }
+
+  function hierarchy(data, children) {
+    if (data instanceof Map) {
+      data = [undefined, data];
+      if (children === undefined) children = mapChildren;
+    } else if (children === undefined) {
+      children = objectChildren;
+    }
+
+    var root = new Node$1(data),
+        node,
+        nodes = [root],
+        child,
+        childs,
+        i,
+        n;
+
+    while (node = nodes.pop()) {
+      if ((childs = children(node.data)) && (n = (childs = Array.from(childs)).length)) {
+        node.children = childs;
+        for (i = n - 1; i >= 0; --i) {
+          nodes.push(child = childs[i] = new Node$1(childs[i]));
+          child.parent = node;
+          child.depth = node.depth + 1;
+        }
+      }
+    }
+
+    return root.eachBefore(computeHeight);
+  }
+
+  function node_copy() {
+    return hierarchy(this).eachBefore(copyData);
+  }
+
+  function objectChildren(d) {
+    return d.children;
+  }
+
+  function mapChildren(d) {
+    return Array.isArray(d) ? d[1] : null;
+  }
+
+  function copyData(node) {
+    if (node.data.value !== undefined) node.value = node.data.value;
+    node.data = node.data.data;
+  }
+
+  function computeHeight(node) {
+    var height = 0;
+    do node.height = height;
+    while ((node = node.parent) && (node.height < ++height));
+  }
+
+  function Node$1(data) {
+    this.data = data;
+    this.depth =
+    this.height = 0;
+    this.parent = null;
+  }
+
+  Node$1.prototype = hierarchy.prototype = {
+    constructor: Node$1,
+    count: node_count,
+    each: node_each,
+    eachAfter: node_eachAfter,
+    eachBefore: node_eachBefore,
+    find: node_find,
+    sum: node_sum,
+    sort: node_sort,
+    path: node_path,
+    ancestors: node_ancestors,
+    descendants: node_descendants,
+    leaves: node_leaves,
+    links: node_links,
+    copy: node_copy,
+    [Symbol.iterator]: node_iterator
+  };
+
+  function required(f) {
+    if (typeof f !== "function") throw new Error;
+    return f;
+  }
+
+  function constantZero() {
+    return 0;
+  }
+
+  function constant$1(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function roundNode(node) {
+    node.x0 = Math.round(node.x0);
+    node.y0 = Math.round(node.y0);
+    node.x1 = Math.round(node.x1);
+    node.y1 = Math.round(node.y1);
+  }
+
+  function treemapDice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (x1 - x0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.y0 = y0, node.y1 = y1;
+      node.x0 = x0, node.x1 = x0 += node.value * k;
+    }
+  }
+
+  function treemapSlice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (y1 - y0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.x0 = x0, node.x1 = x1;
+      node.y0 = y0, node.y1 = y0 += node.value * k;
+    }
+  }
+
+  var phi = (1 + Math.sqrt(5)) / 2;
+
+  function squarifyRatio(ratio, parent, x0, y0, x1, y1) {
+    var rows = [],
+        nodes = parent.children,
+        row,
+        nodeValue,
+        i0 = 0,
+        i1 = 0,
+        n = nodes.length,
+        dx, dy,
+        value = parent.value,
+        sumValue,
+        minValue,
+        maxValue,
+        newRatio,
+        minRatio,
+        alpha,
+        beta;
+
+    while (i0 < n) {
+      dx = x1 - x0, dy = y1 - y0;
+
+      // Find the next non-empty node.
+      do sumValue = nodes[i1++].value; while (!sumValue && i1 < n);
+      minValue = maxValue = sumValue;
+      alpha = Math.max(dy / dx, dx / dy) / (value * ratio);
+      beta = sumValue * sumValue * alpha;
+      minRatio = Math.max(maxValue / beta, beta / minValue);
+
+      // Keep adding nodes while the aspect ratio maintains or improves.
+      for (; i1 < n; ++i1) {
+        sumValue += nodeValue = nodes[i1].value;
+        if (nodeValue < minValue) minValue = nodeValue;
+        if (nodeValue > maxValue) maxValue = nodeValue;
+        beta = sumValue * sumValue * alpha;
+        newRatio = Math.max(maxValue / beta, beta / minValue);
+        if (newRatio > minRatio) { sumValue -= nodeValue; break; }
+        minRatio = newRatio;
+      }
+
+      // Position and record the row orientation.
+      rows.push(row = {value: sumValue, dice: dx < dy, children: nodes.slice(i0, i1)});
+      if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += dy * sumValue / value : y1);
+      else treemapSlice(row, x0, y0, value ? x0 += dx * sumValue / value : x1, y1);
+      value -= sumValue, i0 = i1;
+    }
+
+    return rows;
+  }
+
+  var squarify = (function custom(ratio) {
+
+    function squarify(parent, x0, y0, x1, y1) {
+      squarifyRatio(ratio, parent, x0, y0, x1, y1);
+    }
+
+    squarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return squarify;
+  })(phi);
+
+  function treemap() {
+    var tile = squarify,
+        round = false,
+        dx = 1,
+        dy = 1,
+        paddingStack = [0],
+        paddingInner = constantZero,
+        paddingTop = constantZero,
+        paddingRight = constantZero,
+        paddingBottom = constantZero,
+        paddingLeft = constantZero;
+
+    function treemap(root) {
+      root.x0 =
+      root.y0 = 0;
+      root.x1 = dx;
+      root.y1 = dy;
+      root.eachBefore(positionNode);
+      paddingStack = [0];
+      if (round) root.eachBefore(roundNode);
+      return root;
+    }
+
+    function positionNode(node) {
+      var p = paddingStack[node.depth],
+          x0 = node.x0 + p,
+          y0 = node.y0 + p,
+          x1 = node.x1 - p,
+          y1 = node.y1 - p;
+      if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+      if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+      node.x0 = x0;
+      node.y0 = y0;
+      node.x1 = x1;
+      node.y1 = y1;
+      if (node.children) {
+        p = paddingStack[node.depth + 1] = paddingInner(node) / 2;
+        x0 += paddingLeft(node) - p;
+        y0 += paddingTop(node) - p;
+        x1 -= paddingRight(node) - p;
+        y1 -= paddingBottom(node) - p;
+        if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+        if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+        tile(node, x0, y0, x1, y1);
+      }
+    }
+
+    treemap.round = function(x) {
+      return arguments.length ? (round = !!x, treemap) : round;
+    };
+
+    treemap.size = function(x) {
+      return arguments.length ? (dx = +x[0], dy = +x[1], treemap) : [dx, dy];
+    };
+
+    treemap.tile = function(x) {
+      return arguments.length ? (tile = required(x), treemap) : tile;
+    };
+
+    treemap.padding = function(x) {
+      return arguments.length ? treemap.paddingInner(x).paddingOuter(x) : treemap.paddingInner();
+    };
+
+    treemap.paddingInner = function(x) {
+      return arguments.length ? (paddingInner = typeof x === "function" ? x : constant$1(+x), treemap) : paddingInner;
+    };
+
+    treemap.paddingOuter = function(x) {
+      return arguments.length ? treemap.paddingTop(x).paddingRight(x).paddingBottom(x).paddingLeft(x) : treemap.paddingTop();
+    };
+
+    treemap.paddingTop = function(x) {
+      return arguments.length ? (paddingTop = typeof x === "function" ? x : constant$1(+x), treemap) : paddingTop;
+    };
+
+    treemap.paddingRight = function(x) {
+      return arguments.length ? (paddingRight = typeof x === "function" ? x : constant$1(+x), treemap) : paddingRight;
+    };
+
+    treemap.paddingBottom = function(x) {
+      return arguments.length ? (paddingBottom = typeof x === "function" ? x : constant$1(+x), treemap) : paddingBottom;
+    };
+
+    treemap.paddingLeft = function(x) {
+      return arguments.length ? (paddingLeft = typeof x === "function" ? x : constant$1(+x), treemap) : paddingLeft;
+    };
+
+    return treemap;
+  }
+
+  var treemapResquarify = (function custom(ratio) {
+
+    function resquarify(parent, x0, y0, x1, y1) {
+      if ((rows = parent._squarify) && (rows.ratio === ratio)) {
+        var rows,
+            row,
+            nodes,
+            i,
+            j = -1,
+            n,
+            m = rows.length,
+            value = parent.value;
+
+        while (++j < m) {
+          row = rows[j], nodes = row.children;
+          for (i = row.value = 0, n = nodes.length; i < n; ++i) row.value += nodes[i].value;
+          if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += (y1 - y0) * row.value / value : y1);
+          else treemapSlice(row, x0, y0, value ? x0 += (x1 - x0) * row.value / value : x1, y1);
+          value -= row.value;
+        }
+      } else {
+        parent._squarify = rows = squarifyRatio(ratio, parent, x0, y0, x1, y1);
+        rows.ratio = ratio;
+      }
+    }
+
+    resquarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return resquarify;
+  })(phi);
+
+  const isModuleTree = (mod) => "children" in mod;
+
+  let count = 0;
+  class Id {
+      constructor(id) {
+          this._id = id;
+          const url = new URL(window.location.href);
+          url.hash = id;
+          this._href = url.toString();
+      }
+      get id() {
+          return this._id;
+      }
+      get href() {
+          return this._href;
+      }
+      toString() {
+          return `url(${this.href})`;
+      }
+  }
+  function generateUniqueId(name) {
+      count += 1;
+      const id = ["O", name, count].filter(Boolean).join("-");
+      return new Id(id);
+  }
+
+  const LABELS = {
+      renderedLength: "Rendered",
+      gzipLength: "Gzip",
+      brotliLength: "Brotli",
+  };
+  const getAvailableSizeOptions = (options) => {
+      const availableSizeProperties = ["renderedLength"];
+      if (options.gzip) {
+          availableSizeProperties.push("gzipLength");
+      }
+      if (options.brotli) {
+          availableSizeProperties.push("brotliLength");
+      }
+      return availableSizeProperties;
+  };
+
+  var t,r,u,i,o=0,f=[],c=[],e=l$1.__b,a=l$1.__r,v=l$1.diffed,l=l$1.__c,m=l$1.unmount;function d(t,u){l$1.__h&&l$1.__h(r,t,o||u),o=0;var i=r.__H||(r.__H={__:[],__h:[]});return t>=i.__.length&&i.__.push({__V:c}),i.__[t]}function h(n){return o=1,s(B,n)}function s(n,u,i){var o=d(t++,2);if(o.t=n,!o.__c&&(o.__=[i?i(u):B(void 0,u),function(n){var t=o.__N?o.__N[0]:o.__[0],r=o.t(t,n);t!==r&&(o.__N=[r,o.__[1]],o.__c.setState({}));}],o.__c=r,!r.u)){var f=function(n,t,r){if(!o.__c.__H)return !0;var u=o.__c.__H.__.filter(function(n){return n.__c});if(u.every(function(n){return !n.__N}))return !c||c.call(this,n,t,r);var i=!1;return u.forEach(function(n){if(n.__N){var t=n.__[0];n.__=n.__N,n.__N=void 0,t!==n.__[0]&&(i=!0);}}),!(!i&&o.__c.props===n)&&(!c||c.call(this,n,t,r))};r.u=!0;var c=r.shouldComponentUpdate,e=r.componentWillUpdate;r.componentWillUpdate=function(n,t,r){if(this.__e){var u=c;c=void 0,f(n,t,r),c=u;}e&&e.call(this,n,t,r);},r.shouldComponentUpdate=f;}return o.__N||o.__}function p(u,i){var o=d(t++,3);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__H.__h.push(o));}function y(u,i){var o=d(t++,4);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__h.push(o));}function _(n){return o=5,F(function(){return {current:n}},[])}function F(n,r){var u=d(t++,7);return z(u.__H,r)?(u.__V=n(),u.i=r,u.__h=n,u.__V):u.__}function T(n,t){return o=8,F(function(){return n},t)}function q(n){var u=r.context[n.__c],i=d(t++,9);return i.c=n,u?(null==i.__&&(i.__=!0,u.sub(r)),u.props.value):n.__}function b(){for(var t;t=f.shift();)if(t.__P&&t.__H)try{t.__H.__h.forEach(k),t.__H.__h.forEach(w),t.__H.__h=[];}catch(r){t.__H.__h=[],l$1.__e(r,t.__v);}}l$1.__b=function(n){r=null,e&&e(n);},l$1.__r=function(n){a&&a(n),t=0;var i=(r=n.__c).__H;i&&(u===r?(i.__h=[],r.__h=[],i.__.forEach(function(n){n.__N&&(n.__=n.__N),n.__V=c,n.__N=n.i=void 0;})):(i.__h.forEach(k),i.__h.forEach(w),i.__h=[],t=0)),u=r;},l$1.diffed=function(t){v&&v(t);var o=t.__c;o&&o.__H&&(o.__H.__h.length&&(1!==f.push(o)&&i===l$1.requestAnimationFrame||((i=l$1.requestAnimationFrame)||j)(b)),o.__H.__.forEach(function(n){n.i&&(n.__H=n.i),n.__V!==c&&(n.__=n.__V),n.i=void 0,n.__V=c;})),u=r=null;},l$1.__c=function(t,r){r.some(function(t){try{t.__h.forEach(k),t.__h=t.__h.filter(function(n){return !n.__||w(n)});}catch(u){r.some(function(n){n.__h&&(n.__h=[]);}),r=[],l$1.__e(u,t.__v);}}),l&&l(t,r);},l$1.unmount=function(t){m&&m(t);var r,u=t.__c;u&&u.__H&&(u.__H.__.forEach(function(n){try{k(n);}catch(n){r=n;}}),u.__H=void 0,r&&l$1.__e(r,u.__v));};var g="function"==typeof requestAnimationFrame;function j(n){var t,r=function(){clearTimeout(u),g&&cancelAnimationFrame(t),setTimeout(n);},u=setTimeout(r,100);g&&(t=requestAnimationFrame(r));}function k(n){var t=r,u=n.__c;"function"==typeof u&&(n.__c=void 0,u()),r=t;}function w(n){var t=r;n.__c=n.__(),r=t;}function z(n,t){return !n||n.length!==t.length||t.some(function(t,r){return t!==n[r]})}function B(n,t){return "function"==typeof t?t(n):t}
+
+  const PLACEHOLDER = "bundle-*:**/file/**,**/file**, bundle-*:";
+  const SideBar = ({ availableSizeProperties, sizeProperty, setSizeProperty, onExcludeChange, onIncludeChange, }) => {
+      const [includeValue, setIncludeValue] = h("");
+      const [excludeValue, setExcludeValue] = h("");
+      const handleSizePropertyChange = (sizeProp) => () => {
+          if (sizeProp !== sizeProperty) {
+              setSizeProperty(sizeProp);
+          }
+      };
+      const handleIncludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setIncludeValue(value);
+          onIncludeChange(value);
+      };
+      const handleExcludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setExcludeValue(value);
+          onExcludeChange(value);
+      };
+      return (o$1("aside", { className: "sidebar", children: [o$1("div", { className: "size-selectors", children: availableSizeProperties.length > 1 &&
+                      availableSizeProperties.map((sizeProp) => {
+                          const id = `selector-${sizeProp}`;
+                          return (o$1("div", { className: "size-selector", children: [o$1("input", { type: "radio", id: id, checked: sizeProp === sizeProperty, onChange: handleSizePropertyChange(sizeProp) }), o$1("label", { htmlFor: id, children: LABELS[sizeProp] })] }, sizeProp));
+                      }) }), o$1("div", { className: "module-filters", children: [o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-exclude", children: "Exclude" }), o$1("input", { type: "text", id: "module-filter-exclude", value: excludeValue, onInput: handleExcludeChange, placeholder: PLACEHOLDER })] }), o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-include", children: "Include" }), o$1("input", { type: "text", id: "module-filter-include", value: includeValue, onInput: handleIncludeChange, placeholder: PLACEHOLDER })] })] })] }));
+  };
+
+  function getDefaultExportFromCjs (x) {
+  	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+  }
+
+  var utils$3 = {};
+
+  const WIN_SLASH = '\\\\/';
+  const WIN_NO_SLASH = `[^${WIN_SLASH}]`;
+
+  /**
+   * Posix glob regex
+   */
+
+  const DOT_LITERAL = '\\.';
+  const PLUS_LITERAL = '\\+';
+  const QMARK_LITERAL = '\\?';
+  const SLASH_LITERAL = '\\/';
+  const ONE_CHAR = '(?=.)';
+  const QMARK = '[^/]';
+  const END_ANCHOR = `(?:${SLASH_LITERAL}|$)`;
+  const START_ANCHOR = `(?:^|${SLASH_LITERAL})`;
+  const DOTS_SLASH = `${DOT_LITERAL}{1,2}${END_ANCHOR}`;
+  const NO_DOT = `(?!${DOT_LITERAL})`;
+  const NO_DOTS = `(?!${START_ANCHOR}${DOTS_SLASH})`;
+  const NO_DOT_SLASH = `(?!${DOT_LITERAL}{0,1}${END_ANCHOR})`;
+  const NO_DOTS_SLASH = `(?!${DOTS_SLASH})`;
+  const QMARK_NO_DOT = `[^.${SLASH_LITERAL}]`;
+  const STAR = `${QMARK}*?`;
+  const SEP = '/';
+
+  const POSIX_CHARS = {
+    DOT_LITERAL,
+    PLUS_LITERAL,
+    QMARK_LITERAL,
+    SLASH_LITERAL,
+    ONE_CHAR,
+    QMARK,
+    END_ANCHOR,
+    DOTS_SLASH,
+    NO_DOT,
+    NO_DOTS,
+    NO_DOT_SLASH,
+    NO_DOTS_SLASH,
+    QMARK_NO_DOT,
+    STAR,
+    START_ANCHOR,
+    SEP
+  };
+
+  /**
+   * Windows glob regex
+   */
+
+  const WINDOWS_CHARS = {
+    ...POSIX_CHARS,
+
+    SLASH_LITERAL: `[${WIN_SLASH}]`,
+    QMARK: WIN_NO_SLASH,
+    STAR: `${WIN_NO_SLASH}*?`,
+    DOTS_SLASH: `${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$)`,
+    NO_DOT: `(?!${DOT_LITERAL})`,
+    NO_DOTS: `(?!(?:^|[${WIN_SLASH}])${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    NO_DOT_SLASH: `(?!${DOT_LITERAL}{0,1}(?:[${WIN_SLASH}]|$))`,
+    NO_DOTS_SLASH: `(?!${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    QMARK_NO_DOT: `[^.${WIN_SLASH}]`,
+    START_ANCHOR: `(?:^|[${WIN_SLASH}])`,
+    END_ANCHOR: `(?:[${WIN_SLASH}]|$)`,
+    SEP: '\\'
+  };
+
+  /**
+   * POSIX Bracket Regex
+   */
+
+  const POSIX_REGEX_SOURCE$1 = {
+    alnum: 'a-zA-Z0-9',
+    alpha: 'a-zA-Z',
+    ascii: '\\x00-\\x7F',
+    blank: ' \\t',
+    cntrl: '\\x00-\\x1F\\x7F',
+    digit: '0-9',
+    graph: '\\x21-\\x7E',
+    lower: 'a-z',
+    print: '\\x20-\\x7E ',
+    punct: '\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~',
+    space: ' \\t\\r\\n\\v\\f',
+    upper: 'A-Z',
+    word: 'A-Za-z0-9_',
+    xdigit: 'A-Fa-f0-9'
+  };
+
+  var constants$3 = {
+    MAX_LENGTH: 1024 * 64,
+    POSIX_REGEX_SOURCE: POSIX_REGEX_SOURCE$1,
+
+    // regular expressions
+    REGEX_BACKSLASH: /\\(?![*+?^${}(|)[\]])/g,
+    REGEX_NON_SPECIAL_CHARS: /^[^@![\].,$*+?^{}()|\\/]+/,
+    REGEX_SPECIAL_CHARS: /[-*+?.^${}(|)[\]]/,
+    REGEX_SPECIAL_CHARS_BACKREF: /(\\?)((\W)(\3*))/g,
+    REGEX_SPECIAL_CHARS_GLOBAL: /([-*+?.^${}(|)[\]])/g,
+    REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
+
+    // Replace globs with equivalent patterns to reduce parsing time.
+    REPLACEMENTS: {
+      '***': '*',
+      '**/**': '**',
+      '**/**/**': '**'
+    },
+
+    // Digits
+    CHAR_0: 48, /* 0 */
+    CHAR_9: 57, /* 9 */
+
+    // Alphabet chars.
+    CHAR_UPPERCASE_A: 65, /* A */
+    CHAR_LOWERCASE_A: 97, /* a */
+    CHAR_UPPERCASE_Z: 90, /* Z */
+    CHAR_LOWERCASE_Z: 122, /* z */
+
+    CHAR_LEFT_PARENTHESES: 40, /* ( */
+    CHAR_RIGHT_PARENTHESES: 41, /* ) */
+
+    CHAR_ASTERISK: 42, /* * */
+
+    // Non-alphabetic chars.
+    CHAR_AMPERSAND: 38, /* & */
+    CHAR_AT: 64, /* @ */
+    CHAR_BACKWARD_SLASH: 92, /* \ */
+    CHAR_CARRIAGE_RETURN: 13, /* \r */
+    CHAR_CIRCUMFLEX_ACCENT: 94, /* ^ */
+    CHAR_COLON: 58, /* : */
+    CHAR_COMMA: 44, /* , */
+    CHAR_DOT: 46, /* . */
+    CHAR_DOUBLE_QUOTE: 34, /* " */
+    CHAR_EQUAL: 61, /* = */
+    CHAR_EXCLAMATION_MARK: 33, /* ! */
+    CHAR_FORM_FEED: 12, /* \f */
+    CHAR_FORWARD_SLASH: 47, /* / */
+    CHAR_GRAVE_ACCENT: 96, /* ` */
+    CHAR_HASH: 35, /* # */
+    CHAR_HYPHEN_MINUS: 45, /* - */
+    CHAR_LEFT_ANGLE_BRACKET: 60, /* < */
+    CHAR_LEFT_CURLY_BRACE: 123, /* { */
+    CHAR_LEFT_SQUARE_BRACKET: 91, /* [ */
+    CHAR_LINE_FEED: 10, /* \n */
+    CHAR_NO_BREAK_SPACE: 160, /* \u00A0 */
+    CHAR_PERCENT: 37, /* % */
+    CHAR_PLUS: 43, /* + */
+    CHAR_QUESTION_MARK: 63, /* ? */
+    CHAR_RIGHT_ANGLE_BRACKET: 62, /* > */
+    CHAR_RIGHT_CURLY_BRACE: 125, /* } */
+    CHAR_RIGHT_SQUARE_BRACKET: 93, /* ] */
+    CHAR_SEMICOLON: 59, /* ; */
+    CHAR_SINGLE_QUOTE: 39, /* ' */
+    CHAR_SPACE: 32, /*   */
+    CHAR_TAB: 9, /* \t */
+    CHAR_UNDERSCORE: 95, /* _ */
+    CHAR_VERTICAL_LINE: 124, /* | */
+    CHAR_ZERO_WIDTH_NOBREAK_SPACE: 65279, /* \uFEFF */
+
+    /**
+     * Create EXTGLOB_CHARS
+     */
+
+    extglobChars(chars) {
+      return {
+        '!': { type: 'negate', open: '(?:(?!(?:', close: `))${chars.STAR})` },
+        '?': { type: 'qmark', open: '(?:', close: ')?' },
+        '+': { type: 'plus', open: '(?:', close: ')+' },
+        '*': { type: 'star', open: '(?:', close: ')*' },
+        '@': { type: 'at', open: '(?:', close: ')' }
+      };
+    },
+
+    /**
+     * Create GLOB_CHARS
+     */
+
+    globChars(win32) {
+      return win32 === true ? WINDOWS_CHARS : POSIX_CHARS;
+    }
+  };
+
+  (function (exports) {
+
+  	const {
+  	  REGEX_BACKSLASH,
+  	  REGEX_REMOVE_BACKSLASH,
+  	  REGEX_SPECIAL_CHARS,
+  	  REGEX_SPECIAL_CHARS_GLOBAL
+  	} = constants$3;
+
+  	exports.isObject = val => val !== null && typeof val === 'object' && !Array.isArray(val);
+  	exports.hasRegexChars = str => REGEX_SPECIAL_CHARS.test(str);
+  	exports.isRegexChar = str => str.length === 1 && exports.hasRegexChars(str);
+  	exports.escapeRegex = str => str.replace(REGEX_SPECIAL_CHARS_GLOBAL, '\\$1');
+  	exports.toPosixSlashes = str => str.replace(REGEX_BACKSLASH, '/');
+
+  	exports.removeBackslashes = str => {
+  	  return str.replace(REGEX_REMOVE_BACKSLASH, match => {
+  	    return match === '\\' ? '' : match;
+  	  });
+  	};
+
+  	exports.supportsLookbehinds = () => {
+  	  const segs = process.version.slice(1).split('.').map(Number);
+  	  if (segs.length === 3 && segs[0] >= 9 || (segs[0] === 8 && segs[1] >= 10)) {
+  	    return true;
+  	  }
+  	  return false;
+  	};
+
+  	exports.escapeLast = (input, char, lastIdx) => {
+  	  const idx = input.lastIndexOf(char, lastIdx);
+  	  if (idx === -1) return input;
+  	  if (input[idx - 1] === '\\') return exports.escapeLast(input, char, idx - 1);
+  	  return `${input.slice(0, idx)}\\${input.slice(idx)}`;
+  	};
+
+  	exports.removePrefix = (input, state = {}) => {
+  	  let output = input;
+  	  if (output.startsWith('./')) {
+  	    output = output.slice(2);
+  	    state.prefix = './';
+  	  }
+  	  return output;
+  	};
+
+  	exports.wrapOutput = (input, state = {}, options = {}) => {
+  	  const prepend = options.contains ? '' : '^';
+  	  const append = options.contains ? '' : '$';
+
+  	  let output = `${prepend}(?:${input})${append}`;
+  	  if (state.negated === true) {
+  	    output = `(?:^(?!${output}).*$)`;
+  	  }
+  	  return output;
+  	};
+
+  	exports.basename = (path, { windows } = {}) => {
+  	  if (windows) {
+  	    return path.replace(/[\\/]$/, '').replace(/.*[\\/]/, '');
+  	  } else {
+  	    return path.replace(/\/$/, '').replace(/.*\//, '');
+  	  }
+  	}; 
+  } (utils$3));
+
+  const utils$2 = utils$3;
+  const {
+    CHAR_ASTERISK,             /* * */
+    CHAR_AT,                   /* @ */
+    CHAR_BACKWARD_SLASH,       /* \ */
+    CHAR_COMMA,                /* , */
+    CHAR_DOT,                  /* . */
+    CHAR_EXCLAMATION_MARK,     /* ! */
+    CHAR_FORWARD_SLASH,        /* / */
+    CHAR_LEFT_CURLY_BRACE,     /* { */
+    CHAR_LEFT_PARENTHESES,     /* ( */
+    CHAR_LEFT_SQUARE_BRACKET,  /* [ */
+    CHAR_PLUS,                 /* + */
+    CHAR_QUESTION_MARK,        /* ? */
+    CHAR_RIGHT_CURLY_BRACE,    /* } */
+    CHAR_RIGHT_PARENTHESES,    /* ) */
+    CHAR_RIGHT_SQUARE_BRACKET  /* ] */
+  } = constants$3;
+
+  const isPathSeparator = code => {
+    return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+  };
+
+  const depth = token => {
+    if (token.isPrefix !== true) {
+      token.depth = token.isGlobstar ? Infinity : 1;
+    }
+  };
+
+  /**
+   * Quickly scans a glob pattern and returns an object with a handful of
+   * useful properties, like `isGlob`, `path` (the leading non-glob, if it exists),
+   * `glob` (the actual pattern), and `negated` (true if the path starts with `!`).
+   *
+   * ```js
+   * const pm = require('picomatch');
+   * console.log(pm.scan('foo/bar/*.js'));
+   * { isGlob: true, input: 'foo/bar/*.js', base: 'foo/bar', glob: '*.js' }
+   * ```
+   * @param {String} `str`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with tokens and regex source string.
+   * @api public
+   */
+
+  const scan$1 = (input, options) => {
+    const opts = options || {};
+
+    const length = input.length - 1;
+    const scanToEnd = opts.parts === true || opts.scanToEnd === true;
+    const slashes = [];
+    const tokens = [];
+    const parts = [];
+
+    let str = input;
+    let index = -1;
+    let start = 0;
+    let lastIndex = 0;
+    let isBrace = false;
+    let isBracket = false;
+    let isGlob = false;
+    let isExtglob = false;
+    let isGlobstar = false;
+    let braceEscaped = false;
+    let backslashes = false;
+    let negated = false;
+    let finished = false;
+    let braces = 0;
+    let prev;
+    let code;
+    let token = { value: '', depth: 0, isGlob: false };
+
+    const eos = () => index >= length;
+    const peek = () => str.charCodeAt(index + 1);
+    const advance = () => {
+      prev = code;
+      return str.charCodeAt(++index);
+    };
+
+    while (index < length) {
+      code = advance();
+      let next;
+
+      if (code === CHAR_BACKWARD_SLASH) {
+        backslashes = token.backslashes = true;
+        code = advance();
+
+        if (code === CHAR_LEFT_CURLY_BRACE) {
+          braceEscaped = true;
+        }
+        continue;
+      }
+
+      if (braceEscaped === true || code === CHAR_LEFT_CURLY_BRACE) {
+        braces++;
+
+        while (eos() !== true && (code = advance())) {
+          if (code === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (code === CHAR_LEFT_CURLY_BRACE) {
+            braces++;
+            continue;
+          }
+
+          if (braceEscaped !== true && code === CHAR_DOT && (code = advance()) === CHAR_DOT) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (braceEscaped !== true && code === CHAR_COMMA) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (code === CHAR_RIGHT_CURLY_BRACE) {
+            braces--;
+
+            if (braces === 0) {
+              braceEscaped = false;
+              isBrace = token.isBrace = true;
+              finished = true;
+              break;
+            }
+          }
+        }
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+
+      if (code === CHAR_FORWARD_SLASH) {
+        slashes.push(index);
+        tokens.push(token);
+        token = { value: '', depth: 0, isGlob: false };
+
+        if (finished === true) continue;
+        if (prev === CHAR_DOT && index === (start + 1)) {
+          start += 2;
+          continue;
+        }
+
+        lastIndex = index + 1;
+        continue;
+      }
+
+      if (opts.noext !== true) {
+        const isExtglobChar = code === CHAR_PLUS
+          || code === CHAR_AT
+          || code === CHAR_ASTERISK
+          || code === CHAR_QUESTION_MARK
+          || code === CHAR_EXCLAMATION_MARK;
+
+        if (isExtglobChar === true && peek() === CHAR_LEFT_PARENTHESES) {
+          isGlob = token.isGlob = true;
+          isExtglob = token.isExtglob = true;
+          finished = true;
+
+          if (scanToEnd === true) {
+            while (eos() !== true && (code = advance())) {
+              if (code === CHAR_BACKWARD_SLASH) {
+                backslashes = token.backslashes = true;
+                code = advance();
+                continue;
+              }
+
+              if (code === CHAR_RIGHT_PARENTHESES) {
+                isGlob = token.isGlob = true;
+                finished = true;
+                break;
+              }
+            }
+            continue;
+          }
+          break;
+        }
+      }
+
+      if (code === CHAR_ASTERISK) {
+        if (prev === CHAR_ASTERISK) isGlobstar = token.isGlobstar = true;
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_QUESTION_MARK) {
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_LEFT_SQUARE_BRACKET) {
+        while (eos() !== true && (next = advance())) {
+          if (next === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (next === CHAR_RIGHT_SQUARE_BRACKET) {
+            isBracket = token.isBracket = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+            break;
+          }
+        }
+      }
+
+      if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index === start) {
+        negated = token.negated = true;
+        start++;
+        continue;
+      }
+
+      if (opts.noparen !== true && code === CHAR_LEFT_PARENTHESES) {
+        isGlob = token.isGlob = true;
+
+        if (scanToEnd === true) {
+          while (eos() !== true && (code = advance())) {
+            if (code === CHAR_LEFT_PARENTHESES) {
+              backslashes = token.backslashes = true;
+              code = advance();
+              continue;
+            }
+
+            if (code === CHAR_RIGHT_PARENTHESES) {
+              finished = true;
+              break;
+            }
+          }
+          continue;
+        }
+        break;
+      }
+
+      if (isGlob === true) {
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+    }
+
+    if (opts.noext === true) {
+      isExtglob = false;
+      isGlob = false;
+    }
+
+    let base = str;
+    let prefix = '';
+    let glob = '';
+
+    if (start > 0) {
+      prefix = str.slice(0, start);
+      str = str.slice(start);
+      lastIndex -= start;
+    }
+
+    if (base && isGlob === true && lastIndex > 0) {
+      base = str.slice(0, lastIndex);
+      glob = str.slice(lastIndex);
+    } else if (isGlob === true) {
+      base = '';
+      glob = str;
+    } else {
+      base = str;
+    }
+
+    if (base && base !== '' && base !== '/' && base !== str) {
+      if (isPathSeparator(base.charCodeAt(base.length - 1))) {
+        base = base.slice(0, -1);
+      }
+    }
+
+    if (opts.unescape === true) {
+      if (glob) glob = utils$2.removeBackslashes(glob);
+
+      if (base && backslashes === true) {
+        base = utils$2.removeBackslashes(base);
+      }
+    }
+
+    const state = {
+      prefix,
+      input,
+      start,
+      base,
+      glob,
+      isBrace,
+      isBracket,
+      isGlob,
+      isExtglob,
+      isGlobstar,
+      negated
+    };
+
+    if (opts.tokens === true) {
+      state.maxDepth = 0;
+      if (!isPathSeparator(code)) {
+        tokens.push(token);
+      }
+      state.tokens = tokens;
+    }
+
+    if (opts.parts === true || opts.tokens === true) {
+      let prevIndex;
+
+      for (let idx = 0; idx < slashes.length; idx++) {
+        const n = prevIndex ? prevIndex + 1 : start;
+        const i = slashes[idx];
+        const value = input.slice(n, i);
+        if (opts.tokens) {
+          if (idx === 0 && start !== 0) {
+            tokens[idx].isPrefix = true;
+            tokens[idx].value = prefix;
+          } else {
+            tokens[idx].value = value;
+          }
+          depth(tokens[idx]);
+          state.maxDepth += tokens[idx].depth;
+        }
+        if (idx !== 0 || value !== '') {
+          parts.push(value);
+        }
+        prevIndex = i;
+      }
+
+      if (prevIndex && prevIndex + 1 < input.length) {
+        const value = input.slice(prevIndex + 1);
+        parts.push(value);
+
+        if (opts.tokens) {
+          tokens[tokens.length - 1].value = value;
+          depth(tokens[tokens.length - 1]);
+          state.maxDepth += tokens[tokens.length - 1].depth;
+        }
+      }
+
+      state.slashes = slashes;
+      state.parts = parts;
+    }
+
+    return state;
+  };
+
+  var scan_1 = scan$1;
+
+  const constants$2 = constants$3;
+  const utils$1 = utils$3;
+
+  /**
+   * Constants
+   */
+
+  const {
+    MAX_LENGTH,
+    POSIX_REGEX_SOURCE,
+    REGEX_NON_SPECIAL_CHARS,
+    REGEX_SPECIAL_CHARS_BACKREF,
+    REPLACEMENTS
+  } = constants$2;
+
+  /**
+   * Helpers
+   */
+
+  const expandRange = (args, options) => {
+    if (typeof options.expandRange === 'function') {
+      return options.expandRange(...args, options);
+    }
+
+    args.sort();
+    const value = `[${args.join('-')}]`;
+
+    try {
+      /* eslint-disable-next-line no-new */
+      new RegExp(value);
+    } catch (ex) {
+      return args.map(v => utils$1.escapeRegex(v)).join('..');
+    }
+
+    return value;
+  };
+
+  /**
+   * Create the message for a syntax error
+   */
+
+  const syntaxError = (type, char) => {
+    return `Missing ${type}: "${char}" - use "\\\\${char}" to match literal characters`;
+  };
+
+  /**
+   * Parse the given input string.
+   * @param {String} input
+   * @param {Object} options
+   * @return {Object}
+   */
+
+  const parse$2 = (input, options) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected a string');
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+
+    let len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    const bos = { type: 'bos', value: '', output: opts.prepend || '' };
+    const tokens = [bos];
+
+    const capture = opts.capture ? '' : '?:';
+
+    // create constants based on platform, for windows or posix
+    const PLATFORM_CHARS = constants$2.globChars(opts.windows);
+    const EXTGLOB_CHARS = constants$2.extglobChars(PLATFORM_CHARS);
+
+    const {
+      DOT_LITERAL,
+      PLUS_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOT_SLASH,
+      NO_DOTS_SLASH,
+      QMARK,
+      QMARK_NO_DOT,
+      STAR,
+      START_ANCHOR
+    } = PLATFORM_CHARS;
+
+    const globstar = (opts) => {
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const nodot = opts.dot ? '' : NO_DOT;
+    const qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
+    let star = opts.bash === true ? globstar(opts) : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    // minimatch options support
+    if (typeof opts.noext === 'boolean') {
+      opts.noextglob = opts.noext;
+    }
+
+    const state = {
+      input,
+      index: -1,
+      start: 0,
+      dot: opts.dot === true,
+      consumed: '',
+      output: '',
+      prefix: '',
+      backtrack: false,
+      negated: false,
+      brackets: 0,
+      braces: 0,
+      parens: 0,
+      quotes: 0,
+      globstar: false,
+      tokens
+    };
+
+    input = utils$1.removePrefix(input, state);
+    len = input.length;
+
+    const extglobs = [];
+    const braces = [];
+    const stack = [];
+    let prev = bos;
+    let value;
+
+    /**
+     * Tokenizing helpers
+     */
+
+    const eos = () => state.index === len - 1;
+    const peek = state.peek = (n = 1) => input[state.index + n];
+    const advance = state.advance = () => input[++state.index];
+    const remaining = () => input.slice(state.index + 1);
+    const consume = (value = '', num = 0) => {
+      state.consumed += value;
+      state.index += num;
+    };
+    const append = token => {
+      state.output += token.output != null ? token.output : token.value;
+      consume(token.value);
+    };
+
+    const negate = () => {
+      let count = 1;
+
+      while (peek() === '!' && (peek(2) !== '(' || peek(3) === '?')) {
+        advance();
+        state.start++;
+        count++;
+      }
+
+      if (count % 2 === 0) {
+        return false;
+      }
+
+      state.negated = true;
+      state.start++;
+      return true;
+    };
+
+    const increment = type => {
+      state[type]++;
+      stack.push(type);
+    };
+
+    const decrement = type => {
+      state[type]--;
+      stack.pop();
+    };
+
+    /**
+     * Push tokens onto the tokens array. This helper speeds up
+     * tokenizing by 1) helping us avoid backtracking as much as possible,
+     * and 2) helping us avoid creating extra tokens when consecutive
+     * characters are plain text. This improves performance and simplifies
+     * lookbehinds.
+     */
+
+    const push = tok => {
+      if (prev.type === 'globstar') {
+        const isBrace = state.braces > 0 && (tok.type === 'comma' || tok.type === 'brace');
+        const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.type === 'paren'));
+
+        if (tok.type !== 'slash' && tok.type !== 'paren' && !isBrace && !isExtglob) {
+          state.output = state.output.slice(0, -prev.output.length);
+          prev.type = 'star';
+          prev.value = '*';
+          prev.output = star;
+          state.output += prev.output;
+        }
+      }
+
+      if (extglobs.length && tok.type !== 'paren' && !EXTGLOB_CHARS[tok.value]) {
+        extglobs[extglobs.length - 1].inner += tok.value;
+      }
+
+      if (tok.value || tok.output) append(tok);
+      if (prev && prev.type === 'text' && tok.type === 'text') {
+        prev.value += tok.value;
+        prev.output = (prev.output || '') + tok.value;
+        return;
+      }
+
+      tok.prev = prev;
+      tokens.push(tok);
+      prev = tok;
+    };
+
+    const extglobOpen = (type, value) => {
+      const token = { ...EXTGLOB_CHARS[value], conditions: 1, inner: '' };
+
+      token.prev = prev;
+      token.parens = state.parens;
+      token.output = state.output;
+      const output = (opts.capture ? '(' : '') + token.open;
+
+      increment('parens');
+      push({ type, value, output: state.output ? '' : ONE_CHAR });
+      push({ type: 'paren', extglob: true, value: advance(), output });
+      extglobs.push(token);
+    };
+
+    const extglobClose = token => {
+      let output = token.close + (opts.capture ? ')' : '');
+
+      if (token.type === 'negate') {
+        let extglobStar = star;
+
+        if (token.inner && token.inner.length > 1 && token.inner.includes('/')) {
+          extglobStar = globstar(opts);
+        }
+
+        if (extglobStar !== star || eos() || /^\)+$/.test(remaining())) {
+          output = token.close = `)$))${extglobStar}`;
+        }
+
+        if (token.prev.type === 'bos' && eos()) {
+          state.negatedExtglob = true;
+        }
+      }
+
+      push({ type: 'paren', extglob: true, value, output });
+      decrement('parens');
+    };
+
+    /**
+     * Fast paths
+     */
+
+    if (opts.fastpaths !== false && !/(^[*!]|[/()[\]{}"])/.test(input)) {
+      let backslashes = false;
+
+      let output = input.replace(REGEX_SPECIAL_CHARS_BACKREF, (m, esc, chars, first, rest, index) => {
+        if (first === '\\') {
+          backslashes = true;
+          return m;
+        }
+
+        if (first === '?') {
+          if (esc) {
+            return esc + first + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          if (index === 0) {
+            return qmarkNoDot + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          return QMARK.repeat(chars.length);
+        }
+
+        if (first === '.') {
+          return DOT_LITERAL.repeat(chars.length);
+        }
+
+        if (first === '*') {
+          if (esc) {
+            return esc + first + (rest ? star : '');
+          }
+          return star;
+        }
+        return esc ? m : `\\${m}`;
+      });
+
+      if (backslashes === true) {
+        if (opts.unescape === true) {
+          output = output.replace(/\\/g, '');
+        } else {
+          output = output.replace(/\\+/g, m => {
+            return m.length % 2 === 0 ? '\\\\' : (m ? '\\' : '');
+          });
+        }
+      }
+
+      if (output === input && opts.contains === true) {
+        state.output = input;
+        return state;
+      }
+
+      state.output = utils$1.wrapOutput(output, state, options);
+      return state;
+    }
+
+    /**
+     * Tokenize input until we reach end-of-string
+     */
+
+    while (!eos()) {
+      value = advance();
+
+      if (value === '\u0000') {
+        continue;
+      }
+
+      /**
+       * Escaped characters
+       */
+
+      if (value === '\\') {
+        const next = peek();
+
+        if (next === '/' && opts.bash !== true) {
+          continue;
+        }
+
+        if (next === '.' || next === ';') {
+          continue;
+        }
+
+        if (!next) {
+          value += '\\';
+          push({ type: 'text', value });
+          continue;
+        }
+
+        // collapse slashes to reduce potential for exploits
+        const match = /^\\+/.exec(remaining());
+        let slashes = 0;
+
+        if (match && match[0].length > 2) {
+          slashes = match[0].length;
+          state.index += slashes;
+          if (slashes % 2 !== 0) {
+            value += '\\';
+          }
+        }
+
+        if (opts.unescape === true) {
+          value = advance() || '';
+        } else {
+          value += advance() || '';
+        }
+
+        if (state.brackets === 0) {
+          push({ type: 'text', value });
+          continue;
+        }
+      }
+
+      /**
+       * If we're inside a regex character class, continue
+       * until we reach the closing bracket.
+       */
+
+      if (state.brackets > 0 && (value !== ']' || prev.value === '[' || prev.value === '[^')) {
+        if (opts.posix !== false && value === ':') {
+          const inner = prev.value.slice(1);
+          if (inner.includes('[')) {
+            prev.posix = true;
+
+            if (inner.includes(':')) {
+              const idx = prev.value.lastIndexOf('[');
+              const pre = prev.value.slice(0, idx);
+              const rest = prev.value.slice(idx + 2);
+              const posix = POSIX_REGEX_SOURCE[rest];
+              if (posix) {
+                prev.value = pre + posix;
+                state.backtrack = true;
+                advance();
+
+                if (!bos.output && tokens.indexOf(prev) === 1) {
+                  bos.output = ONE_CHAR;
+                }
+                continue;
+              }
+            }
+          }
+        }
+
+        if ((value === '[' && peek() !== ':') || (value === '-' && peek() === ']')) {
+          value = `\\${value}`;
+        }
+
+        if (value === ']' && (prev.value === '[' || prev.value === '[^')) {
+          value = `\\${value}`;
+        }
+
+        if (opts.posix === true && value === '!' && prev.value === '[') {
+          value = '^';
+        }
+
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * If we're inside a quoted string, continue
+       * until we reach the closing double quote.
+       */
+
+      if (state.quotes === 1 && value !== '"') {
+        value = utils$1.escapeRegex(value);
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * Double quotes
+       */
+
+      if (value === '"') {
+        state.quotes = state.quotes === 1 ? 0 : 1;
+        if (opts.keepQuotes === true) {
+          push({ type: 'text', value });
+        }
+        continue;
+      }
+
+      /**
+       * Parentheses
+       */
+
+      if (value === '(') {
+        increment('parens');
+        push({ type: 'paren', value });
+        continue;
+      }
+
+      if (value === ')') {
+        if (state.parens === 0 && opts.strictBrackets === true) {
+          throw new SyntaxError(syntaxError('opening', '('));
+        }
+
+        const extglob = extglobs[extglobs.length - 1];
+        if (extglob && state.parens === extglob.parens + 1) {
+          extglobClose(extglobs.pop());
+          continue;
+        }
+
+        push({ type: 'paren', value, output: state.parens ? ')' : '\\)' });
+        decrement('parens');
+        continue;
+      }
+
+      /**
+       * Square brackets
+       */
+
+      if (value === '[') {
+        if (opts.nobracket === true || !remaining().includes(']')) {
+          if (opts.nobracket !== true && opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('closing', ']'));
+          }
+
+          value = `\\${value}`;
+        } else {
+          increment('brackets');
+        }
+
+        push({ type: 'bracket', value });
+        continue;
+      }
+
+      if (value === ']') {
+        if (opts.nobracket === true || (prev && prev.type === 'bracket' && prev.value.length === 1)) {
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        if (state.brackets === 0) {
+          if (opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('opening', '['));
+          }
+
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        decrement('brackets');
+
+        const prevValue = prev.value.slice(1);
+        if (prev.posix !== true && prevValue[0] === '^' && !prevValue.includes('/')) {
+          value = `/${value}`;
+        }
+
+        prev.value += value;
+        append({ value });
+
+        // when literal brackets are explicitly disabled
+        // assume we should match with a regex character class
+        if (opts.literalBrackets === false || utils$1.hasRegexChars(prevValue)) {
+          continue;
+        }
+
+        const escaped = utils$1.escapeRegex(prev.value);
+        state.output = state.output.slice(0, -prev.value.length);
+
+        // when literal brackets are explicitly enabled
+        // assume we should escape the brackets to match literal characters
+        if (opts.literalBrackets === true) {
+          state.output += escaped;
+          prev.value = escaped;
+          continue;
+        }
+
+        // when the user specifies nothing, try to match both
+        prev.value = `(${capture}${escaped}|${prev.value})`;
+        state.output += prev.value;
+        continue;
+      }
+
+      /**
+       * Braces
+       */
+
+      if (value === '{' && opts.nobrace !== true) {
+        increment('braces');
+
+        const open = {
+          type: 'brace',
+          value,
+          output: '(',
+          outputIndex: state.output.length,
+          tokensIndex: state.tokens.length
+        };
+
+        braces.push(open);
+        push(open);
+        continue;
+      }
+
+      if (value === '}') {
+        const brace = braces[braces.length - 1];
+
+        if (opts.nobrace === true || !brace) {
+          push({ type: 'text', value, output: value });
+          continue;
+        }
+
+        let output = ')';
+
+        if (brace.dots === true) {
+          const arr = tokens.slice();
+          const range = [];
+
+          for (let i = arr.length - 1; i >= 0; i--) {
+            tokens.pop();
+            if (arr[i].type === 'brace') {
+              break;
+            }
+            if (arr[i].type !== 'dots') {
+              range.unshift(arr[i].value);
+            }
+          }
+
+          output = expandRange(range, opts);
+          state.backtrack = true;
+        }
+
+        if (brace.comma !== true && brace.dots !== true) {
+          const out = state.output.slice(0, brace.outputIndex);
+          const toks = state.tokens.slice(brace.tokensIndex);
+          brace.value = brace.output = '\\{';
+          value = output = '\\}';
+          state.output = out;
+          for (const t of toks) {
+            state.output += (t.output || t.value);
+          }
+        }
+
+        push({ type: 'brace', value, output });
+        decrement('braces');
+        braces.pop();
+        continue;
+      }
+
+      /**
+       * Pipes
+       */
+
+      if (value === '|') {
+        if (extglobs.length > 0) {
+          extglobs[extglobs.length - 1].conditions++;
+        }
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Commas
+       */
+
+      if (value === ',') {
+        let output = value;
+
+        const brace = braces[braces.length - 1];
+        if (brace && stack[stack.length - 1] === 'braces') {
+          brace.comma = true;
+          output = '|';
+        }
+
+        push({ type: 'comma', value, output });
+        continue;
+      }
+
+      /**
+       * Slashes
+       */
+
+      if (value === '/') {
+        // if the beginning of the glob is "./", advance the start
+        // to the current index, and don't add the "./" characters
+        // to the state. This greatly simplifies lookbehinds when
+        // checking for BOS characters like "!" and "." (not "./")
+        if (prev.type === 'dot' && state.index === state.start + 1) {
+          state.start = state.index + 1;
+          state.consumed = '';
+          state.output = '';
+          tokens.pop();
+          prev = bos; // reset "prev" to the first token
+          continue;
+        }
+
+        push({ type: 'slash', value, output: SLASH_LITERAL });
+        continue;
+      }
+
+      /**
+       * Dots
+       */
+
+      if (value === '.') {
+        if (state.braces > 0 && prev.type === 'dot') {
+          if (prev.value === '.') prev.output = DOT_LITERAL;
+          const brace = braces[braces.length - 1];
+          prev.type = 'dots';
+          prev.output += value;
+          prev.value += value;
+          brace.dots = true;
+          continue;
+        }
+
+        if ((state.braces + state.parens) === 0 && prev.type !== 'bos' && prev.type !== 'slash') {
+          push({ type: 'text', value, output: DOT_LITERAL });
+          continue;
+        }
+
+        push({ type: 'dot', value, output: DOT_LITERAL });
+        continue;
+      }
+
+      /**
+       * Question marks
+       */
+
+      if (value === '?') {
+        const isGroup = prev && prev.value === '(';
+        if (!isGroup && opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('qmark', value);
+          continue;
+        }
+
+        if (prev && prev.type === 'paren') {
+          const next = peek();
+          let output = value;
+
+          if (next === '<' && !utils$1.supportsLookbehinds()) {
+            throw new Error('Node.js v10 or higher is required for regex lookbehinds');
+          }
+
+          if ((prev.value === '(' && !/[!=<:]/.test(next)) || (next === '<' && !/<([!=]|\w+>)/.test(remaining()))) {
+            output = `\\${value}`;
+          }
+
+          push({ type: 'text', value, output });
+          continue;
+        }
+
+        if (opts.dot !== true && (prev.type === 'slash' || prev.type === 'bos')) {
+          push({ type: 'qmark', value, output: QMARK_NO_DOT });
+          continue;
+        }
+
+        push({ type: 'qmark', value, output: QMARK });
+        continue;
+      }
+
+      /**
+       * Exclamation
+       */
+
+      if (value === '!') {
+        if (opts.noextglob !== true && peek() === '(') {
+          if (peek(2) !== '?' || !/[!=<:]/.test(peek(3))) {
+            extglobOpen('negate', value);
+            continue;
+          }
+        }
+
+        if (opts.nonegate !== true && state.index === 0) {
+          negate();
+          continue;
+        }
+      }
+
+      /**
+       * Plus
+       */
+
+      if (value === '+') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('plus', value);
+          continue;
+        }
+
+        if ((prev && prev.value === '(') || opts.regex === false) {
+          push({ type: 'plus', value, output: PLUS_LITERAL });
+          continue;
+        }
+
+        if ((prev && (prev.type === 'bracket' || prev.type === 'paren' || prev.type === 'brace')) || state.parens > 0) {
+          push({ type: 'plus', value });
+          continue;
+        }
+
+        push({ type: 'plus', value: PLUS_LITERAL });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value === '@') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          push({ type: 'at', extglob: true, value, output: '' });
+          continue;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value !== '*') {
+        if (value === '$' || value === '^') {
+          value = `\\${value}`;
+        }
+
+        const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
+        if (match) {
+          value += match[0];
+          state.index += match[0].length;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Stars
+       */
+
+      if (prev && (prev.type === 'globstar' || prev.star === true)) {
+        prev.type = 'star';
+        prev.star = true;
+        prev.value += value;
+        prev.output = star;
+        state.backtrack = true;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      let rest = remaining();
+      if (opts.noextglob !== true && /^\([^?]/.test(rest)) {
+        extglobOpen('star', value);
+        continue;
+      }
+
+      if (prev.type === 'star') {
+        if (opts.noglobstar === true) {
+          consume(value);
+          continue;
+        }
+
+        const prior = prev.prev;
+        const before = prior.prev;
+        const isStart = prior.type === 'slash' || prior.type === 'bos';
+        const afterStar = before && (before.type === 'star' || before.type === 'globstar');
+
+        if (opts.bash === true && (!isStart || (rest[0] && rest[0] !== '/'))) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        const isBrace = state.braces > 0 && (prior.type === 'comma' || prior.type === 'brace');
+        const isExtglob = extglobs.length && (prior.type === 'pipe' || prior.type === 'paren');
+        if (!isStart && prior.type !== 'paren' && !isBrace && !isExtglob) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        // strip consecutive `/**/`
+        while (rest.slice(0, 3) === '/**') {
+          const after = input[state.index + 4];
+          if (after && after !== '/') {
+            break;
+          }
+          rest = rest.slice(3);
+          consume('/**', 3);
+        }
+
+        if (prior.type === 'bos' && eos()) {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = globstar(opts);
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && !afterStar && eos()) {
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = globstar(opts) + (opts.strictSlashes ? ')' : '|$)');
+          prev.value += value;
+          state.globstar = true;
+          state.output += prior.output + prev.output;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && rest[0] === '/') {
+          const end = rest[1] !== void 0 ? '|$' : '';
+
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = `${globstar(opts)}${SLASH_LITERAL}|${SLASH_LITERAL}${end})`;
+          prev.value += value;
+
+          state.output += prior.output + prev.output;
+          state.globstar = true;
+
+          consume(value + advance());
+
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        if (prior.type === 'bos' && rest[0] === '/') {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value + advance());
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        // remove single star from output
+        state.output = state.output.slice(0, -prev.output.length);
+
+        // reset previous token to globstar
+        prev.type = 'globstar';
+        prev.output = globstar(opts);
+        prev.value += value;
+
+        // reset output with globstar
+        state.output += prev.output;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      const token = { type: 'star', value, output: star };
+
+      if (opts.bash === true) {
+        token.output = '.*?';
+        if (prev.type === 'bos' || prev.type === 'slash') {
+          token.output = nodot + token.output;
+        }
+        push(token);
+        continue;
+      }
+
+      if (prev && (prev.type === 'bracket' || prev.type === 'paren') && opts.regex === true) {
+        token.output = value;
+        push(token);
+        continue;
+      }
+
+      if (state.index === state.start || prev.type === 'slash' || prev.type === 'dot') {
+        if (prev.type === 'dot') {
+          state.output += NO_DOT_SLASH;
+          prev.output += NO_DOT_SLASH;
+
+        } else if (opts.dot === true) {
+          state.output += NO_DOTS_SLASH;
+          prev.output += NO_DOTS_SLASH;
+
+        } else {
+          state.output += nodot;
+          prev.output += nodot;
+        }
+
+        if (peek() !== '*') {
+          state.output += ONE_CHAR;
+          prev.output += ONE_CHAR;
+        }
+      }
+
+      push(token);
+    }
+
+    while (state.brackets > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ']'));
+      state.output = utils$1.escapeLast(state.output, '[');
+      decrement('brackets');
+    }
+
+    while (state.parens > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ')'));
+      state.output = utils$1.escapeLast(state.output, '(');
+      decrement('parens');
+    }
+
+    while (state.braces > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', '}'));
+      state.output = utils$1.escapeLast(state.output, '{');
+      decrement('braces');
+    }
+
+    if (opts.strictSlashes !== true && (prev.type === 'star' || prev.type === 'bracket')) {
+      push({ type: 'maybe_slash', value: '', output: `${SLASH_LITERAL}?` });
+    }
+
+    // rebuild the output if we had to backtrack at any point
+    if (state.backtrack === true) {
+      state.output = '';
+
+      for (const token of state.tokens) {
+        state.output += token.output != null ? token.output : token.value;
+
+        if (token.suffix) {
+          state.output += token.suffix;
+        }
+      }
+    }
+
+    return state;
+  };
+
+  /**
+   * Fast paths for creating regular expressions for common glob patterns.
+   * This can significantly speed up processing and has very little downside
+   * impact when none of the fast paths match.
+   */
+
+  parse$2.fastpaths = (input, options) => {
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+    const len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    // create constants based on platform, for windows or posix
+    const {
+      DOT_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOTS,
+      NO_DOTS_SLASH,
+      STAR,
+      START_ANCHOR
+    } = constants$2.globChars(opts.windows);
+
+    const nodot = opts.dot ? NO_DOTS : NO_DOT;
+    const slashDot = opts.dot ? NO_DOTS_SLASH : NO_DOT;
+    const capture = opts.capture ? '' : '?:';
+    const state = { negated: false, prefix: '' };
+    let star = opts.bash === true ? '.*?' : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    const globstar = (opts) => {
+      if (opts.noglobstar === true) return star;
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const create = str => {
+      switch (str) {
+        case '*':
+          return `${nodot}${ONE_CHAR}${star}`;
+
+        case '.*':
+          return `${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*.*':
+          return `${nodot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*/*':
+          return `${nodot}${star}${SLASH_LITERAL}${ONE_CHAR}${slashDot}${star}`;
+
+        case '**':
+          return nodot + globstar(opts);
+
+        case '**/*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${ONE_CHAR}${star}`;
+
+        case '**/*.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '**/.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        default: {
+          const match = /^(.*?)\.(\w+)$/.exec(str);
+          if (!match) return;
+
+          const source = create(match[1]);
+          if (!source) return;
+
+          return source + DOT_LITERAL + match[2];
+        }
+      }
+    };
+
+    const output = utils$1.removePrefix(input, state);
+    let source = create(output);
+
+    if (source && opts.strictSlashes !== true) {
+      source += `${SLASH_LITERAL}?`;
+    }
+
+    return source;
+  };
+
+  var parse_1 = parse$2;
+
+  const scan = scan_1;
+  const parse$1 = parse_1;
+  const utils = utils$3;
+  const constants$1 = constants$3;
+  const isObject = val => val && typeof val === 'object' && !Array.isArray(val);
+
+  /**
+   * Creates a matcher function from one or more glob patterns. The
+   * returned function takes a string to match as its first argument,
+   * and returns true if the string is a match. The returned matcher
+   * function also takes a boolean as the second argument that, when true,
+   * returns an object with additional information.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch(glob[, options]);
+   *
+   * const isMatch = picomatch('*.!(*a)');
+   * console.log(isMatch('a.a')); //=> false
+   * console.log(isMatch('a.b')); //=> true
+   * ```
+   * @name picomatch
+   * @param {String|Array} `globs` One or more glob patterns.
+   * @param {Object=} `options`
+   * @return {Function=} Returns a matcher function.
+   * @api public
+   */
+
+  const picomatch = (glob, options, returnState = false) => {
+    if (Array.isArray(glob)) {
+      const fns = glob.map(input => picomatch(input, options, returnState));
+      const arrayMatcher = str => {
+        for (const isMatch of fns) {
+          const state = isMatch(str);
+          if (state) return state;
+        }
+        return false;
+      };
+      return arrayMatcher;
+    }
+
+    const isState = isObject(glob) && glob.tokens && glob.input;
+
+    if (glob === '' || (typeof glob !== 'string' && !isState)) {
+      throw new TypeError('Expected pattern to be a non-empty string');
+    }
+
+    const opts = options || {};
+    const posix = opts.windows;
+    const regex = isState
+      ? picomatch.compileRe(glob, options)
+      : picomatch.makeRe(glob, options, false, true);
+
+    const state = regex.state;
+    delete regex.state;
+
+    let isIgnored = () => false;
+    if (opts.ignore) {
+      const ignoreOpts = { ...options, ignore: null, onMatch: null, onResult: null };
+      isIgnored = picomatch(opts.ignore, ignoreOpts, returnState);
+    }
+
+    const matcher = (input, returnObject = false) => {
+      const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+      const result = { glob, state, regex, posix, input, output, match, isMatch };
+
+      if (typeof opts.onResult === 'function') {
+        opts.onResult(result);
+      }
+
+      if (isMatch === false) {
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (isIgnored(input)) {
+        if (typeof opts.onIgnore === 'function') {
+          opts.onIgnore(result);
+        }
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (typeof opts.onMatch === 'function') {
+        opts.onMatch(result);
+      }
+      return returnObject ? result : true;
+    };
+
+    if (returnState) {
+      matcher.state = state;
+    }
+
+    return matcher;
+  };
+
+  /**
+   * Test `input` with the given `regex`. This is used by the main
+   * `picomatch()` function to test the input string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.test(input, regex[, options]);
+   *
+   * console.log(picomatch.test('foo/bar', /^(?:([^/]*?)\/([^/]*?))$/));
+   * // { isMatch: true, match: [ 'foo/', 'foo', 'bar' ], output: 'foo/bar' }
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp} `regex`
+   * @return {Object} Returns an object with matching info.
+   * @api public
+   */
+
+  picomatch.test = (input, regex, options, { glob, posix } = {}) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected input to be a string');
+    }
+
+    if (input === '') {
+      return { isMatch: false, output: '' };
+    }
+
+    const opts = options || {};
+    const format = opts.format || (posix ? utils.toPosixSlashes : null);
+    let match = input === glob;
+    let output = (match && format) ? format(input) : input;
+
+    if (match === false) {
+      output = format ? format(input) : input;
+      match = output === glob;
+    }
+
+    if (match === false || opts.capture === true) {
+      if (opts.matchBase === true || opts.basename === true) {
+        match = picomatch.matchBase(input, regex, options, posix);
+      } else {
+        match = regex.exec(output);
+      }
+    }
+
+    return { isMatch: Boolean(match), match, output };
+  };
+
+  /**
+   * Match the basename of a filepath.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.matchBase(input, glob[, options]);
+   * console.log(picomatch.matchBase('foo/bar.js', '*.js'); // true
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp|String} `glob` Glob pattern or regex created by [.makeRe](#makeRe).
+   * @return {Boolean}
+   * @api public
+   */
+
+  picomatch.matchBase = (input, glob, options) => {
+    const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
+    return regex.test(utils.basename(input));
+  };
+
+  /**
+   * Returns true if **any** of the given glob `patterns` match the specified `string`.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.isMatch(string, patterns[, options]);
+   *
+   * console.log(picomatch.isMatch('a.a', ['b.*', '*.a'])); //=> true
+   * console.log(picomatch.isMatch('a.a', 'b.*')); //=> false
+   * ```
+   * @param {String|Array} str The string to test.
+   * @param {String|Array} patterns One or more glob patterns to use for matching.
+   * @param {Object} [options] See available [options](#options).
+   * @return {Boolean} Returns true if any patterns match `str`
+   * @api public
+   */
+
+  picomatch.isMatch = (str, patterns, options) => picomatch(patterns, options)(str);
+
+  /**
+   * Parse a glob pattern to create the source string for a regular
+   * expression.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const result = picomatch.parse(pattern[, options]);
+   * ```
+   * @param {String} `pattern`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with useful properties and output to be used as a regex source string.
+   * @api public
+   */
+
+  picomatch.parse = (pattern, options) => {
+    if (Array.isArray(pattern)) return pattern.map(p => picomatch.parse(p, options));
+    return parse$1(pattern, { ...options, fastpaths: false });
+  };
+
+  /**
+   * Scan a glob pattern to separate the pattern into segments.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.scan(input[, options]);
+   *
+   * const result = picomatch.scan('!./foo/*.js');
+   * console.log(result);
+   * { prefix: '!./',
+   *   input: '!./foo/*.js',
+   *   start: 3,
+   *   base: 'foo',
+   *   glob: '*.js',
+   *   isBrace: false,
+   *   isBracket: false,
+   *   isGlob: true,
+   *   isExtglob: false,
+   *   isGlobstar: false,
+   *   negated: true }
+   * ```
+   * @param {String} `input` Glob pattern to scan.
+   * @param {Object} `options`
+   * @return {Object} Returns an object with
+   * @api public
+   */
+
+  picomatch.scan = (input, options) => scan(input, options);
+
+  /**
+   * Create a regular expression from a parsed glob pattern.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const state = picomatch.parse('*.js');
+   * // picomatch.compileRe(state[, options]);
+   *
+   * console.log(picomatch.compileRe(state));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `state` The object returned from the `.parse` method.
+   * @param {Object} `options`
+   * @return {RegExp} Returns a regex created from the given pattern.
+   * @api public
+   */
+
+  picomatch.compileRe = (parsed, options, returnOutput = false, returnState = false) => {
+    if (returnOutput === true) {
+      return parsed.output;
+    }
+
+    const opts = options || {};
+    const prepend = opts.contains ? '' : '^';
+    const append = opts.contains ? '' : '$';
+
+    let source = `${prepend}(?:${parsed.output})${append}`;
+    if (parsed && parsed.negated === true) {
+      source = `^(?!${source}).*$`;
+    }
+
+    const regex = picomatch.toRegex(source, options);
+    if (returnState === true) {
+      regex.state = parsed;
+    }
+
+    return regex;
+  };
+
+  picomatch.makeRe = (input, options, returnOutput = false, returnState = false) => {
+    if (!input || typeof input !== 'string') {
+      throw new TypeError('Expected a non-empty string');
+    }
+
+    const opts = options || {};
+    let parsed = { negated: false, fastpaths: true };
+    let prefix = '';
+    let output;
+
+    if (input.startsWith('./')) {
+      input = input.slice(2);
+      prefix = parsed.prefix = './';
+    }
+
+    if (opts.fastpaths !== false && (input[0] === '.' || input[0] === '*')) {
+      output = parse$1.fastpaths(input, options);
+    }
+
+    if (output === undefined) {
+      parsed = parse$1(input, options);
+      parsed.prefix = prefix + (parsed.prefix || '');
+    } else {
+      parsed.output = output;
+    }
+
+    return picomatch.compileRe(parsed, options, returnOutput, returnState);
+  };
+
+  /**
+   * Create a regular expression from the given regex source string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.toRegex(source[, options]);
+   *
+   * const { output } = picomatch.parse('*.js');
+   * console.log(picomatch.toRegex(output));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `source` Regular expression source string.
+   * @param {Object} `options`
+   * @return {RegExp}
+   * @api public
+   */
+
+  picomatch.toRegex = (source, options) => {
+    try {
+      const opts = options || {};
+      return new RegExp(source, opts.flags || (opts.nocase ? 'i' : ''));
+    } catch (err) {
+      if (options && options.debug === true) throw err;
+      return /$^/;
+    }
+  };
+
+  /**
+   * Picomatch constants.
+   * @return {Object}
+   */
+
+  picomatch.constants = constants$1;
+
+  /**
+   * Expose "picomatch"
+   */
+
+  var picomatch_1 = picomatch;
+
+  var picomatchBrowser = picomatch_1;
+
+  var pm = /*@__PURE__*/getDefaultExportFromCjs(picomatchBrowser);
+
+  function isArray(arg) {
+      return Array.isArray(arg);
+  }
+  function ensureArray(thing) {
+      if (isArray(thing))
+          return thing;
+      if (thing == null)
+          return [];
+      return [thing];
+  }
+  const globToTest = (glob) => {
+      const pattern = glob;
+      const fn = pm(pattern, { dot: true });
+      return {
+          test: (what) => {
+              const result = fn(what);
+              return result;
+          },
+      };
+  };
+  const testTrue = {
+      test: () => true,
+  };
+  const getMatcher = (filter) => {
+      const bundleTest = "bundle" in filter && filter.bundle != null ? globToTest(filter.bundle) : testTrue;
+      const fileTest = "file" in filter && filter.file != null ? globToTest(filter.file) : testTrue;
+      return { bundleTest, fileTest };
+  };
+  const createFilter = (include, exclude) => {
+      const includeMatchers = ensureArray(include).map(getMatcher);
+      const excludeMatchers = ensureArray(exclude).map(getMatcher);
+      return (bundleId, id) => {
+          for (let i = 0; i < excludeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = excludeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return false;
+          }
+          for (let i = 0; i < includeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = includeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return true;
+          }
+          return !includeMatchers.length;
+      };
+  };
+
+  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      return (val) => {
+          if (!waiting) {
+              callback(val);
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+              }, limit);
+          }
+      };
+  };
+  const prepareFilter = (filt) => {
+      if (filt === "")
+          return [];
+      return (filt
+          .split(",")
+          // remove spaces before and after
+          .map((entry) => entry.trim())
+          // unquote "
+          .map((entry) => entry.startsWith('"') && entry.endsWith('"') ? entry.substring(1, entry.length - 1) : entry)
+          // unquote '
+          .map((entry) => entry.startsWith("'") && entry.endsWith("'") ? entry.substring(1, entry.length - 1) : entry)
+          // remove empty strings
+          .filter((entry) => entry)
+          // parse bundle:file
+          .map((entry) => entry.split(":"))
+          // normalize entry just in case
+          .flatMap((entry) => {
+          if (entry.length === 0)
+              return [];
+          let bundle = null;
+          let file = null;
+          if (entry.length === 1 && entry[0]) {
+              file = entry[0];
+              return [{ file, bundle }];
+          }
+          bundle = entry[0] || null;
+          file = entry.slice(1).join(":") || null;
+          return [{ bundle, file }];
+      }));
+  };
+  const useFilter = () => {
+      const [includeFilter, setIncludeFilter] = h("");
+      const [excludeFilter, setExcludeFilter] = h("");
+      const setIncludeFilterTrottled = F(() => throttleFilter(setIncludeFilter, 200), []);
+      const setExcludeFilterTrottled = F(() => throttleFilter(setExcludeFilter, 200), []);
+      const isIncluded = F(() => createFilter(prepareFilter(includeFilter), prepareFilter(excludeFilter)), [includeFilter, excludeFilter]);
+      const getModuleFilterMultiplier = T((bundleId, data) => {
+          return isIncluded(bundleId, data.id) ? 1 : 0;
+      }, [isIncluded]);
+      return {
+          getModuleFilterMultiplier,
+          includeFilter,
+          excludeFilter,
+          setExcludeFilter: setExcludeFilterTrottled,
+          setIncludeFilter: setIncludeFilterTrottled,
+      };
+  };
+
+  function ascending(a, b) {
+    return a == null || b == null ? NaN : a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
+  }
+
+  function descending(a, b) {
+    return a == null || b == null ? NaN
+      : b < a ? -1
+      : b > a ? 1
+      : b >= a ? 0
+      : NaN;
+  }
+
+  function bisector(f) {
+    let compare1, compare2, delta;
+
+    // If an accessor is specified, promote it to a comparator. In this case we
+    // can test whether the search value is (self-) comparable. We can’t do this
+    // for a comparator (except for specific, known comparators) because we can’t
+    // tell if the comparator is symmetric, and an asymmetric comparator can’t be
+    // used to test whether a single value is comparable.
+    if (f.length !== 2) {
+      compare1 = ascending;
+      compare2 = (d, x) => ascending(f(d), x);
+      delta = (d, x) => f(d) - x;
+    } else {
+      compare1 = f === ascending || f === descending ? f : zero$1;
+      compare2 = f;
+      delta = f;
+    }
+
+    function left(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) < 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function right(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) <= 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function center(a, x, lo = 0, hi = a.length) {
+      const i = left(a, x, lo, hi - 1);
+      return i > lo && delta(a[i - 1], x) > -delta(a[i], x) ? i - 1 : i;
+    }
+
+    return {left, center, right};
+  }
+
+  function zero$1() {
+    return 0;
+  }
+
+  function number$1(x) {
+    return x === null ? NaN : +x;
+  }
+
+  const ascendingBisect = bisector(ascending);
+  const bisectRight = ascendingBisect.right;
+  bisector(number$1).center;
+  var bisect = bisectRight;
+
+  class InternMap extends Map {
+    constructor(entries, key = keyof) {
+      super();
+      Object.defineProperties(this, {_intern: {value: new Map()}, _key: {value: key}});
+      if (entries != null) for (const [key, value] of entries) this.set(key, value);
+    }
+    get(key) {
+      return super.get(intern_get(this, key));
+    }
+    has(key) {
+      return super.has(intern_get(this, key));
+    }
+    set(key, value) {
+      return super.set(intern_set(this, key), value);
+    }
+    delete(key) {
+      return super.delete(intern_delete(this, key));
+    }
+  }
+
+  function intern_get({_intern, _key}, value) {
+    const key = _key(value);
+    return _intern.has(key) ? _intern.get(key) : value;
+  }
+
+  function intern_set({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) return _intern.get(key);
+    _intern.set(key, value);
+    return value;
+  }
+
+  function intern_delete({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) {
+      value = _intern.get(key);
+      _intern.delete(key);
+    }
+    return value;
+  }
+
+  function keyof(value) {
+    return value !== null && typeof value === "object" ? value.valueOf() : value;
+  }
+
+  function identity$2(x) {
+    return x;
+  }
+
+  function group(values, ...keys) {
+    return nest(values, identity$2, identity$2, keys);
+  }
+
+  function nest(values, map, reduce, keys) {
+    return (function regroup(values, i) {
+      if (i >= keys.length) return reduce(values);
+      const groups = new InternMap();
+      const keyof = keys[i++];
+      let index = -1;
+      for (const value of values) {
+        const key = keyof(value, ++index, values);
+        const group = groups.get(key);
+        if (group) group.push(value);
+        else groups.set(key, [value]);
+      }
+      for (const [key, values] of groups) {
+        groups.set(key, regroup(values, i));
+      }
+      return map(groups);
+    })(values, 0);
+  }
+
+  const e10 = Math.sqrt(50),
+      e5 = Math.sqrt(10),
+      e2 = Math.sqrt(2);
+
+  function tickSpec(start, stop, count) {
+    const step = (stop - start) / Math.max(0, count),
+        power = Math.floor(Math.log10(step)),
+        error = step / Math.pow(10, power),
+        factor = error >= e10 ? 10 : error >= e5 ? 5 : error >= e2 ? 2 : 1;
+    let i1, i2, inc;
+    if (power < 0) {
+      inc = Math.pow(10, -power) / factor;
+      i1 = Math.round(start * inc);
+      i2 = Math.round(stop * inc);
+      if (i1 / inc < start) ++i1;
+      if (i2 / inc > stop) --i2;
+      inc = -inc;
+    } else {
+      inc = Math.pow(10, power) * factor;
+      i1 = Math.round(start / inc);
+      i2 = Math.round(stop / inc);
+      if (i1 * inc < start) ++i1;
+      if (i2 * inc > stop) --i2;
+    }
+    if (i2 < i1 && 0.5 <= count && count < 2) return tickSpec(start, stop, count * 2);
+    return [i1, i2, inc];
+  }
+
+  function ticks(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    if (!(count > 0)) return [];
+    if (start === stop) return [start];
+    const reverse = stop < start, [i1, i2, inc] = reverse ? tickSpec(stop, start, count) : tickSpec(start, stop, count);
+    if (!(i2 >= i1)) return [];
+    const n = i2 - i1 + 1, ticks = new Array(n);
+    if (reverse) {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) * inc;
+    } else {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) * inc;
+    }
+    return ticks;
+  }
+
+  function tickIncrement(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    return tickSpec(start, stop, count)[2];
+  }
+
+  function tickStep(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    const reverse = stop < start, inc = reverse ? tickIncrement(stop, start, count) : tickIncrement(start, stop, count);
+    return (reverse ? -1 : 1) * (inc < 0 ? 1 / -inc : inc);
+  }
+
+  const TOP_PADDING = 20;
+  const PADDING = 2;
+
+  const Node = ({ node, onMouseOver, onClick, selected }) => {
+      const { getModuleColor } = q(StaticContext);
+      const { backgroundColor, fontColor } = getModuleColor(node);
+      const { x0, x1, y1, y0, data, children = null } = node;
+      const textRef = _(null);
+      const textRectRef = _();
+      const width = x1 - x0;
+      const height = y1 - y0;
+      const textProps = {
+          "font-size": "0.7em",
+          "dominant-baseline": "middle",
+          "text-anchor": "middle",
+          x: width / 2,
+      };
+      if (children != null) {
+          textProps.y = (TOP_PADDING + PADDING) / 2;
+      }
+      else {
+          textProps.y = height / 2;
+      }
+      y(() => {
+          if (width == 0 || height == 0 || !textRef.current) {
+              return;
+          }
+          if (textRectRef.current == null) {
+              textRectRef.current = textRef.current.getBoundingClientRect();
+          }
+          let scale = 1;
+          if (children != null) {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, Math.min(height, TOP_PADDING + PADDING) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(Math.min(TOP_PADDING + PADDING, height) / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          else {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, (height * 0.9) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(height / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          textRef.current.setAttribute("transform", `scale(${scale.toFixed(2)})`);
+      }, [children, height, width]);
+      if (width == 0 || height == 0) {
+          return null;
+      }
+      return (o$1("g", { className: "node", transform: `translate(${x0},${y0})`, onClick: (event) => {
+              event.stopPropagation();
+              onClick(node);
+          }, onMouseOver: (event) => {
+              event.stopPropagation();
+              onMouseOver(node);
+          }, children: [o$1("rect", { fill: backgroundColor, rx: 2, ry: 2, width: x1 - x0, height: y1 - y0, stroke: selected ? "#fff" : undefined, "stroke-width": selected ? 2 : undefined }), o$1("text", Object.assign({ ref: textRef, fill: fontColor, onClick: (event) => {
+                      var _a;
+                      if (((_a = window.getSelection()) === null || _a === void 0 ? void 0 : _a.toString()) !== "") {
+                          event.stopPropagation();
+                      }
+                  } }, textProps, { children: data.name }))] }));
+  };
+
+  const TreeMap = ({ root, onNodeHover, selectedNode, onNodeClick, }) => {
+      const { width, height, getModuleIds } = q(StaticContext);
+      console.time("layering");
+      // this will make groups by height
+      const nestedData = F(() => {
+          const nestedDataMap = group(root.descendants(), (d) => d.height);
+          const nestedData = Array.from(nestedDataMap, ([key, values]) => ({
+              key,
+              values,
+          }));
+          nestedData.sort((a, b) => b.key - a.key);
+          return nestedData;
+      }, [root]);
+      console.timeEnd("layering");
+      return (o$1("svg", { xmlns: "http://www.w3.org/2000/svg", viewBox: `0 0 ${width} ${height}`, children: nestedData.map(({ key, values }) => {
+              return (o$1("g", { className: "layer", children: values.map((node) => {
+                      return (o$1(Node, { node: node, onMouseOver: onNodeHover, selected: selectedNode === node, onClick: onNodeClick }, getModuleIds(node.data).nodeUid.id));
+                  }) }, key));
+          }) }));
+  };
+
+  var bytes$1 = {exports: {}};
+
+  /*!
+   * bytes
+   * Copyright(c) 2012-2014 TJ Holowaychuk
+   * Copyright(c) 2015 Jed Watson
+   * MIT Licensed
+   */
+
+  /**
+   * Module exports.
+   * @public
+   */
+
+  bytes$1.exports = bytes;
+  var format_1 = bytes$1.exports.format = format$1;
+  bytes$1.exports.parse = parse;
+
+  /**
+   * Module variables.
+   * @private
+   */
+
+  var formatThousandsRegExp = /\B(?=(\d{3})+(?!\d))/g;
+
+  var formatDecimalsRegExp = /(?:\.0*|(\.[^0]+)0+)$/;
+
+  var map$1 = {
+    b:  1,
+    kb: 1 << 10,
+    mb: 1 << 20,
+    gb: 1 << 30,
+    tb: Math.pow(1024, 4),
+    pb: Math.pow(1024, 5),
+  };
+
+  var parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
+
+  /**
+   * Convert the given value in bytes into a string or parse to string to an integer in bytes.
+   *
+   * @param {string|number} value
+   * @param {{
+   *  case: [string],
+   *  decimalPlaces: [number]
+   *  fixedDecimals: [boolean]
+   *  thousandsSeparator: [string]
+   *  unitSeparator: [string]
+   *  }} [options] bytes options.
+   *
+   * @returns {string|number|null}
+   */
+
+  function bytes(value, options) {
+    if (typeof value === 'string') {
+      return parse(value);
+    }
+
+    if (typeof value === 'number') {
+      return format$1(value, options);
+    }
+
+    return null;
+  }
+
+  /**
+   * Format the given value in bytes into a string.
+   *
+   * If the value is negative, it is kept as such. If it is a float,
+   * it is rounded.
+   *
+   * @param {number} value
+   * @param {object} [options]
+   * @param {number} [options.decimalPlaces=2]
+   * @param {number} [options.fixedDecimals=false]
+   * @param {string} [options.thousandsSeparator=]
+   * @param {string} [options.unit=]
+   * @param {string} [options.unitSeparator=]
+   *
+   * @returns {string|null}
+   * @public
+   */
+
+  function format$1(value, options) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    var mag = Math.abs(value);
+    var thousandsSeparator = (options && options.thousandsSeparator) || '';
+    var unitSeparator = (options && options.unitSeparator) || '';
+    var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
+    var fixedDecimals = Boolean(options && options.fixedDecimals);
+    var unit = (options && options.unit) || '';
+
+    if (!unit || !map$1[unit.toLowerCase()]) {
+      if (mag >= map$1.pb) {
+        unit = 'PB';
+      } else if (mag >= map$1.tb) {
+        unit = 'TB';
+      } else if (mag >= map$1.gb) {
+        unit = 'GB';
+      } else if (mag >= map$1.mb) {
+        unit = 'MB';
+      } else if (mag >= map$1.kb) {
+        unit = 'KB';
+      } else {
+        unit = 'B';
+      }
+    }
+
+    var val = value / map$1[unit.toLowerCase()];
+    var str = val.toFixed(decimalPlaces);
+
+    if (!fixedDecimals) {
+      str = str.replace(formatDecimalsRegExp, '$1');
+    }
+
+    if (thousandsSeparator) {
+      str = str.split('.').map(function (s, i) {
+        return i === 0
+          ? s.replace(formatThousandsRegExp, thousandsSeparator)
+          : s
+      }).join('.');
+    }
+
+    return str + unitSeparator + unit;
+  }
+
+  /**
+   * Parse the string value into an integer in bytes.
+   *
+   * If no unit is given, it is assumed the value is in bytes.
+   *
+   * @param {number|string} val
+   *
+   * @returns {number|null}
+   * @public
+   */
+
+  function parse(val) {
+    if (typeof val === 'number' && !isNaN(val)) {
+      return val;
+    }
+
+    if (typeof val !== 'string') {
+      return null;
+    }
+
+    // Test if the string passed is valid
+    var results = parseRegExp.exec(val);
+    var floatValue;
+    var unit = 'b';
+
+    if (!results) {
+      // Nothing could be extracted from the given string
+      floatValue = parseInt(val, 10);
+      unit = 'b';
+    } else {
+      // Retrieve the value and the unit
+      floatValue = parseFloat(results[1]);
+      unit = results[4].toLowerCase();
+    }
+
+    if (isNaN(floatValue)) {
+      return null;
+    }
+
+    return Math.floor(map$1[unit] * floatValue);
+  }
+
+  const Tooltip_marginX = 10;
+  const Tooltip_marginY = 30;
+  const SOURCEMAP_RENDERED = (o$1("span", { children: [" ", o$1("b", { children: LABELS.renderedLength }), " is a number of characters in the file after individual and ", o$1("br", {}), " ", "whole bundle transformations according to sourcemap."] }));
+  const RENDRED = (o$1("span", { children: [o$1("b", { children: LABELS.renderedLength }), " is a byte size of individual file after transformations and treeshake."] }));
+  const COMPRESSED = (o$1("span", { children: [o$1("b", { children: LABELS.gzipLength }), " and ", o$1("b", { children: LABELS.brotliLength }), " is a byte size of individual file after individual transformations,", o$1("br", {}), " treeshake and compression."] }));
+  const Tooltip = ({ node, visible, root, sizeProperty, }) => {
+      const { availableSizeProperties, getModuleSize, data } = q(StaticContext);
+      const ref = _(null);
+      const [style, setStyle] = h({});
+      const content = F(() => {
+          if (!node)
+              return null;
+          const mainSize = getModuleSize(node.data, sizeProperty);
+          const percentageNum = (100 * mainSize) / getModuleSize(root.data, sizeProperty);
+          const percentage = percentageNum.toFixed(2);
+          const percentageString = percentage + "%";
+          const path = node
+              .ancestors()
+              .reverse()
+              .map((d) => d.data.name)
+              .join("/");
+          let dataNode = null;
+          if (!isModuleTree(node.data)) {
+              const mainUid = data.nodeParts[node.data.uid].metaUid;
+              dataNode = data.nodeMetas[mainUid];
+          }
+          return (o$1(k$1, { children: [o$1("div", { children: path }), availableSizeProperties.map((sizeProp) => {
+                      if (sizeProp === sizeProperty) {
+                          return (o$1("div", { children: [o$1("b", { children: [LABELS[sizeProp], ": ", format_1(mainSize)] }), " ", "(", percentageString, ")"] }, sizeProp));
+                      }
+                      else {
+                          return (o$1("div", { children: [LABELS[sizeProp], ": ", format_1(getModuleSize(node.data, sizeProp))] }, sizeProp));
+                      }
+                  }), o$1("br", {}), dataNode && dataNode.importedBy.length > 0 && (o$1("div", { children: [o$1("div", { children: [o$1("b", { children: "Imported By" }), ":"] }), dataNode.importedBy.map(({ uid }) => {
+                              const id = data.nodeMetas[uid].id;
+                              return o$1("div", { children: id }, id);
+                          })] })), o$1("br", {}), o$1("small", { children: data.options.sourcemap ? SOURCEMAP_RENDERED : RENDRED }), (data.options.gzip || data.options.brotli) && (o$1(k$1, { children: [o$1("br", {}), o$1("small", { children: COMPRESSED })] }))] }));
+      }, [availableSizeProperties, data, getModuleSize, node, root.data, sizeProperty]);
+      const updatePosition = (mouseCoords) => {
+          if (!ref.current)
+              return;
+          const pos = {
+              left: mouseCoords.x + Tooltip_marginX,
+              top: mouseCoords.y + Tooltip_marginY,
+          };
+          const boundingRect = ref.current.getBoundingClientRect();
+          if (pos.left + boundingRect.width > window.innerWidth) {
+              // Shifting horizontally
+              pos.left = window.innerWidth - boundingRect.width;
+          }
+          if (pos.top + boundingRect.height > window.innerHeight) {
+              // Flipping vertically
+              pos.top = mouseCoords.y - Tooltip_marginY - boundingRect.height;
+          }
+          setStyle(pos);
+      };
+      p(() => {
+          const handleMouseMove = (event) => {
+              updatePosition({
+                  x: event.pageX,
+                  y: event.pageY,
+              });
+          };
+          document.addEventListener("mousemove", handleMouseMove, true);
+          return () => {
+              document.removeEventListener("mousemove", handleMouseMove, true);
+          };
+      }, []);
+      return (o$1("div", { className: `tooltip ${visible ? "" : "tooltip-hidden"}`, ref: ref, style: style, children: content }));
+  };
+
+  const Chart = ({ root, sizeProperty, selectedNode, setSelectedNode, }) => {
+      const [showTooltip, setShowTooltip] = h(false);
+      const [tooltipNode, setTooltipNode] = h(undefined);
+      p(() => {
+          const handleMouseOut = () => {
+              setShowTooltip(false);
+          };
+          document.addEventListener("mouseover", handleMouseOut);
+          return () => {
+              document.removeEventListener("mouseover", handleMouseOut);
+          };
+      }, []);
+      return (o$1(k$1, { children: [o$1(TreeMap, { root: root, onNodeHover: (node) => {
+                      setTooltipNode(node);
+                      setShowTooltip(true);
+                  }, selectedNode: selectedNode, onNodeClick: (node) => {
+                      setSelectedNode(selectedNode === node ? undefined : node);
+                  } }), o$1(Tooltip, { visible: showTooltip, node: tooltipNode, root: root, sizeProperty: sizeProperty })] }));
+  };
+
+  const Main = () => {
+      const { availableSizeProperties, rawHierarchy, getModuleSize, layout, data } = q(StaticContext);
+      const [sizeProperty, setSizeProperty] = h(availableSizeProperties[0]);
+      const [selectedNode, setSelectedNode] = h(undefined);
+      const { getModuleFilterMultiplier, setExcludeFilter, setIncludeFilter } = useFilter();
+      console.time("getNodeSizeMultiplier");
+      const getNodeSizeMultiplier = F(() => {
+          const selectedMultiplier = 1; // selectedSize < rootSize * increaseFactor ? (rootSize * increaseFactor) / selectedSize : rootSize / selectedSize;
+          const nonSelectedMultiplier = 0; // 1 / selectedMultiplier
+          if (selectedNode === undefined) {
+              return () => 1;
+          }
+          else if (isModuleTree(selectedNode.data)) {
+              const leaves = new Set(selectedNode.leaves().map((d) => d.data));
+              return (node) => {
+                  if (leaves.has(node)) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+          else {
+              return (node) => {
+                  if (node === selectedNode.data) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+      }, [getModuleSize, rawHierarchy.data, selectedNode, sizeProperty]);
+      console.timeEnd("getNodeSizeMultiplier");
+      console.time("root hierarchy compute");
+      // root here always be the same as rawHierarchy even after layouting
+      const root = F(() => {
+          const rootWithSizesAndSorted = rawHierarchy
+              .sum((node) => {
+              var _a;
+              if (isModuleTree(node))
+                  return 0;
+              const meta = data.nodeMetas[data.nodeParts[node.uid].metaUid];
+              const bundleId = (_a = Object.entries(meta.moduleParts).find(([bundleId, uid]) => uid == node.uid)) === null || _a === void 0 ? void 0 : _a[0];
+              const ownSize = getModuleSize(node, sizeProperty);
+              const zoomMultiplier = getNodeSizeMultiplier(node);
+              const filterMultiplier = getModuleFilterMultiplier(bundleId, meta);
+              return ownSize * zoomMultiplier * filterMultiplier;
+          })
+              .sort((a, b) => getModuleSize(a.data, sizeProperty) - getModuleSize(b.data, sizeProperty));
+          return layout(rootWithSizesAndSorted);
+      }, [
+          data,
+          getModuleFilterMultiplier,
+          getModuleSize,
+          getNodeSizeMultiplier,
+          layout,
+          rawHierarchy,
+          sizeProperty,
+      ]);
+      console.timeEnd("root hierarchy compute");
+      return (o$1(k$1, { children: [o$1(SideBar, { sizeProperty: sizeProperty, availableSizeProperties: availableSizeProperties, setSizeProperty: setSizeProperty, onExcludeChange: setExcludeFilter, onIncludeChange: setIncludeFilter }), o$1(Chart, { root: root, sizeProperty: sizeProperty, selectedNode: selectedNode, setSelectedNode: setSelectedNode })] }));
+  };
+
+  function initRange(domain, range) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: this.range(domain); break;
+      default: this.range(range).domain(domain); break;
+    }
+    return this;
+  }
+
+  function initInterpolator(domain, interpolator) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: {
+        if (typeof domain === "function") this.interpolator(domain);
+        else this.range(domain);
+        break;
+      }
+      default: {
+        this.domain(domain);
+        if (typeof interpolator === "function") this.interpolator(interpolator);
+        else this.range(interpolator);
+        break;
+      }
+    }
+    return this;
+  }
+
+  function define(constructor, factory, prototype) {
+    constructor.prototype = factory.prototype = prototype;
+    prototype.constructor = constructor;
+  }
+
+  function extend(parent, definition) {
+    var prototype = Object.create(parent.prototype);
+    for (var key in definition) prototype[key] = definition[key];
+    return prototype;
+  }
+
+  function Color() {}
+
+  var darker = 0.7;
+  var brighter = 1 / darker;
+
+  var reI = "\\s*([+-]?\\d+)\\s*",
+      reN = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*",
+      reP = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*",
+      reHex = /^#([0-9a-f]{3,8})$/,
+      reRgbInteger = new RegExp(`^rgb\\(${reI},${reI},${reI}\\)$`),
+      reRgbPercent = new RegExp(`^rgb\\(${reP},${reP},${reP}\\)$`),
+      reRgbaInteger = new RegExp(`^rgba\\(${reI},${reI},${reI},${reN}\\)$`),
+      reRgbaPercent = new RegExp(`^rgba\\(${reP},${reP},${reP},${reN}\\)$`),
+      reHslPercent = new RegExp(`^hsl\\(${reN},${reP},${reP}\\)$`),
+      reHslaPercent = new RegExp(`^hsla\\(${reN},${reP},${reP},${reN}\\)$`);
+
+  var named = {
+    aliceblue: 0xf0f8ff,
+    antiquewhite: 0xfaebd7,
+    aqua: 0x00ffff,
+    aquamarine: 0x7fffd4,
+    azure: 0xf0ffff,
+    beige: 0xf5f5dc,
+    bisque: 0xffe4c4,
+    black: 0x000000,
+    blanchedalmond: 0xffebcd,
+    blue: 0x0000ff,
+    blueviolet: 0x8a2be2,
+    brown: 0xa52a2a,
+    burlywood: 0xdeb887,
+    cadetblue: 0x5f9ea0,
+    chartreuse: 0x7fff00,
+    chocolate: 0xd2691e,
+    coral: 0xff7f50,
+    cornflowerblue: 0x6495ed,
+    cornsilk: 0xfff8dc,
+    crimson: 0xdc143c,
+    cyan: 0x00ffff,
+    darkblue: 0x00008b,
+    darkcyan: 0x008b8b,
+    darkgoldenrod: 0xb8860b,
+    darkgray: 0xa9a9a9,
+    darkgreen: 0x006400,
+    darkgrey: 0xa9a9a9,
+    darkkhaki: 0xbdb76b,
+    darkmagenta: 0x8b008b,
+    darkolivegreen: 0x556b2f,
+    darkorange: 0xff8c00,
+    darkorchid: 0x9932cc,
+    darkred: 0x8b0000,
+    darksalmon: 0xe9967a,
+    darkseagreen: 0x8fbc8f,
+    darkslateblue: 0x483d8b,
+    darkslategray: 0x2f4f4f,
+    darkslategrey: 0x2f4f4f,
+    darkturquoise: 0x00ced1,
+    darkviolet: 0x9400d3,
+    deeppink: 0xff1493,
+    deepskyblue: 0x00bfff,
+    dimgray: 0x696969,
+    dimgrey: 0x696969,
+    dodgerblue: 0x1e90ff,
+    firebrick: 0xb22222,
+    floralwhite: 0xfffaf0,
+    forestgreen: 0x228b22,
+    fuchsia: 0xff00ff,
+    gainsboro: 0xdcdcdc,
+    ghostwhite: 0xf8f8ff,
+    gold: 0xffd700,
+    goldenrod: 0xdaa520,
+    gray: 0x808080,
+    green: 0x008000,
+    greenyellow: 0xadff2f,
+    grey: 0x808080,
+    honeydew: 0xf0fff0,
+    hotpink: 0xff69b4,
+    indianred: 0xcd5c5c,
+    indigo: 0x4b0082,
+    ivory: 0xfffff0,
+    khaki: 0xf0e68c,
+    lavender: 0xe6e6fa,
+    lavenderblush: 0xfff0f5,
+    lawngreen: 0x7cfc00,
+    lemonchiffon: 0xfffacd,
+    lightblue: 0xadd8e6,
+    lightcoral: 0xf08080,
+    lightcyan: 0xe0ffff,
+    lightgoldenrodyellow: 0xfafad2,
+    lightgray: 0xd3d3d3,
+    lightgreen: 0x90ee90,
+    lightgrey: 0xd3d3d3,
+    lightpink: 0xffb6c1,
+    lightsalmon: 0xffa07a,
+    lightseagreen: 0x20b2aa,
+    lightskyblue: 0x87cefa,
+    lightslategray: 0x778899,
+    lightslategrey: 0x778899,
+    lightsteelblue: 0xb0c4de,
+    lightyellow: 0xffffe0,
+    lime: 0x00ff00,
+    limegreen: 0x32cd32,
+    linen: 0xfaf0e6,
+    magenta: 0xff00ff,
+    maroon: 0x800000,
+    mediumaquamarine: 0x66cdaa,
+    mediumblue: 0x0000cd,
+    mediumorchid: 0xba55d3,
+    mediumpurple: 0x9370db,
+    mediumseagreen: 0x3cb371,
+    mediumslateblue: 0x7b68ee,
+    mediumspringgreen: 0x00fa9a,
+    mediumturquoise: 0x48d1cc,
+    mediumvioletred: 0xc71585,
+    midnightblue: 0x191970,
+    mintcream: 0xf5fffa,
+    mistyrose: 0xffe4e1,
+    moccasin: 0xffe4b5,
+    navajowhite: 0xffdead,
+    navy: 0x000080,
+    oldlace: 0xfdf5e6,
+    olive: 0x808000,
+    olivedrab: 0x6b8e23,
+    orange: 0xffa500,
+    orangered: 0xff4500,
+    orchid: 0xda70d6,
+    palegoldenrod: 0xeee8aa,
+    palegreen: 0x98fb98,
+    paleturquoise: 0xafeeee,
+    palevioletred: 0xdb7093,
+    papayawhip: 0xffefd5,
+    peachpuff: 0xffdab9,
+    peru: 0xcd853f,
+    pink: 0xffc0cb,
+    plum: 0xdda0dd,
+    powderblue: 0xb0e0e6,
+    purple: 0x800080,
+    rebeccapurple: 0x663399,
+    red: 0xff0000,
+    rosybrown: 0xbc8f8f,
+    royalblue: 0x4169e1,
+    saddlebrown: 0x8b4513,
+    salmon: 0xfa8072,
+    sandybrown: 0xf4a460,
+    seagreen: 0x2e8b57,
+    seashell: 0xfff5ee,
+    sienna: 0xa0522d,
+    silver: 0xc0c0c0,
+    skyblue: 0x87ceeb,
+    slateblue: 0x6a5acd,
+    slategray: 0x708090,
+    slategrey: 0x708090,
+    snow: 0xfffafa,
+    springgreen: 0x00ff7f,
+    steelblue: 0x4682b4,
+    tan: 0xd2b48c,
+    teal: 0x008080,
+    thistle: 0xd8bfd8,
+    tomato: 0xff6347,
+    turquoise: 0x40e0d0,
+    violet: 0xee82ee,
+    wheat: 0xf5deb3,
+    white: 0xffffff,
+    whitesmoke: 0xf5f5f5,
+    yellow: 0xffff00,
+    yellowgreen: 0x9acd32
+  };
+
+  define(Color, color, {
+    copy(channels) {
+      return Object.assign(new this.constructor, this, channels);
+    },
+    displayable() {
+      return this.rgb().displayable();
+    },
+    hex: color_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: color_formatHex,
+    formatHex8: color_formatHex8,
+    formatHsl: color_formatHsl,
+    formatRgb: color_formatRgb,
+    toString: color_formatRgb
+  });
+
+  function color_formatHex() {
+    return this.rgb().formatHex();
+  }
+
+  function color_formatHex8() {
+    return this.rgb().formatHex8();
+  }
+
+  function color_formatHsl() {
+    return hslConvert(this).formatHsl();
+  }
+
+  function color_formatRgb() {
+    return this.rgb().formatRgb();
+  }
+
+  function color(format) {
+    var m, l;
+    format = (format + "").trim().toLowerCase();
+    return (m = reHex.exec(format)) ? (l = m[1].length, m = parseInt(m[1], 16), l === 6 ? rgbn(m) // #ff0000
+        : l === 3 ? new Rgb((m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), ((m & 0xf) << 4) | (m & 0xf), 1) // #f00
+        : l === 8 ? rgba(m >> 24 & 0xff, m >> 16 & 0xff, m >> 8 & 0xff, (m & 0xff) / 0xff) // #ff000000
+        : l === 4 ? rgba((m >> 12 & 0xf) | (m >> 8 & 0xf0), (m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), (((m & 0xf) << 4) | (m & 0xf)) / 0xff) // #f000
+        : null) // invalid hex
+        : (m = reRgbInteger.exec(format)) ? new Rgb(m[1], m[2], m[3], 1) // rgb(255, 0, 0)
+        : (m = reRgbPercent.exec(format)) ? new Rgb(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, 1) // rgb(100%, 0%, 0%)
+        : (m = reRgbaInteger.exec(format)) ? rgba(m[1], m[2], m[3], m[4]) // rgba(255, 0, 0, 1)
+        : (m = reRgbaPercent.exec(format)) ? rgba(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, m[4]) // rgb(100%, 0%, 0%, 1)
+        : (m = reHslPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, 1) // hsl(120, 50%, 50%)
+        : (m = reHslaPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, m[4]) // hsla(120, 50%, 50%, 1)
+        : named.hasOwnProperty(format) ? rgbn(named[format]) // eslint-disable-line no-prototype-builtins
+        : format === "transparent" ? new Rgb(NaN, NaN, NaN, 0)
+        : null;
+  }
+
+  function rgbn(n) {
+    return new Rgb(n >> 16 & 0xff, n >> 8 & 0xff, n & 0xff, 1);
+  }
+
+  function rgba(r, g, b, a) {
+    if (a <= 0) r = g = b = NaN;
+    return new Rgb(r, g, b, a);
+  }
+
+  function rgbConvert(o) {
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Rgb;
+    o = o.rgb();
+    return new Rgb(o.r, o.g, o.b, o.opacity);
+  }
+
+  function rgb$1(r, g, b, opacity) {
+    return arguments.length === 1 ? rgbConvert(r) : new Rgb(r, g, b, opacity == null ? 1 : opacity);
+  }
+
+  function Rgb(r, g, b, opacity) {
+    this.r = +r;
+    this.g = +g;
+    this.b = +b;
+    this.opacity = +opacity;
+  }
+
+  define(Rgb, rgb$1, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    rgb() {
+      return this;
+    },
+    clamp() {
+      return new Rgb(clampi(this.r), clampi(this.g), clampi(this.b), clampa(this.opacity));
+    },
+    displayable() {
+      return (-0.5 <= this.r && this.r < 255.5)
+          && (-0.5 <= this.g && this.g < 255.5)
+          && (-0.5 <= this.b && this.b < 255.5)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    hex: rgb_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: rgb_formatHex,
+    formatHex8: rgb_formatHex8,
+    formatRgb: rgb_formatRgb,
+    toString: rgb_formatRgb
+  }));
+
+  function rgb_formatHex() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}`;
+  }
+
+  function rgb_formatHex8() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}${hex((isNaN(this.opacity) ? 1 : this.opacity) * 255)}`;
+  }
+
+  function rgb_formatRgb() {
+    const a = clampa(this.opacity);
+    return `${a === 1 ? "rgb(" : "rgba("}${clampi(this.r)}, ${clampi(this.g)}, ${clampi(this.b)}${a === 1 ? ")" : `, ${a})`}`;
+  }
+
+  function clampa(opacity) {
+    return isNaN(opacity) ? 1 : Math.max(0, Math.min(1, opacity));
+  }
+
+  function clampi(value) {
+    return Math.max(0, Math.min(255, Math.round(value) || 0));
+  }
+
+  function hex(value) {
+    value = clampi(value);
+    return (value < 16 ? "0" : "") + value.toString(16);
+  }
+
+  function hsla(h, s, l, a) {
+    if (a <= 0) h = s = l = NaN;
+    else if (l <= 0 || l >= 1) h = s = NaN;
+    else if (s <= 0) h = NaN;
+    return new Hsl(h, s, l, a);
+  }
+
+  function hslConvert(o) {
+    if (o instanceof Hsl) return new Hsl(o.h, o.s, o.l, o.opacity);
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Hsl;
+    if (o instanceof Hsl) return o;
+    o = o.rgb();
+    var r = o.r / 255,
+        g = o.g / 255,
+        b = o.b / 255,
+        min = Math.min(r, g, b),
+        max = Math.max(r, g, b),
+        h = NaN,
+        s = max - min,
+        l = (max + min) / 2;
+    if (s) {
+      if (r === max) h = (g - b) / s + (g < b) * 6;
+      else if (g === max) h = (b - r) / s + 2;
+      else h = (r - g) / s + 4;
+      s /= l < 0.5 ? max + min : 2 - max - min;
+      h *= 60;
+    } else {
+      s = l > 0 && l < 1 ? 0 : h;
+    }
+    return new Hsl(h, s, l, o.opacity);
+  }
+
+  function hsl(h, s, l, opacity) {
+    return arguments.length === 1 ? hslConvert(h) : new Hsl(h, s, l, opacity == null ? 1 : opacity);
+  }
+
+  function Hsl(h, s, l, opacity) {
+    this.h = +h;
+    this.s = +s;
+    this.l = +l;
+    this.opacity = +opacity;
+  }
+
+  define(Hsl, hsl, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    rgb() {
+      var h = this.h % 360 + (this.h < 0) * 360,
+          s = isNaN(h) || isNaN(this.s) ? 0 : this.s,
+          l = this.l,
+          m2 = l + (l < 0.5 ? l : 1 - l) * s,
+          m1 = 2 * l - m2;
+      return new Rgb(
+        hsl2rgb(h >= 240 ? h - 240 : h + 120, m1, m2),
+        hsl2rgb(h, m1, m2),
+        hsl2rgb(h < 120 ? h + 240 : h - 120, m1, m2),
+        this.opacity
+      );
+    },
+    clamp() {
+      return new Hsl(clamph(this.h), clampt(this.s), clampt(this.l), clampa(this.opacity));
+    },
+    displayable() {
+      return (0 <= this.s && this.s <= 1 || isNaN(this.s))
+          && (0 <= this.l && this.l <= 1)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    formatHsl() {
+      const a = clampa(this.opacity);
+      return `${a === 1 ? "hsl(" : "hsla("}${clamph(this.h)}, ${clampt(this.s) * 100}%, ${clampt(this.l) * 100}%${a === 1 ? ")" : `, ${a})`}`;
+    }
+  }));
+
+  function clamph(value) {
+    value = (value || 0) % 360;
+    return value < 0 ? value + 360 : value;
+  }
+
+  function clampt(value) {
+    return Math.max(0, Math.min(1, value || 0));
+  }
+
+  /* From FvD 13.37, CSS Color Module Level 3 */
+  function hsl2rgb(h, m1, m2) {
+    return (h < 60 ? m1 + (m2 - m1) * h / 60
+        : h < 180 ? m2
+        : h < 240 ? m1 + (m2 - m1) * (240 - h) / 60
+        : m1) * 255;
+  }
+
+  var constant = x => () => x;
+
+  function linear$1(a, d) {
+    return function(t) {
+      return a + t * d;
+    };
+  }
+
+  function exponential(a, b, y) {
+    return a = Math.pow(a, y), b = Math.pow(b, y) - a, y = 1 / y, function(t) {
+      return Math.pow(a + t * b, y);
+    };
+  }
+
+  function gamma(y) {
+    return (y = +y) === 1 ? nogamma : function(a, b) {
+      return b - a ? exponential(a, b, y) : constant(isNaN(a) ? b : a);
+    };
+  }
+
+  function nogamma(a, b) {
+    var d = b - a;
+    return d ? linear$1(a, d) : constant(isNaN(a) ? b : a);
+  }
+
+  var rgb = (function rgbGamma(y) {
+    var color = gamma(y);
+
+    function rgb(start, end) {
+      var r = color((start = rgb$1(start)).r, (end = rgb$1(end)).r),
+          g = color(start.g, end.g),
+          b = color(start.b, end.b),
+          opacity = nogamma(start.opacity, end.opacity);
+      return function(t) {
+        start.r = r(t);
+        start.g = g(t);
+        start.b = b(t);
+        start.opacity = opacity(t);
+        return start + "";
+      };
+    }
+
+    rgb.gamma = rgbGamma;
+
+    return rgb;
+  })(1);
+
+  function numberArray(a, b) {
+    if (!b) b = [];
+    var n = a ? Math.min(b.length, a.length) : 0,
+        c = b.slice(),
+        i;
+    return function(t) {
+      for (i = 0; i < n; ++i) c[i] = a[i] * (1 - t) + b[i] * t;
+      return c;
+    };
+  }
+
+  function isNumberArray(x) {
+    return ArrayBuffer.isView(x) && !(x instanceof DataView);
+  }
+
+  function genericArray(a, b) {
+    var nb = b ? b.length : 0,
+        na = a ? Math.min(nb, a.length) : 0,
+        x = new Array(na),
+        c = new Array(nb),
+        i;
+
+    for (i = 0; i < na; ++i) x[i] = interpolate(a[i], b[i]);
+    for (; i < nb; ++i) c[i] = b[i];
+
+    return function(t) {
+      for (i = 0; i < na; ++i) c[i] = x[i](t);
+      return c;
+    };
+  }
+
+  function date(a, b) {
+    var d = new Date;
+    return a = +a, b = +b, function(t) {
+      return d.setTime(a * (1 - t) + b * t), d;
+    };
+  }
+
+  function interpolateNumber(a, b) {
+    return a = +a, b = +b, function(t) {
+      return a * (1 - t) + b * t;
+    };
+  }
+
+  function object(a, b) {
+    var i = {},
+        c = {},
+        k;
+
+    if (a === null || typeof a !== "object") a = {};
+    if (b === null || typeof b !== "object") b = {};
+
+    for (k in b) {
+      if (k in a) {
+        i[k] = interpolate(a[k], b[k]);
+      } else {
+        c[k] = b[k];
+      }
+    }
+
+    return function(t) {
+      for (k in i) c[k] = i[k](t);
+      return c;
+    };
+  }
+
+  var reA = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g,
+      reB = new RegExp(reA.source, "g");
+
+  function zero(b) {
+    return function() {
+      return b;
+    };
+  }
+
+  function one(b) {
+    return function(t) {
+      return b(t) + "";
+    };
+  }
+
+  function string(a, b) {
+    var bi = reA.lastIndex = reB.lastIndex = 0, // scan index for next number in b
+        am, // current match in a
+        bm, // current match in b
+        bs, // string preceding current number in b, if any
+        i = -1, // index in s
+        s = [], // string constants and placeholders
+        q = []; // number interpolators
+
+    // Coerce inputs to strings.
+    a = a + "", b = b + "";
+
+    // Interpolate pairs of numbers in a & b.
+    while ((am = reA.exec(a))
+        && (bm = reB.exec(b))) {
+      if ((bs = bm.index) > bi) { // a string precedes the next number in b
+        bs = b.slice(bi, bs);
+        if (s[i]) s[i] += bs; // coalesce with previous string
+        else s[++i] = bs;
+      }
+      if ((am = am[0]) === (bm = bm[0])) { // numbers in a & b match
+        if (s[i]) s[i] += bm; // coalesce with previous string
+        else s[++i] = bm;
+      } else { // interpolate non-matching numbers
+        s[++i] = null;
+        q.push({i: i, x: interpolateNumber(am, bm)});
+      }
+      bi = reB.lastIndex;
+    }
+
+    // Add remains of b.
+    if (bi < b.length) {
+      bs = b.slice(bi);
+      if (s[i]) s[i] += bs; // coalesce with previous string
+      else s[++i] = bs;
+    }
+
+    // Special optimization for only a single match.
+    // Otherwise, interpolate each of the numbers and rejoin the string.
+    return s.length < 2 ? (q[0]
+        ? one(q[0].x)
+        : zero(b))
+        : (b = q.length, function(t) {
+            for (var i = 0, o; i < b; ++i) s[(o = q[i]).i] = o.x(t);
+            return s.join("");
+          });
+  }
+
+  function interpolate(a, b) {
+    var t = typeof b, c;
+    return b == null || t === "boolean" ? constant(b)
+        : (t === "number" ? interpolateNumber
+        : t === "string" ? ((c = color(b)) ? (b = c, rgb) : string)
+        : b instanceof color ? rgb
+        : b instanceof Date ? date
+        : isNumberArray(b) ? numberArray
+        : Array.isArray(b) ? genericArray
+        : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
+        : interpolateNumber)(a, b);
+  }
+
+  function interpolateRound(a, b) {
+    return a = +a, b = +b, function(t) {
+      return Math.round(a * (1 - t) + b * t);
+    };
+  }
+
+  function constants(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function number(x) {
+    return +x;
+  }
+
+  var unit = [0, 1];
+
+  function identity$1(x) {
+    return x;
+  }
+
+  function normalize(a, b) {
+    return (b -= (a = +a))
+        ? function(x) { return (x - a) / b; }
+        : constants(isNaN(b) ? NaN : 0.5);
+  }
+
+  function clamper(a, b) {
+    var t;
+    if (a > b) t = a, a = b, b = t;
+    return function(x) { return Math.max(a, Math.min(b, x)); };
+  }
+
+  // normalize(a, b)(x) takes a domain value x in [a,b] and returns the corresponding parameter t in [0,1].
+  // interpolate(a, b)(t) takes a parameter t in [0,1] and returns the corresponding range value x in [a,b].
+  function bimap(domain, range, interpolate) {
+    var d0 = domain[0], d1 = domain[1], r0 = range[0], r1 = range[1];
+    if (d1 < d0) d0 = normalize(d1, d0), r0 = interpolate(r1, r0);
+    else d0 = normalize(d0, d1), r0 = interpolate(r0, r1);
+    return function(x) { return r0(d0(x)); };
+  }
+
+  function polymap(domain, range, interpolate) {
+    var j = Math.min(domain.length, range.length) - 1,
+        d = new Array(j),
+        r = new Array(j),
+        i = -1;
+
+    // Reverse descending domains.
+    if (domain[j] < domain[0]) {
+      domain = domain.slice().reverse();
+      range = range.slice().reverse();
+    }
+
+    while (++i < j) {
+      d[i] = normalize(domain[i], domain[i + 1]);
+      r[i] = interpolate(range[i], range[i + 1]);
+    }
+
+    return function(x) {
+      var i = bisect(domain, x, 1, j) - 1;
+      return r[i](d[i](x));
+    };
+  }
+
+  function copy$1(source, target) {
+    return target
+        .domain(source.domain())
+        .range(source.range())
+        .interpolate(source.interpolate())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function transformer$1() {
+    var domain = unit,
+        range = unit,
+        interpolate$1 = interpolate,
+        transform,
+        untransform,
+        unknown,
+        clamp = identity$1,
+        piecewise,
+        output,
+        input;
+
+    function rescale() {
+      var n = Math.min(domain.length, range.length);
+      if (clamp !== identity$1) clamp = clamper(domain[0], domain[n - 1]);
+      piecewise = n > 2 ? polymap : bimap;
+      output = input = null;
+      return scale;
+    }
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : (output || (output = piecewise(domain.map(transform), range, interpolate$1)))(transform(clamp(x)));
+    }
+
+    scale.invert = function(y) {
+      return clamp(untransform((input || (input = piecewise(range, domain.map(transform), interpolateNumber)))(y)));
+    };
+
+    scale.domain = function(_) {
+      return arguments.length ? (domain = Array.from(_, number), rescale()) : domain.slice();
+    };
+
+    scale.range = function(_) {
+      return arguments.length ? (range = Array.from(_), rescale()) : range.slice();
+    };
+
+    scale.rangeRound = function(_) {
+      return range = Array.from(_), interpolate$1 = interpolateRound, rescale();
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = _ ? true : identity$1, rescale()) : clamp !== identity$1;
+    };
+
+    scale.interpolate = function(_) {
+      return arguments.length ? (interpolate$1 = _, rescale()) : interpolate$1;
+    };
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t, u) {
+      transform = t, untransform = u;
+      return rescale();
+    };
+  }
+
+  function continuous() {
+    return transformer$1()(identity$1, identity$1);
+  }
+
+  function formatDecimal(x) {
+    return Math.abs(x = Math.round(x)) >= 1e21
+        ? x.toLocaleString("en").replace(/,/g, "")
+        : x.toString(10);
+  }
+
+  // Computes the decimal coefficient and exponent of the specified number x with
+  // significant digits p, where x is positive and p is in [1, 21] or undefined.
+  // For example, formatDecimalParts(1.23) returns ["123", 0].
+  function formatDecimalParts(x, p) {
+    if ((i = (x = p ? x.toExponential(p - 1) : x.toExponential()).indexOf("e")) < 0) return null; // NaN, ±Infinity
+    var i, coefficient = x.slice(0, i);
+
+    // The string returned by toExponential either has the form \d\.\d+e[-+]\d+
+    // (e.g., 1.2e+3) or the form \de[-+]\d+ (e.g., 1e+3).
+    return [
+      coefficient.length > 1 ? coefficient[0] + coefficient.slice(2) : coefficient,
+      +x.slice(i + 1)
+    ];
+  }
+
+  function exponent(x) {
+    return x = formatDecimalParts(Math.abs(x)), x ? x[1] : NaN;
+  }
+
+  function formatGroup(grouping, thousands) {
+    return function(value, width) {
+      var i = value.length,
+          t = [],
+          j = 0,
+          g = grouping[0],
+          length = 0;
+
+      while (i > 0 && g > 0) {
+        if (length + g + 1 > width) g = Math.max(1, width - length);
+        t.push(value.substring(i -= g, i + g));
+        if ((length += g + 1) > width) break;
+        g = grouping[j = (j + 1) % grouping.length];
+      }
+
+      return t.reverse().join(thousands);
+    };
+  }
+
+  function formatNumerals(numerals) {
+    return function(value) {
+      return value.replace(/[0-9]/g, function(i) {
+        return numerals[+i];
+      });
+    };
+  }
+
+  // [[fill]align][sign][symbol][0][width][,][.precision][~][type]
+  var re = /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
+
+  function formatSpecifier(specifier) {
+    if (!(match = re.exec(specifier))) throw new Error("invalid format: " + specifier);
+    var match;
+    return new FormatSpecifier({
+      fill: match[1],
+      align: match[2],
+      sign: match[3],
+      symbol: match[4],
+      zero: match[5],
+      width: match[6],
+      comma: match[7],
+      precision: match[8] && match[8].slice(1),
+      trim: match[9],
+      type: match[10]
+    });
+  }
+
+  formatSpecifier.prototype = FormatSpecifier.prototype; // instanceof
+
+  function FormatSpecifier(specifier) {
+    this.fill = specifier.fill === undefined ? " " : specifier.fill + "";
+    this.align = specifier.align === undefined ? ">" : specifier.align + "";
+    this.sign = specifier.sign === undefined ? "-" : specifier.sign + "";
+    this.symbol = specifier.symbol === undefined ? "" : specifier.symbol + "";
+    this.zero = !!specifier.zero;
+    this.width = specifier.width === undefined ? undefined : +specifier.width;
+    this.comma = !!specifier.comma;
+    this.precision = specifier.precision === undefined ? undefined : +specifier.precision;
+    this.trim = !!specifier.trim;
+    this.type = specifier.type === undefined ? "" : specifier.type + "";
+  }
+
+  FormatSpecifier.prototype.toString = function() {
+    return this.fill
+        + this.align
+        + this.sign
+        + this.symbol
+        + (this.zero ? "0" : "")
+        + (this.width === undefined ? "" : Math.max(1, this.width | 0))
+        + (this.comma ? "," : "")
+        + (this.precision === undefined ? "" : "." + Math.max(0, this.precision | 0))
+        + (this.trim ? "~" : "")
+        + this.type;
+  };
+
+  // Trims insignificant zeros, e.g., replaces 1.2000k with 1.2k.
+  function formatTrim(s) {
+    out: for (var n = s.length, i = 1, i0 = -1, i1; i < n; ++i) {
+      switch (s[i]) {
+        case ".": i0 = i1 = i; break;
+        case "0": if (i0 === 0) i0 = i; i1 = i; break;
+        default: if (!+s[i]) break out; if (i0 > 0) i0 = 0; break;
+      }
+    }
+    return i0 > 0 ? s.slice(0, i0) + s.slice(i1 + 1) : s;
+  }
+
+  var prefixExponent;
+
+  function formatPrefixAuto(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1],
+        i = exponent - (prefixExponent = Math.max(-8, Math.min(8, Math.floor(exponent / 3))) * 3) + 1,
+        n = coefficient.length;
+    return i === n ? coefficient
+        : i > n ? coefficient + new Array(i - n + 1).join("0")
+        : i > 0 ? coefficient.slice(0, i) + "." + coefficient.slice(i)
+        : "0." + new Array(1 - i).join("0") + formatDecimalParts(x, Math.max(0, p + i - 1))[0]; // less than 1y!
+  }
+
+  function formatRounded(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1];
+    return exponent < 0 ? "0." + new Array(-exponent).join("0") + coefficient
+        : coefficient.length > exponent + 1 ? coefficient.slice(0, exponent + 1) + "." + coefficient.slice(exponent + 1)
+        : coefficient + new Array(exponent - coefficient.length + 2).join("0");
+  }
+
+  var formatTypes = {
+    "%": (x, p) => (x * 100).toFixed(p),
+    "b": (x) => Math.round(x).toString(2),
+    "c": (x) => x + "",
+    "d": formatDecimal,
+    "e": (x, p) => x.toExponential(p),
+    "f": (x, p) => x.toFixed(p),
+    "g": (x, p) => x.toPrecision(p),
+    "o": (x) => Math.round(x).toString(8),
+    "p": (x, p) => formatRounded(x * 100, p),
+    "r": formatRounded,
+    "s": formatPrefixAuto,
+    "X": (x) => Math.round(x).toString(16).toUpperCase(),
+    "x": (x) => Math.round(x).toString(16)
+  };
+
+  function identity(x) {
+    return x;
+  }
+
+  var map = Array.prototype.map,
+      prefixes = ["y","z","a","f","p","n","µ","m","","k","M","G","T","P","E","Z","Y"];
+
+  function formatLocale(locale) {
+    var group = locale.grouping === undefined || locale.thousands === undefined ? identity : formatGroup(map.call(locale.grouping, Number), locale.thousands + ""),
+        currencyPrefix = locale.currency === undefined ? "" : locale.currency[0] + "",
+        currencySuffix = locale.currency === undefined ? "" : locale.currency[1] + "",
+        decimal = locale.decimal === undefined ? "." : locale.decimal + "",
+        numerals = locale.numerals === undefined ? identity : formatNumerals(map.call(locale.numerals, String)),
+        percent = locale.percent === undefined ? "%" : locale.percent + "",
+        minus = locale.minus === undefined ? "−" : locale.minus + "",
+        nan = locale.nan === undefined ? "NaN" : locale.nan + "";
+
+    function newFormat(specifier) {
+      specifier = formatSpecifier(specifier);
+
+      var fill = specifier.fill,
+          align = specifier.align,
+          sign = specifier.sign,
+          symbol = specifier.symbol,
+          zero = specifier.zero,
+          width = specifier.width,
+          comma = specifier.comma,
+          precision = specifier.precision,
+          trim = specifier.trim,
+          type = specifier.type;
+
+      // The "n" type is an alias for ",g".
+      if (type === "n") comma = true, type = "g";
+
+      // The "" type, and any invalid type, is an alias for ".12~g".
+      else if (!formatTypes[type]) precision === undefined && (precision = 12), trim = true, type = "g";
+
+      // If zero fill is specified, padding goes after sign and before digits.
+      if (zero || (fill === "0" && align === "=")) zero = true, fill = "0", align = "=";
+
+      // Compute the prefix and suffix.
+      // For SI-prefix, the suffix is lazily computed.
+      var prefix = symbol === "$" ? currencyPrefix : symbol === "#" && /[boxX]/.test(type) ? "0" + type.toLowerCase() : "",
+          suffix = symbol === "$" ? currencySuffix : /[%p]/.test(type) ? percent : "";
+
+      // What format function should we use?
+      // Is this an integer type?
+      // Can this type generate exponential notation?
+      var formatType = formatTypes[type],
+          maybeSuffix = /[defgprs%]/.test(type);
+
+      // Set the default precision if not specified,
+      // or clamp the specified precision to the supported range.
+      // For significant precision, it must be in [1, 21].
+      // For fixed precision, it must be in [0, 20].
+      precision = precision === undefined ? 6
+          : /[gprs]/.test(type) ? Math.max(1, Math.min(21, precision))
+          : Math.max(0, Math.min(20, precision));
+
+      function format(value) {
+        var valuePrefix = prefix,
+            valueSuffix = suffix,
+            i, n, c;
+
+        if (type === "c") {
+          valueSuffix = formatType(value) + valueSuffix;
+          value = "";
+        } else {
+          value = +value;
+
+          // Determine the sign. -0 is not less than 0, but 1 / -0 is!
+          var valueNegative = value < 0 || 1 / value < 0;
+
+          // Perform the initial formatting.
+          value = isNaN(value) ? nan : formatType(Math.abs(value), precision);
+
+          // Trim insignificant zeros.
+          if (trim) value = formatTrim(value);
+
+          // If a negative value rounds to zero after formatting, and no explicit positive sign is requested, hide the sign.
+          if (valueNegative && +value === 0 && sign !== "+") valueNegative = false;
+
+          // Compute the prefix and suffix.
+          valuePrefix = (valueNegative ? (sign === "(" ? sign : minus) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
+          valueSuffix = (type === "s" ? prefixes[8 + prefixExponent / 3] : "") + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
+
+          // Break the formatted value into the integer “value” part that can be
+          // grouped, and fractional or exponential “suffix” part that is not.
+          if (maybeSuffix) {
+            i = -1, n = value.length;
+            while (++i < n) {
+              if (c = value.charCodeAt(i), 48 > c || c > 57) {
+                valueSuffix = (c === 46 ? decimal + value.slice(i + 1) : value.slice(i)) + valueSuffix;
+                value = value.slice(0, i);
+                break;
+              }
+            }
+          }
+        }
+
+        // If the fill character is not "0", grouping is applied before padding.
+        if (comma && !zero) value = group(value, Infinity);
+
+        // Compute the padding.
+        var length = valuePrefix.length + value.length + valueSuffix.length,
+            padding = length < width ? new Array(width - length + 1).join(fill) : "";
+
+        // If the fill character is "0", grouping is applied after padding.
+        if (comma && zero) value = group(padding + value, padding.length ? width - valueSuffix.length : Infinity), padding = "";
+
+        // Reconstruct the final output based on the desired alignment.
+        switch (align) {
+          case "<": value = valuePrefix + value + valueSuffix + padding; break;
+          case "=": value = valuePrefix + padding + value + valueSuffix; break;
+          case "^": value = padding.slice(0, length = padding.length >> 1) + valuePrefix + value + valueSuffix + padding.slice(length); break;
+          default: value = padding + valuePrefix + value + valueSuffix; break;
+        }
+
+        return numerals(value);
+      }
+
+      format.toString = function() {
+        return specifier + "";
+      };
+
+      return format;
+    }
+
+    function formatPrefix(specifier, value) {
+      var f = newFormat((specifier = formatSpecifier(specifier), specifier.type = "f", specifier)),
+          e = Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3,
+          k = Math.pow(10, -e),
+          prefix = prefixes[8 + e / 3];
+      return function(value) {
+        return f(k * value) + prefix;
+      };
+    }
+
+    return {
+      format: newFormat,
+      formatPrefix: formatPrefix
+    };
+  }
+
+  var locale;
+  var format;
+  var formatPrefix;
+
+  defaultLocale({
+    thousands: ",",
+    grouping: [3],
+    currency: ["$", ""]
+  });
+
+  function defaultLocale(definition) {
+    locale = formatLocale(definition);
+    format = locale.format;
+    formatPrefix = locale.formatPrefix;
+    return locale;
+  }
+
+  function precisionFixed(step) {
+    return Math.max(0, -exponent(Math.abs(step)));
+  }
+
+  function precisionPrefix(step, value) {
+    return Math.max(0, Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3 - exponent(Math.abs(step)));
+  }
+
+  function precisionRound(step, max) {
+    step = Math.abs(step), max = Math.abs(max) - step;
+    return Math.max(0, exponent(max) - exponent(step)) + 1;
+  }
+
+  function tickFormat(start, stop, count, specifier) {
+    var step = tickStep(start, stop, count),
+        precision;
+    specifier = formatSpecifier(specifier == null ? ",f" : specifier);
+    switch (specifier.type) {
+      case "s": {
+        var value = Math.max(Math.abs(start), Math.abs(stop));
+        if (specifier.precision == null && !isNaN(precision = precisionPrefix(step, value))) specifier.precision = precision;
+        return formatPrefix(specifier, value);
+      }
+      case "":
+      case "e":
+      case "g":
+      case "p":
+      case "r": {
+        if (specifier.precision == null && !isNaN(precision = precisionRound(step, Math.max(Math.abs(start), Math.abs(stop))))) specifier.precision = precision - (specifier.type === "e");
+        break;
+      }
+      case "f":
+      case "%": {
+        if (specifier.precision == null && !isNaN(precision = precisionFixed(step))) specifier.precision = precision - (specifier.type === "%") * 2;
+        break;
+      }
+    }
+    return format(specifier);
+  }
+
+  function linearish(scale) {
+    var domain = scale.domain;
+
+    scale.ticks = function(count) {
+      var d = domain();
+      return ticks(d[0], d[d.length - 1], count == null ? 10 : count);
+    };
+
+    scale.tickFormat = function(count, specifier) {
+      var d = domain();
+      return tickFormat(d[0], d[d.length - 1], count == null ? 10 : count, specifier);
+    };
+
+    scale.nice = function(count) {
+      if (count == null) count = 10;
+
+      var d = domain();
+      var i0 = 0;
+      var i1 = d.length - 1;
+      var start = d[i0];
+      var stop = d[i1];
+      var prestep;
+      var step;
+      var maxIter = 10;
+
+      if (stop < start) {
+        step = start, start = stop, stop = step;
+        step = i0, i0 = i1, i1 = step;
+      }
+      
+      while (maxIter-- > 0) {
+        step = tickIncrement(start, stop, count);
+        if (step === prestep) {
+          d[i0] = start;
+          d[i1] = stop;
+          return domain(d);
+        } else if (step > 0) {
+          start = Math.floor(start / step) * step;
+          stop = Math.ceil(stop / step) * step;
+        } else if (step < 0) {
+          start = Math.ceil(start * step) / step;
+          stop = Math.floor(stop * step) / step;
+        } else {
+          break;
+        }
+        prestep = step;
+      }
+
+      return scale;
+    };
+
+    return scale;
+  }
+
+  function linear() {
+    var scale = continuous();
+
+    scale.copy = function() {
+      return copy$1(scale, linear());
+    };
+
+    initRange.apply(scale, arguments);
+
+    return linearish(scale);
+  }
+
+  function transformer() {
+    var x0 = 0,
+        x1 = 1,
+        t0,
+        t1,
+        k10,
+        transform,
+        interpolator = identity$1,
+        clamp = false,
+        unknown;
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : interpolator(k10 === 0 ? 0.5 : (x = (transform(x) - t0) * k10, clamp ? Math.max(0, Math.min(1, x)) : x));
+    }
+
+    scale.domain = function(_) {
+      return arguments.length ? ([x0, x1] = _, t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0), scale) : [x0, x1];
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = !!_, scale) : clamp;
+    };
+
+    scale.interpolator = function(_) {
+      return arguments.length ? (interpolator = _, scale) : interpolator;
+    };
+
+    function range(interpolate) {
+      return function(_) {
+        var r0, r1;
+        return arguments.length ? ([r0, r1] = _, interpolator = interpolate(r0, r1), scale) : [interpolator(0), interpolator(1)];
+      };
+    }
+
+    scale.range = range(interpolate);
+
+    scale.rangeRound = range(interpolateRound);
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t) {
+      transform = t, t0 = t(x0), t1 = t(x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0);
+      return scale;
+    };
+  }
+
+  function copy(source, target) {
+    return target
+        .domain(source.domain())
+        .interpolator(source.interpolator())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function sequential() {
+    var scale = linearish(transformer()(identity$1));
+
+    scale.copy = function() {
+      return copy(scale, sequential());
+    };
+
+    return initInterpolator.apply(scale, arguments);
+  }
+
+  const COLOR_BASE = "#cecece";
+
+  // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+  const rc = 0.2126;
+  const gc = 0.7152;
+  const bc = 0.0722;
+  // low-gamma adjust coefficient
+  const lowc = 1 / 12.92;
+  function adjustGamma(p) {
+      return Math.pow((p + 0.055) / 1.055, 2.4);
+  }
+  function relativeLuminance(o) {
+      const rsrgb = o.r / 255;
+      const gsrgb = o.g / 255;
+      const bsrgb = o.b / 255;
+      const r = rsrgb <= 0.03928 ? rsrgb * lowc : adjustGamma(rsrgb);
+      const g = gsrgb <= 0.03928 ? gsrgb * lowc : adjustGamma(gsrgb);
+      const b = bsrgb <= 0.03928 ? bsrgb * lowc : adjustGamma(bsrgb);
+      return r * rc + g * gc + b * bc;
+  }
+  const createRainbowColor = (root) => {
+      const colorParentMap = new Map();
+      colorParentMap.set(root, COLOR_BASE);
+      if (root.children != null) {
+          const colorScale = sequential([0, root.children.length], (n) => hsl(360 * n, 0.3, 0.85));
+          root.children.forEach((c, id) => {
+              colorParentMap.set(c, colorScale(id).toString());
+          });
+      }
+      const colorMap = new Map();
+      const lightScale = linear().domain([0, root.height]).range([0.9, 0.3]);
+      const getBackgroundColor = (node) => {
+          const parents = node.ancestors();
+          const colorStr = parents.length === 1
+              ? colorParentMap.get(parents[0])
+              : colorParentMap.get(parents[parents.length - 2]);
+          const hslColor = hsl(colorStr);
+          hslColor.l = lightScale(node.depth);
+          return hslColor;
+      };
+      return (node) => {
+          if (!colorMap.has(node)) {
+              const backgroundColor = getBackgroundColor(node);
+              const l = relativeLuminance(backgroundColor.rgb());
+              const fontColor = l > 0.19 ? "#000" : "#fff";
+              colorMap.set(node, {
+                  backgroundColor: backgroundColor.toString(),
+                  fontColor,
+              });
+          }
+          return colorMap.get(node);
+      };
+  };
+
+  const StaticContext = G({});
+  const drawChart = (parentNode, data, width, height) => {
+      const availableSizeProperties = getAvailableSizeOptions(data.options);
+      console.time("layout create");
+      const layout = treemap()
+          .size([width, height])
+          .paddingOuter(PADDING)
+          .paddingTop(TOP_PADDING)
+          .paddingInner(PADDING)
+          .round(true)
+          .tile(treemapResquarify);
+      console.timeEnd("layout create");
+      console.time("rawHierarchy create");
+      const rawHierarchy = hierarchy(data.tree);
+      console.timeEnd("rawHierarchy create");
+      const nodeSizesCache = new Map();
+      const nodeIdsCache = new Map();
+      const getModuleSize = (node, sizeKey) => { var _a, _b; return (_b = (_a = nodeSizesCache.get(node)) === null || _a === void 0 ? void 0 : _a[sizeKey]) !== null && _b !== void 0 ? _b : 0; };
+      console.time("rawHierarchy eachAfter cache");
+      rawHierarchy.eachAfter((node) => {
+          var _a;
+          const nodeData = node.data;
+          nodeIdsCache.set(nodeData, {
+              nodeUid: generateUniqueId("node"),
+              clipUid: generateUniqueId("clip"),
+          });
+          const sizes = { renderedLength: 0, gzipLength: 0, brotliLength: 0 };
+          if (isModuleTree(nodeData)) {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = nodeData.children.reduce((acc, child) => getModuleSize(child, sizeKey) + acc, 0);
+              }
+          }
+          else {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = (_a = data.nodeParts[nodeData.uid][sizeKey]) !== null && _a !== void 0 ? _a : 0;
+              }
+          }
+          nodeSizesCache.set(nodeData, sizes);
+      });
+      console.timeEnd("rawHierarchy eachAfter cache");
+      const getModuleIds = (node) => nodeIdsCache.get(node);
+      console.time("color");
+      const getModuleColor = createRainbowColor(rawHierarchy);
+      console.timeEnd("color");
+      D(o$1(StaticContext.Provider, { value: {
+              data,
+              availableSizeProperties,
+              width,
+              height,
+              getModuleSize,
+              getModuleIds,
+              getModuleColor,
+              rawHierarchy,
+              layout,
+          }, children: o$1(Main, {}) }), parentNode);
+  };
+
+  exports.StaticContext = StaticContext;
+  exports.default = drawChart;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+  return exports;
+
+})({});
+
+  /*-->*/
+  </script>
+  <script>
+    /*<!--*/
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"metamask-sdk.js","children":[{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"rollup-plugin-node-globals/src","children":[{"uid":"5277-1","name":"global.js"},{"uid":"5277-501","name":"browser.js"}]},{"name":"buffer-es6","children":[{"uid":"5277-3","name":"base64.js"},{"uid":"5277-5","name":"ieee754.js"},{"uid":"5277-7","name":"isArray.js"},{"uid":"5277-9","name":"index.js"}]},{"name":"process-es6/browser.js","uid":"5277-23"},{"name":"safe-buffer/index.js","uid":"5277-29"},{"name":"randombytes/browser.js","uid":"5277-31"},{"name":"inherits/inherits_browser.js","uid":"5277-35"},{"name":"rollup-plugin-node-builtins/src/es6","children":[{"uid":"5277-39","name":"events.js"},{"uid":"5277-45","name":"inherits.js"},{"uid":"5277-47","name":"util.js"},{"name":"readable-stream","children":[{"uid":"5277-111","name":"buffer-list.js"},{"uid":"5277-115","name":"readable.js"},{"uid":"5277-117","name":"writable.js"},{"uid":"5277-119","name":"duplex.js"},{"uid":"5277-121","name":"transform.js"},{"uid":"5277-123","name":"passthrough.js"}]},{"uid":"5277-113","name":"string-decoder.js"},{"uid":"5277-125","name":"stream.js"},{"uid":"5277-783","name":"empty.js"}]},{"name":"hash-base","children":[{"name":"node_modules","children":[{"name":"readable-stream","children":[{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-43","name":"stream-browser.js"},{"uid":"5277-51","name":"buffer_list.js"},{"uid":"5277-53","name":"destroy.js"},{"uid":"5277-59","name":"state.js"},{"uid":"5277-71","name":"end-of-stream.js"},{"uid":"5277-73","name":"async_iterator.js"},{"uid":"5277-75","name":"from-browser.js"},{"uid":"5277-83","name":"pipeline.js"}]},{"uid":"5277-63","name":"_stream_writable.js"},{"uid":"5277-65","name":"_stream_duplex.js"},{"uid":"5277-77","name":"_stream_readable.js"},{"uid":"5277-79","name":"_stream_transform.js"},{"uid":"5277-81","name":"_stream_passthrough.js"}]},{"uid":"5277-57","name":"errors-browser.js"},{"uid":"5277-85","name":"readable-browser.js"}]},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-69"}]},{"uid":"5277-87","name":"index.js"}]},{"name":"util-deprecate/browser.js","uid":"5277-61"},{"name":"md5.js/index.js","uid":"5277-89"},{"name":"ripemd160/index.js","uid":"5277-91"},{"name":"sha.js","children":[{"uid":"5277-95","name":"hash.js"},{"uid":"5277-97","name":"sha.js"},{"uid":"5277-99","name":"sha1.js"},{"uid":"5277-101","name":"sha256.js"},{"uid":"5277-103","name":"sha224.js"},{"uid":"5277-105","name":"sha512.js"},{"uid":"5277-107","name":"sha384.js"},{"uid":"5277-109","name":"index.js"}]},{"name":"cipher-base/index.js","uid":"5277-131"},{"name":"create-hash","children":[{"uid":"5277-133","name":"browser.js"},{"uid":"5277-137","name":"md5.js"}]},{"name":"create-hmac","children":[{"uid":"5277-135","name":"legacy.js"},{"uid":"5277-139","name":"browser.js"}]},{"name":"browserify-sign","children":[{"name":"browser","children":[{"uid":"5277-141","name":"algorithms.json"},{"uid":"5277-469","name":"curves.json"},{"uid":"5277-471","name":"sign.js"},{"uid":"5277-473","name":"verify.js"},{"uid":"5277-475","name":"index.js"}]},{"uid":"5277-143","name":"algos.js"},{"name":"node_modules","children":[{"name":"readable-stream","children":[{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-275","name":"stream-browser.js"},{"uid":"5277-277","name":"buffer_list.js"},{"uid":"5277-279","name":"destroy.js"},{"uid":"5277-285","name":"state.js"},{"uid":"5277-295","name":"end-of-stream.js"},{"uid":"5277-297","name":"async_iterator.js"},{"uid":"5277-299","name":"from-browser.js"},{"uid":"5277-307","name":"pipeline.js"}]},{"uid":"5277-287","name":"_stream_writable.js"},{"uid":"5277-289","name":"_stream_duplex.js"},{"uid":"5277-301","name":"_stream_readable.js"},{"uid":"5277-303","name":"_stream_transform.js"},{"uid":"5277-305","name":"_stream_passthrough.js"}]},{"uid":"5277-283","name":"errors-browser.js"},{"uid":"5277-309","name":"readable-browser.js"}]},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-293"}]}]},{"name":"pbkdf2","children":[{"name":"lib","children":[{"uid":"5277-147","name":"precondition.js"},{"uid":"5277-149","name":"default-encoding.js"},{"uid":"5277-151","name":"to-buffer.js"},{"uid":"5277-153","name":"sync-browser.js"},{"uid":"5277-155","name":"async.js"}]},{"uid":"5277-157","name":"browser.js"}]},{"name":"des.js/lib","children":[{"name":"des","children":[{"uid":"5277-165","name":"utils.js"},{"uid":"5277-169","name":"cipher.js"},{"uid":"5277-171","name":"des.js"},{"uid":"5277-175","name":"cbc.js"},{"uid":"5277-177","name":"ede.js"}]},{"uid":"5277-179","name":"des.js"}]},{"name":"minimalistic-assert/index.js","uid":"5277-167"},{"name":"browserify-des","children":[{"uid":"5277-181","name":"index.js"},{"uid":"5277-245","name":"modes.js"}]},{"name":"browserify-aes","children":[{"name":"modes","children":[{"uid":"5277-189","name":"ecb.js"},{"uid":"5277-195","name":"cbc.js"},{"uid":"5277-199","name":"cfb.js"},{"uid":"5277-203","name":"cfb8.js"},{"uid":"5277-207","name":"cfb1.js"},{"uid":"5277-211","name":"ofb.js"},{"uid":"5277-217","name":"ctr.js"},{"uid":"5277-219","name":"list.json"},{"uid":"5277-221","name":"index.js"}]},{"uid":"5277-215","name":"incr32.js"},{"uid":"5277-225","name":"aes.js"},{"uid":"5277-227","name":"ghash.js"},{"uid":"5277-229","name":"authCipher.js"},{"uid":"5277-231","name":"streamCipher.js"},{"uid":"5277-235","name":"encrypter.js"},{"uid":"5277-239","name":"decrypter.js"},{"uid":"5277-241","name":"browser.js"}]},{"name":"buffer-xor/index.js","uid":"5277-193"},{"name":"evp_bytestokey/index.js","uid":"5277-233"},{"name":"browserify-cipher/browser.js","uid":"5277-247"},{"name":"diffie-hellman","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-253"},{"name":"lib","children":[{"uid":"5277-265","name":"generatePrime.js"},{"uid":"5277-267","name":"primes.json"},{"uid":"5277-269","name":"dh.js"}]},{"uid":"5277-271","name":"browser.js"}]},{"name":"miller-rabin","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-257"},{"name":"lib/mr.js","uid":"5277-263"}]},{"name":"brorand/index.js","uid":"5277-261"},{"name":"bn.js/lib/bn.js","uid":"5277-315"},{"name":"browserify-rsa/index.js","uid":"5277-317"},{"name":"elliptic","children":[{"uid":"5277-321","name":"package.json"},{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-327"},{"name":"lib","children":[{"name":"elliptic","children":[{"uid":"5277-333","name":"utils.js"},{"name":"curve","children":[{"uid":"5277-337","name":"base.js"},{"uid":"5277-339","name":"short.js"},{"uid":"5277-341","name":"mont.js"},{"uid":"5277-343","name":"edwards.js"},{"uid":"5277-345","name":"index.js"}]},{"name":"precomputed/secp256k1.js","uid":"5277-385"},{"uid":"5277-387","name":"curves.js"},{"name":"ec","children":[{"uid":"5277-391","name":"key.js"},{"uid":"5277-393","name":"signature.js"},{"uid":"5277-395","name":"index.js"}]},{"name":"eddsa","children":[{"uid":"5277-397","name":"key.js"},{"uid":"5277-399","name":"signature.js"},{"uid":"5277-401","name":"index.js"}]}]},{"uid":"5277-403","name":"elliptic.js"}]}]},{"name":"minimalistic-crypto-utils/lib/utils.js","uid":"5277-331"},{"name":"hash.js/lib","children":[{"name":"hash","children":[{"uid":"5277-353","name":"utils.js"},{"uid":"5277-357","name":"common.js"},{"name":"sha","children":[{"uid":"5277-363","name":"common.js"},{"uid":"5277-365","name":"1.js"},{"uid":"5277-367","name":"256.js"},{"uid":"5277-369","name":"224.js"},{"uid":"5277-371","name":"512.js"},{"uid":"5277-373","name":"384.js"}]},{"uid":"5277-375","name":"sha.js"},{"uid":"5277-379","name":"ripemd.js"},{"uid":"5277-381","name":"hmac.js"}]},{"uid":"5277-383","name":"hash.js"}]},{"name":"hmac-drbg/lib/hmac-drbg.js","uid":"5277-389"},{"name":"asn1.js","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-411"},{"name":"lib","children":[{"name":"asn1","children":[{"name":"base","children":[{"uid":"5277-421","name":"reporter.js"},{"uid":"5277-425","name":"buffer.js"},{"uid":"5277-427","name":"node.js"},{"uid":"5277-451","name":"index.js"}]},{"name":"constants","children":[{"uid":"5277-431","name":"der.js"},{"uid":"5277-455","name":"index.js"}]},{"name":"encoders","children":[{"uid":"5277-433","name":"der.js"},{"uid":"5277-435","name":"pem.js"},{"uid":"5277-437","name":"index.js"}]},{"name":"decoders","children":[{"uid":"5277-441","name":"der.js"},{"uid":"5277-443","name":"pem.js"},{"uid":"5277-445","name":"index.js"}]},{"uid":"5277-447","name":"api.js"}]},{"uid":"5277-457","name":"asn1.js"}]}]},{"name":"safer-buffer/safer.js","uid":"5277-417"},{"name":"parse-asn1","children":[{"uid":"5277-459","name":"certificate.js"},{"uid":"5277-461","name":"asn1.js"},{"uid":"5277-463","name":"aesid.json"},{"uid":"5277-465","name":"fixProc.js"},{"uid":"5277-467","name":"index.js"}]},{"name":"create-ecdh","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-479"},{"uid":"5277-481","name":"browser.js"}]},{"name":"public-encrypt","children":[{"uid":"5277-485","name":"mgf.js"},{"uid":"5277-487","name":"xor.js"},{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-491"},{"uid":"5277-493","name":"withPublic.js"},{"uid":"5277-495","name":"publicEncrypt.js"},{"uid":"5277-497","name":"privateDecrypt.js"},{"uid":"5277-499","name":"browser.js"}]},{"name":"randomfill/browser.js","uid":"5277-505"},{"name":"crypto-browserify/index.js","uid":"5277-507"},{"name":"futoin-hkdf/hkdf.js","uid":"5277-509"},{"name":"eciesjs","children":[{"name":"node_modules/secp256k1","children":[{"name":"lib","children":[{"uid":"5277-511","name":"index.js"},{"uid":"5277-513","name":"elliptic.js"}]},{"uid":"5277-515","name":"elliptic.js"}]},{"name":"dist","children":[{"uid":"5277-521","name":"consts.js"},{"uid":"5277-523","name":"utils.js"},{"name":"keys","children":[{"uid":"5277-527","name":"PublicKey.js"},{"uid":"5277-529","name":"PrivateKey.js"},{"uid":"5277-531","name":"index.js"}]},{"uid":"5277-533","name":"index.js"}]}]},{"name":"eventemitter2/lib/eventemitter2.js","uid":"5277-537"},{"name":"uuid/dist/esm-browser","children":[{"uid":"5277-539","name":"rng.js"},{"uid":"5277-541","name":"regex.js"},{"uid":"5277-543","name":"validate.js"},{"uid":"5277-545","name":"stringify.js"},{"uid":"5277-547","name":"v4.js"}]},{"name":"engine.io-parser/build/esm","children":[{"uid":"5277-549","name":"commons.js"},{"uid":"5277-551","name":"encodePacket.browser.js"},{"name":"contrib/base64-arraybuffer.js","uid":"5277-553"},{"uid":"5277-555","name":"decodePacket.browser.js"},{"uid":"5277-557","name":"index.js"}]},{"name":"@socket.io/component-emitter/index.mjs","uid":"5277-559"},{"name":"engine.io-client/build/esm","children":[{"uid":"5277-561","name":"globalThis.browser.js"},{"uid":"5277-563","name":"util.js"},{"name":"contrib","children":[{"uid":"5277-565","name":"parseqs.js"},{"uid":"5277-569","name":"yeast.js"},{"uid":"5277-571","name":"has-cors.js"},{"uid":"5277-585","name":"parseuri.js"}]},{"uid":"5277-567","name":"transport.js"},{"name":"transports","children":[{"uid":"5277-573","name":"xmlhttprequest.browser.js"},{"uid":"5277-575","name":"polling.js"},{"uid":"5277-577","name":"websocket-constructor.browser.js"},{"uid":"5277-579","name":"websocket.js"},{"uid":"5277-581","name":"webtransport.js"},{"uid":"5277-583","name":"index.js"}]},{"uid":"5277-587","name":"socket.js"}]},{"name":"socket.io-client/build/esm","children":[{"uid":"5277-589","name":"url.js"},{"uid":"5277-597","name":"on.js"},{"uid":"5277-599","name":"socket.js"},{"name":"contrib/backo2.js","uid":"5277-601"},{"uid":"5277-603","name":"manager.js"},{"uid":"5277-605","name":"index.js"}]},{"name":"socket.io-parser/build/esm","children":[{"uid":"5277-591","name":"is-binary.js"},{"uid":"5277-593","name":"binary.js"},{"uid":"5277-595","name":"index.js"}]},{"name":"cross-fetch/dist/browser-ponyfill.js","uid":"5277-609"},{"name":"@metamask","children":[{"name":"safe-event-emitter/index.js","uid":"5277-621"},{"name":"providers","children":[{"name":"node_modules/fast-deep-equal/index.js","uid":"5277-645"},{"name":"dist","children":[{"uid":"5277-677","name":"messages.js"},{"name":"middleware/createRpcWarningMiddleware.js","uid":"5277-683"},{"uid":"5277-685","name":"utils.js"},{"uid":"5277-687","name":"BaseProvider.js"},{"uid":"5277-703","name":"siteMetadata.js"},{"uid":"5277-789","name":"StreamProvider.js"},{"uid":"5277-791","name":"MetaMaskInpageProvider.js"},{"name":"extension-provider","children":[{"uid":"5277-793","name":"external-extension-config.json"},{"uid":"5277-795","name":"createExternalExtensionProvider.js"}]},{"uid":"5277-801","name":"shimWeb3.js"},{"uid":"5277-803","name":"initializeInpageProvider.js"},{"uid":"5277-805","name":"index.js"}]}]},{"name":"object-multiplex/dist","children":[{"uid":"5277-759","name":"Substream.js"},{"uid":"5277-761","name":"ObjectMultiplex.js"},{"uid":"5277-763","name":"index.js"}]},{"name":"onboarding/dist/metamask-onboarding.es.js","uid":"5277-947"}]},{"name":"fast-safe-stringify/index.js","uid":"5277-627"},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-629","name":"classes.js"},{"uid":"5277-635","name":"error-constants.js"},{"uid":"5277-637","name":"utils.js"},{"uid":"5277-641","name":"errors.js"},{"uid":"5277-643","name":"index.js"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-653","name":"getUniqueId.js"},{"uid":"5277-655","name":"idRemapMiddleware.js"},{"uid":"5277-659","name":"createAsyncMiddleware.js"},{"uid":"5277-663","name":"createScaffoldMiddleware.js"},{"uid":"5277-667","name":"JsonRpcEngine.js"},{"uid":"5277-671","name":"mergeMiddleware.js"},{"uid":"5277-673","name":"index.js"}]},{"name":"extension-port-stream/dist/index.js","uid":"5277-693"},{"name":"detect-browser/es/index.js","uid":"5277-695"},{"name":"process-nextick-args/index.js","uid":"5277-713"},{"name":"readable-stream","children":[{"name":"node_modules","children":[{"name":"isarray/index.js","uid":"5277-715"},{"name":"safe-buffer/index.js","uid":"5277-721"},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-739"}]},{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-717","name":"stream-browser.js"},{"uid":"5277-729","name":"BufferList.js"},{"uid":"5277-731","name":"destroy.js"}]},{"uid":"5277-733","name":"_stream_writable.js"},{"uid":"5277-735","name":"_stream_duplex.js"},{"uid":"5277-741","name":"_stream_readable.js"},{"uid":"5277-743","name":"_stream_transform.js"},{"uid":"5277-745","name":"_stream_passthrough.js"}]},{"uid":"5277-747","name":"readable-browser.js"}]},{"name":"core-util-is/lib/util.js","uid":"5277-725"},{"name":"wrappy/wrappy.js","uid":"5277-751"},{"name":"once/once.js","uid":"5277-753"},{"name":"end-of-stream/index.js","uid":"5277-755"},{"name":"is-stream/index.js","uid":"5277-765"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-771","name":"createEngineStream.js"},{"uid":"5277-779","name":"createStreamMiddleware.js"},{"uid":"5277-781","name":"index.js"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js","uid":"5277-777"}]},{"name":"pump/index.js","uid":"5277-787"},{"name":"i18next","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-817","name":"typeof.js"},{"uid":"5277-819","name":"classCallCheck.js"},{"uid":"5277-821","name":"toPrimitive.js"},{"uid":"5277-823","name":"toPropertyKey.js"},{"uid":"5277-825","name":"createClass.js"},{"uid":"5277-827","name":"assertThisInitialized.js"},{"uid":"5277-829","name":"setPrototypeOf.js"},{"uid":"5277-831","name":"inherits.js"},{"uid":"5277-833","name":"possibleConstructorReturn.js"},{"uid":"5277-835","name":"getPrototypeOf.js"},{"uid":"5277-837","name":"defineProperty.js"},{"uid":"5277-839","name":"arrayWithHoles.js"},{"uid":"5277-841","name":"iterableToArray.js"},{"uid":"5277-843","name":"arrayLikeToArray.js"},{"uid":"5277-845","name":"unsupportedIterableToArray.js"},{"uid":"5277-847","name":"nonIterableRest.js"},{"uid":"5277-849","name":"toArray.js"}]},{"name":"dist/esm/i18next.js","uid":"5277-851"}]},{"name":"bowser/es5.js","uid":"5277-917"},{"name":"qr-code-styling/lib/qr-code-styling.js","uid":"5277-959"},{"name":"i18next-browser-languagedetector","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-1005","name":"classCallCheck.js"},{"uid":"5277-1007","name":"typeof.js"},{"uid":"5277-1009","name":"toPrimitive.js"},{"uid":"5277-1011","name":"toPropertyKey.js"},{"uid":"5277-1013","name":"createClass.js"}]},{"name":"dist/esm/i18nextBrowserLanguageDetector.js","uid":"5277-1015"}]},{"name":"react","children":[{"name":"cjs","children":[{"uid":"5277-1021","name":"react.production.min.js"},{"uid":"5277-1025","name":"react.development.js"}]},{"uid":"5277-1027","name":"index.js"}]},{"name":"react-i18next/dist/es","children":[{"uid":"5277-1029","name":"unescape.js"},{"uid":"5277-1031","name":"defaults.js"},{"uid":"5277-1033","name":"initReactI18next.js"},{"uid":"5277-1035","name":"context.js"}]}]},{"uid":"5277-11","name":"\u0000commonjsHelpers.js"},{"name":"\u0000","children":[{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"eciesjs/dist","children":[{"uid":"5277-13","name":"index.js?commonjs-exports"},{"name":"keys","children":[{"uid":"5277-15","name":"index.js?commonjs-exports"},{"uid":"5277-17","name":"PrivateKey.js?commonjs-exports"},{"uid":"5277-525","name":"PublicKey.js?commonjs-exports"}]},{"uid":"5277-517","name":"utils.js?commonjs-exports"},{"uid":"5277-519","name":"consts.js?commonjs-exports"}]},{"name":"buffer-es6/index.js?commonjs-proxy","uid":"5277-19"},{"name":"crypto-browserify/index.js?commonjs-exports","uid":"5277-21"},{"name":"randombytes/browser.js?commonjs-module","uid":"5277-25"},{"name":"safe-buffer/index.js?commonjs-module","uid":"5277-27"},{"name":"inherits/inherits_browser.js?commonjs-module","uid":"5277-33"},{"name":"hash-base/node_modules","children":[{"name":"readable-stream","children":[{"uid":"5277-37","name":"readable-browser.js?commonjs-module"},{"uid":"5277-55","name":"errors-browser.js?commonjs-exports"}]},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-67"}]},{"name":"rollup-plugin-node-builtins/src/es6","children":[{"uid":"5277-41","name":"events.js?commonjs-proxy"},{"uid":"5277-49","name":"util.js?commonjs-proxy"},{"uid":"5277-127","name":"stream.js?commonjs-proxy"},{"uid":"5277-129","name":"string-decoder.js?commonjs-proxy"},{"uid":"5277-785","name":"empty.js?commonjs-proxy"}]},{"name":"sha.js/index.js?commonjs-module","uid":"5277-93"},{"name":"pbkdf2/browser.js?commonjs-exports","uid":"5277-145"},{"name":"browserify-cipher/browser.js?commonjs-exports","uid":"5277-159"},{"name":"des.js/lib","children":[{"uid":"5277-161","name":"des.js?commonjs-exports"},{"name":"des","children":[{"uid":"5277-163","name":"utils.js?commonjs-exports"},{"uid":"5277-173","name":"cbc.js?commonjs-exports"}]}]},{"name":"browserify-aes","children":[{"uid":"5277-183","name":"browser.js?commonjs-exports"},{"uid":"5277-185","name":"encrypter.js?commonjs-exports"},{"name":"modes","children":[{"uid":"5277-187","name":"ecb.js?commonjs-exports"},{"uid":"5277-191","name":"cbc.js?commonjs-exports"},{"uid":"5277-197","name":"cfb.js?commonjs-exports"},{"uid":"5277-201","name":"cfb8.js?commonjs-exports"},{"uid":"5277-205","name":"cfb1.js?commonjs-exports"},{"uid":"5277-209","name":"ofb.js?commonjs-exports"},{"uid":"5277-213","name":"ctr.js?commonjs-exports"}]},{"uid":"5277-223","name":"aes.js?commonjs-exports"},{"uid":"5277-237","name":"decrypter.js?commonjs-exports"}]},{"name":"browserify-des/modes.js?commonjs-exports","uid":"5277-243"},{"name":"diffie-hellman","children":[{"uid":"5277-249","name":"browser.js?commonjs-exports"},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-251"}]},{"name":"miller-rabin/node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-255"},{"name":"brorand/index.js?commonjs-module","uid":"5277-259"},{"name":"browserify-sign","children":[{"name":"node_modules","children":[{"name":"readable-stream","children":[{"uid":"5277-273","name":"readable-browser.js?commonjs-module"},{"uid":"5277-281","name":"errors-browser.js?commonjs-exports"}]},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-291"}]},{"name":"browser/sign.js?commonjs-module","uid":"5277-311"}]},{"name":"bn.js/lib/bn.js?commonjs-module","uid":"5277-313"},{"name":"elliptic","children":[{"name":"lib","children":[{"uid":"5277-319","name":"elliptic.js?commonjs-exports"},{"name":"elliptic","children":[{"uid":"5277-323","name":"utils.js?commonjs-exports"},{"name":"curve/index.js?commonjs-exports","uid":"5277-335"},{"uid":"5277-347","name":"curves.js?commonjs-exports"}]}]},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-325"}]},{"name":"minimalistic-crypto-utils/lib/utils.js?commonjs-exports","uid":"5277-329"},{"name":"hash.js/lib","children":[{"uid":"5277-349","name":"hash.js?commonjs-exports"},{"name":"hash","children":[{"uid":"5277-351","name":"utils.js?commonjs-exports"},{"uid":"5277-355","name":"common.js?commonjs-exports"},{"uid":"5277-359","name":"sha.js?commonjs-exports"},{"name":"sha/common.js?commonjs-exports","uid":"5277-361"},{"uid":"5277-377","name":"ripemd.js?commonjs-exports"}]}]},{"name":"parse-asn1/asn1.js?commonjs-exports","uid":"5277-405"},{"name":"asn1.js","children":[{"name":"lib","children":[{"uid":"5277-407","name":"asn1.js?commonjs-exports"},{"name":"asn1","children":[{"uid":"5277-413","name":"api.js?commonjs-exports"},{"name":"encoders/index.js?commonjs-exports","uid":"5277-415"},{"name":"base","children":[{"uid":"5277-419","name":"reporter.js?commonjs-exports"},{"uid":"5277-423","name":"buffer.js?commonjs-exports"},{"uid":"5277-449","name":"index.js?commonjs-exports"}]},{"name":"constants","children":[{"uid":"5277-429","name":"der.js?commonjs-exports"},{"uid":"5277-453","name":"index.js?commonjs-exports"}]},{"name":"decoders/index.js?commonjs-exports","uid":"5277-439"}]}]},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-409"}]},{"name":"create-ecdh/node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-477"},{"name":"public-encrypt","children":[{"uid":"5277-483","name":"browser.js?commonjs-exports"},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-489"}]},{"name":"randomfill/browser.js?commonjs-exports","uid":"5277-503"},{"name":"eventemitter2/lib/eventemitter2.js?commonjs-module","uid":"5277-535"},{"name":"cross-fetch/dist/browser-ponyfill.js?commonjs-module","uid":"5277-607"},{"name":"@metamask","children":[{"name":"providers/dist","children":[{"uid":"5277-615","name":"index.js?commonjs-exports"},{"uid":"5277-617","name":"BaseProvider.js?commonjs-exports"},{"uid":"5277-675","name":"messages.js?commonjs-exports"},{"uid":"5277-679","name":"utils.js?commonjs-exports"},{"name":"middleware/createRpcWarningMiddleware.js?commonjs-exports","uid":"5277-681"},{"name":"extension-provider/createExternalExtensionProvider.js?commonjs-exports","uid":"5277-689"},{"uid":"5277-699","name":"MetaMaskInpageProvider.js?commonjs-exports"},{"uid":"5277-701","name":"siteMetadata.js?commonjs-exports"},{"uid":"5277-705","name":"StreamProvider.js?commonjs-exports"},{"uid":"5277-797","name":"initializeInpageProvider.js?commonjs-exports"},{"uid":"5277-799","name":"shimWeb3.js?commonjs-exports"}]},{"name":"safe-event-emitter/index.js?commonjs-exports","uid":"5277-619"},{"name":"object-multiplex/dist","children":[{"uid":"5277-707","name":"ObjectMultiplex.js?commonjs-exports"},{"uid":"5277-757","name":"Substream.js?commonjs-exports"}]}]},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-623","name":"index.js?commonjs-exports"},{"uid":"5277-625","name":"classes.js?commonjs-exports"},{"uid":"5277-631","name":"utils.js?commonjs-exports"},{"uid":"5277-633","name":"error-constants.js?commonjs-exports"},{"uid":"5277-639","name":"errors.js?commonjs-exports"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-647","name":"index.js?commonjs-exports"},{"uid":"5277-649","name":"idRemapMiddleware.js?commonjs-exports"},{"uid":"5277-651","name":"getUniqueId.js?commonjs-exports"},{"uid":"5277-657","name":"createAsyncMiddleware.js?commonjs-exports"},{"uid":"5277-661","name":"createScaffoldMiddleware.js?commonjs-exports"},{"uid":"5277-665","name":"JsonRpcEngine.js?commonjs-exports"},{"uid":"5277-669","name":"mergeMiddleware.js?commonjs-exports"}]},{"name":"extension-port-stream/dist/index.js?commonjs-exports","uid":"5277-691"},{"name":"detect-browser/es/index.js?commonjs-proxy","uid":"5277-697"},{"name":"readable-stream","children":[{"uid":"5277-709","name":"readable-browser.js?commonjs-module"},{"name":"node_modules","children":[{"name":"safe-buffer/index.js?commonjs-module","uid":"5277-719"},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-737"}]},{"name":"lib/internal/streams/BufferList.js?commonjs-module","uid":"5277-727"}]},{"name":"process-nextick-args/index.js?commonjs-module","uid":"5277-711"},{"name":"core-util-is/lib/util.js?commonjs-exports","uid":"5277-723"},{"name":"once/once.js?commonjs-module","uid":"5277-749"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-767","name":"index.js?commonjs-exports"},{"uid":"5277-769","name":"createEngineStream.js?commonjs-exports"},{"uid":"5277-773","name":"createStreamMiddleware.js?commonjs-exports"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","uid":"5277-775"}]},{"name":"bowser/es5.js?commonjs-module","uid":"5277-915"},{"name":"qr-code-styling/lib/qr-code-styling.js?commonjs-module","uid":"5277-957"},{"name":"react","children":[{"uid":"5277-1017","name":"index.js?commonjs-module"},{"name":"cjs","children":[{"uid":"5277-1019","name":"react.production.min.js?commonjs-exports"},{"uid":"5277-1023","name":"react.development.js?commonjs-module"}]}]}]},{"name":"node_modules/cross-fetch/dist/browser-ponyfill.js?commonjs-module","uid":"5277-887"}]},{"name":"-communication-layer/dist/browser/es/metamask-sdk-communication-layer.js","uid":"5277-611"},{"uid":"5277-613","name":"\u0000tslib.js"},{"name":"src","children":[{"name":"services","children":[{"name":"SDKProvider","children":[{"name":"ChainManager/handleChainChanged.ts","uid":"5277-807"},{"name":"ConnectionManager/handleDisconnect.ts","uid":"5277-809"},{"name":"InitializationManager","children":[{"uid":"5277-811","name":"initializeState.ts"},{"uid":"5277-813","name":"initializeStateAsync.ts"}]}]},{"name":"MetaMaskSDK","children":[{"name":"ConnectionManager","children":[{"uid":"5277-853","name":"connect.ts"},{"uid":"5277-855","name":"resume.ts"},{"uid":"5277-861","name":"terminate.ts"},{"uid":"5277-1057","name":"connectAndSign.ts"}]},{"name":"ProviderManager/connectWithExtensionProvider.ts","uid":"5277-863"},{"name":"InitializerManager","children":[{"uid":"5277-867","name":"handleAutoAndExtensionConnections.ts"},{"uid":"5277-869","name":"initEventListeners.ts"},{"uid":"5277-897","name":"initializeProviderAndEventListeners.ts"},{"uid":"5277-899","name":"setupAnalytics.ts"},{"uid":"5277-905","name":"setupDappMetadata.ts"},{"uid":"5277-913","name":"setupExtensionPreferences.ts"},{"uid":"5277-941","name":"setupPlatformManager.ts"},{"uid":"5277-993","name":"setupRemoteConnectionAndInstaller.ts"},{"uid":"5277-999","name":"setupStorage.ts"},{"uid":"5277-1001","name":"setupInfuraProvider.ts"},{"uid":"5277-1003","name":"setupReadOnlyRPCProviders.ts"},{"uid":"5277-1051","name":"initializeI18next.ts"},{"uid":"5277-1053","name":"performSDKInitialization.ts"},{"uid":"5277-1055","name":"initializeMetaMaskSDK.ts"}]}]},{"uid":"5277-865","name":"Analytics.ts"},{"name":"RemoteCommunicationPostMessageStream","children":[{"uid":"5277-873","name":"onMessage.ts"},{"uid":"5277-877","name":"extractMethod.ts"},{"uid":"5277-879","name":"write.ts"}]},{"uid":"5277-875","name":"Ethereum.ts"},{"name":"rpc-requests/RPCRequestHandler.ts","uid":"5277-891"},{"name":"PlatfformManager","children":[{"uid":"5277-921","name":"disableWakeLock.ts"},{"uid":"5277-923","name":"enableWakeLock.ts"},{"uid":"5277-925","name":"getPlatformType.ts"},{"uid":"5277-927","name":"isMetaMaskInstalled.ts"},{"uid":"5277-929","name":"openDeeplink.ts"}]},{"name":"MetaMaskInstaller","children":[{"uid":"5277-943","name":"checkInstallation.ts"},{"uid":"5277-945","name":"redirectToProperInstall.ts"},{"uid":"5277-949","name":"startDesktopOnboarding.ts"},{"uid":"5277-951","name":"startInstaller.ts"}]},{"name":"RemoteConnection","children":[{"name":"ConnectionInitializer/initializeConnector.ts","uid":"5277-971"},{"name":"ConnectionManager","children":[{"uid":"5277-973","name":"connectWithDeeplink.ts"},{"uid":"5277-977","name":"connectWithModalInstaller.ts"},{"uid":"5277-985","name":"startConnection.ts"}]},{"name":"ModalManager","children":[{"uid":"5277-975","name":"showInstallModal.ts"},{"uid":"5277-979","name":"onOTPModalDisconnect.ts"},{"uid":"5277-981","name":"waitForOTPAnswer.ts"},{"uid":"5277-983","name":"reconnectWithModalOTP.ts"},{"uid":"5277-989","name":"showActiveModal.ts"}]},{"name":"EventListeners/setupListeners.ts","uid":"5277-987"},{"uid":"5277-991","name":"RemoteConnection.ts"}]}]},{"name":"provider","children":[{"uid":"5277-815","name":"SDKProvider.ts"},{"uid":"5277-895","name":"initializeMobileProvider.ts"},{"uid":"5277-907","name":"wrapExtensionProvider.ts"}]},{"uid":"5277-857","name":"config.ts"},{"name":"types","children":[{"uid":"5277-859","name":"ProviderUpdateType.ts"},{"uid":"5277-919","name":"WakeLockStatus.ts"}]},{"uid":"5277-871","name":"constants.ts"},{"name":"PostMessageStream","children":[{"uid":"5277-881","name":"RemoteCommunicationPostMessageStream.ts"},{"uid":"5277-883","name":"getPostMessageStream.ts"}]},{"name":"utils","children":[{"uid":"5277-885","name":"wait.ts"},{"uid":"5277-901","name":"extractFavicon.ts"},{"uid":"5277-903","name":"getBase64FromUrl.ts"},{"uid":"5277-909","name":"eip6963RequestProvider.ts"},{"uid":"5277-911","name":"get-browser-extension.ts"},{"uid":"5277-931","name":"hasNativeWakeLockSupport.ts"},{"uid":"5277-933","name":"isOldIOS.ts"}]},{"name":"Platform","children":[{"uid":"5277-935","name":"Media.ts"},{"uid":"5277-937","name":"WakeLockManager.ts"},{"uid":"5277-939","name":"PlatfformManager.ts"},{"uid":"5277-953","name":"MetaMaskInstaller.ts"}]},{"name":"ui/InstallModal","children":[{"uid":"5277-963","name":"InstallModal-web.ts"},{"uid":"5277-965","name":"installModal.ts"},{"uid":"5277-967","name":"pendingModal-web.ts"},{"uid":"5277-969","name":"pendingModal.ts"}]},{"name":"storage-manager","children":[{"uid":"5277-995","name":"StorageManagerWeb.ts"},{"uid":"5277-997","name":"getStorageManager.ts"}]},{"name":"locales","children":[{"uid":"5277-1037","name":"en.json"},{"uid":"5277-1039","name":"es.json"},{"uid":"5277-1041","name":"fr.json"},{"uid":"5277-1043","name":"he.json"},{"uid":"5277-1045","name":"it.json"},{"uid":"5277-1047","name":"pt.json"},{"uid":"5277-1049","name":"tr.json"}]},{"uid":"5277-1059","name":"sdk.ts"},{"uid":"5277-1061","name":"index.ts"}]},{"name":"node_modules/cross-fetch/dist/browser-ponyfill.js","uid":"5277-889"},{"uid":"5277-893","name":"package.json"},{"name":"\u0000-install-modal-web/dist/umd/index.js?commonjs-module","uid":"5277-955"},{"name":"-install-modal-web/dist/umd/index.js","uid":"5277-961"}]}],"isRoot":true},"nodeParts":{"5277-1":{"renderedLength":163,"gzipLength":0,"brotliLength":0,"metaUid":"5277-0"},"5277-3":{"renderedLength":3390,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2"},"5277-5":{"renderedLength":2080,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4"},"5277-7":{"renderedLength":134,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6"},"5277-9":{"renderedLength":48871,"gzipLength":0,"brotliLength":0,"metaUid":"5277-8"},"5277-11":{"renderedLength":943,"gzipLength":0,"brotliLength":0,"metaUid":"5277-10"},"5277-13":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-12"},"5277-15":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-14"},"5277-17":{"renderedLength":22,"gzipLength":0,"brotliLength":0,"metaUid":"5277-16"},"5277-19":{"renderedLength":65,"gzipLength":0,"brotliLength":0,"metaUid":"5277-18"},"5277-21":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-20"},"5277-23":{"renderedLength":6194,"gzipLength":0,"brotliLength":0,"metaUid":"5277-22"},"5277-25":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-24"},"5277-27":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-26"},"5277-29":{"renderedLength":1858,"gzipLength":0,"brotliLength":0,"metaUid":"5277-28"},"5277-31":{"renderedLength":1648,"gzipLength":0,"brotliLength":0,"metaUid":"5277-30"},"5277-33":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-32"},"5277-35":{"renderedLength":837,"gzipLength":0,"brotliLength":0,"metaUid":"5277-34"},"5277-37":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-36"},"5277-39":{"renderedLength":12968,"gzipLength":0,"brotliLength":0,"metaUid":"5277-38"},"5277-41":{"renderedLength":62,"gzipLength":0,"brotliLength":0,"metaUid":"5277-40"},"5277-43":{"renderedLength":48,"gzipLength":0,"brotliLength":0,"metaUid":"5277-42"},"5277-45":{"renderedLength":678,"gzipLength":0,"brotliLength":0,"metaUid":"5277-44"},"5277-47":{"renderedLength":13808,"gzipLength":0,"brotliLength":0,"metaUid":"5277-46"},"5277-49":{"renderedLength":60,"gzipLength":0,"brotliLength":0,"metaUid":"5277-48"},"5277-51":{"renderedLength":7251,"gzipLength":0,"brotliLength":0,"metaUid":"5277-50"},"5277-53":{"renderedLength":3089,"gzipLength":0,"brotliLength":0,"metaUid":"5277-52"},"5277-55":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-54"},"5277-57":{"renderedLength":4236,"gzipLength":0,"brotliLength":0,"metaUid":"5277-56"},"5277-59":{"renderedLength":728,"gzipLength":0,"brotliLength":0,"metaUid":"5277-58"},"5277-61":{"renderedLength":1627,"gzipLength":0,"brotliLength":0,"metaUid":"5277-60"},"5277-63":{"renderedLength":21114,"gzipLength":0,"brotliLength":0,"metaUid":"5277-62"},"5277-65":{"renderedLength":3315,"gzipLength":0,"brotliLength":0,"metaUid":"5277-64"},"5277-67":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-66"},"5277-69":{"renderedLength":8763,"gzipLength":0,"brotliLength":0,"metaUid":"5277-68"},"5277-71":{"renderedLength":2963,"gzipLength":0,"brotliLength":0,"metaUid":"5277-70"},"5277-73":{"renderedLength":6823,"gzipLength":0,"brotliLength":0,"metaUid":"5277-72"},"5277-75":{"renderedLength":296,"gzipLength":0,"brotliLength":0,"metaUid":"5277-74"},"5277-77":{"renderedLength":35856,"gzipLength":0,"brotliLength":0,"metaUid":"5277-76"},"5277-79":{"renderedLength":4514,"gzipLength":0,"brotliLength":0,"metaUid":"5277-78"},"5277-81":{"renderedLength":372,"gzipLength":0,"brotliLength":0,"metaUid":"5277-80"},"5277-83":{"renderedLength":2324,"gzipLength":0,"brotliLength":0,"metaUid":"5277-82"},"5277-85":{"renderedLength":504,"gzipLength":0,"brotliLength":0,"metaUid":"5277-84"},"5277-87":{"renderedLength":2386,"gzipLength":0,"brotliLength":0,"metaUid":"5277-86"},"5277-89":{"renderedLength":4715,"gzipLength":0,"brotliLength":0,"metaUid":"5277-88"},"5277-91":{"renderedLength":4644,"gzipLength":0,"brotliLength":0,"metaUid":"5277-90"},"5277-93":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-92"},"5277-95":{"renderedLength":1932,"gzipLength":0,"brotliLength":0,"metaUid":"5277-94"},"5277-97":{"renderedLength":1975,"gzipLength":0,"brotliLength":0,"metaUid":"5277-96"},"5277-99":{"renderedLength":2079,"gzipLength":0,"brotliLength":0,"metaUid":"5277-98"},"5277-101":{"renderedLength":3367,"gzipLength":0,"brotliLength":0,"metaUid":"5277-100"},"5277-103":{"renderedLength":1111,"gzipLength":0,"brotliLength":0,"metaUid":"5277-102"},"5277-105":{"renderedLength":7324,"gzipLength":0,"brotliLength":0,"metaUid":"5277-104"},"5277-107":{"renderedLength":1200,"gzipLength":0,"brotliLength":0,"metaUid":"5277-106"},"5277-109":{"renderedLength":445,"gzipLength":0,"brotliLength":0,"metaUid":"5277-108"},"5277-111":{"renderedLength":1304,"gzipLength":0,"brotliLength":0,"metaUid":"5277-110"},"5277-113":{"renderedLength":7736,"gzipLength":0,"brotliLength":0,"metaUid":"5277-112"},"5277-115":{"renderedLength":26906,"gzipLength":0,"brotliLength":0,"metaUid":"5277-114"},"5277-117":{"renderedLength":14015,"gzipLength":0,"brotliLength":0,"metaUid":"5277-116"},"5277-119":{"renderedLength":1033,"gzipLength":0,"brotliLength":0,"metaUid":"5277-118"},"5277-121":{"renderedLength":6184,"gzipLength":0,"brotliLength":0,"metaUid":"5277-120"},"5277-123":{"renderedLength":279,"gzipLength":0,"brotliLength":0,"metaUid":"5277-122"},"5277-125":{"renderedLength":2280,"gzipLength":0,"brotliLength":0,"metaUid":"5277-124"},"5277-127":{"renderedLength":62,"gzipLength":0,"brotliLength":0,"metaUid":"5277-126"},"5277-129":{"renderedLength":69,"gzipLength":0,"brotliLength":0,"metaUid":"5277-128"},"5277-131":{"renderedLength":2290,"gzipLength":0,"brotliLength":0,"metaUid":"5277-130"},"5277-133":{"renderedLength":611,"gzipLength":0,"brotliLength":0,"metaUid":"5277-132"},"5277-135":{"renderedLength":1002,"gzipLength":0,"brotliLength":0,"metaUid":"5277-134"},"5277-137":{"renderedLength":100,"gzipLength":0,"brotliLength":0,"metaUid":"5277-136"},"5277-139":{"renderedLength":1597,"gzipLength":0,"brotliLength":0,"metaUid":"5277-138"},"5277-141":{"renderedLength":2727,"gzipLength":0,"brotliLength":0,"metaUid":"5277-140"},"5277-143":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-142"},"5277-145":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-144"},"5277-147":{"renderedLength":510,"gzipLength":0,"brotliLength":0,"metaUid":"5277-146"},"5277-149":{"renderedLength":440,"gzipLength":0,"brotliLength":0,"metaUid":"5277-148"},"5277-151":{"renderedLength":420,"gzipLength":0,"brotliLength":0,"metaUid":"5277-150"},"5277-153":{"renderedLength":2533,"gzipLength":0,"brotliLength":0,"metaUid":"5277-152"},"5277-155":{"renderedLength":3127,"gzipLength":0,"brotliLength":0,"metaUid":"5277-154"},"5277-157":{"renderedLength":61,"gzipLength":0,"brotliLength":0,"metaUid":"5277-156"},"5277-159":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-158"},"5277-161":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-160"},"5277-163":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-162"},"5277-165":{"renderedLength":6590,"gzipLength":0,"brotliLength":0,"metaUid":"5277-164"},"5277-167":{"renderedLength":265,"gzipLength":0,"brotliLength":0,"metaUid":"5277-166"},"5277-169":{"renderedLength":3368,"gzipLength":0,"brotliLength":0,"metaUid":"5277-168"},"5277-171":{"renderedLength":3295,"gzipLength":0,"brotliLength":0,"metaUid":"5277-170"},"5277-173":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-172"},"5277-175":{"renderedLength":1426,"gzipLength":0,"brotliLength":0,"metaUid":"5277-174"},"5277-177":{"renderedLength":1307,"gzipLength":0,"brotliLength":0,"metaUid":"5277-176"},"5277-179":{"renderedLength":100,"gzipLength":0,"brotliLength":0,"metaUid":"5277-178"},"5277-181":{"renderedLength":1247,"gzipLength":0,"brotliLength":0,"metaUid":"5277-180"},"5277-183":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-182"},"5277-185":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-184"},"5277-187":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-186"},"5277-189":{"renderedLength":168,"gzipLength":0,"brotliLength":0,"metaUid":"5277-188"},"5277-191":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-190"},"5277-193":{"renderedLength":210,"gzipLength":0,"brotliLength":0,"metaUid":"5277-192"},"5277-195":{"renderedLength":335,"gzipLength":0,"brotliLength":0,"metaUid":"5277-194"},"5277-197":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-196"},"5277-199":{"renderedLength":880,"gzipLength":0,"brotliLength":0,"metaUid":"5277-198"},"5277-201":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-200"},"5277-203":{"renderedLength":532,"gzipLength":0,"brotliLength":0,"metaUid":"5277-202"},"5277-205":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-204"},"5277-207":{"renderedLength":941,"gzipLength":0,"brotliLength":0,"metaUid":"5277-206"},"5277-209":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-208"},"5277-211":{"renderedLength":414,"gzipLength":0,"brotliLength":0,"metaUid":"5277-210"},"5277-213":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-212"},"5277-215":{"renderedLength":268,"gzipLength":0,"brotliLength":0,"metaUid":"5277-214"},"5277-217":{"renderedLength":908,"gzipLength":0,"brotliLength":0,"metaUid":"5277-216"},"5277-219":{"renderedLength":2407,"gzipLength":0,"brotliLength":0,"metaUid":"5277-218"},"5277-221":{"renderedLength":266,"gzipLength":0,"brotliLength":0,"metaUid":"5277-220"},"5277-223":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-222"},"5277-225":{"renderedLength":6396,"gzipLength":0,"brotliLength":0,"metaUid":"5277-224"},"5277-227":{"renderedLength":2018,"gzipLength":0,"brotliLength":0,"metaUid":"5277-226"},"5277-229":{"renderedLength":3086,"gzipLength":0,"brotliLength":0,"metaUid":"5277-228"},"5277-231":{"renderedLength":686,"gzipLength":0,"brotliLength":0,"metaUid":"5277-230"},"5277-233":{"renderedLength":1221,"gzipLength":0,"brotliLength":0,"metaUid":"5277-232"},"5277-235":{"renderedLength":2917,"gzipLength":0,"brotliLength":0,"metaUid":"5277-234"},"5277-237":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-236"},"5277-239":{"renderedLength":3239,"gzipLength":0,"brotliLength":0,"metaUid":"5277-238"},"5277-241":{"renderedLength":499,"gzipLength":0,"brotliLength":0,"metaUid":"5277-240"},"5277-243":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-242"},"5277-245":{"renderedLength":365,"gzipLength":0,"brotliLength":0,"metaUid":"5277-244"},"5277-247":{"renderedLength":1969,"gzipLength":0,"brotliLength":0,"metaUid":"5277-246"},"5277-249":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-248"},"5277-251":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-250"},"5277-253":{"renderedLength":90660,"gzipLength":0,"brotliLength":0,"metaUid":"5277-252"},"5277-255":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-254"},"5277-257":{"renderedLength":90660,"gzipLength":0,"brotliLength":0,"metaUid":"5277-256"},"5277-259":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-258"},"5277-261":{"renderedLength":1730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-260"},"5277-263":{"renderedLength":2675,"gzipLength":0,"brotliLength":0,"metaUid":"5277-262"},"5277-265":{"renderedLength":2446,"gzipLength":0,"brotliLength":0,"metaUid":"5277-264"},"5277-267":{"renderedLength":7197,"gzipLength":0,"brotliLength":0,"metaUid":"5277-266"},"5277-269":{"renderedLength":4110,"gzipLength":0,"brotliLength":0,"metaUid":"5277-268"},"5277-271":{"renderedLength":1300,"gzipLength":0,"brotliLength":0,"metaUid":"5277-270"},"5277-273":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-272"},"5277-275":{"renderedLength":48,"gzipLength":0,"brotliLength":0,"metaUid":"5277-274"},"5277-277":{"renderedLength":7235,"gzipLength":0,"brotliLength":0,"metaUid":"5277-276"},"5277-279":{"renderedLength":3069,"gzipLength":0,"brotliLength":0,"metaUid":"5277-278"},"5277-281":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-280"},"5277-283":{"renderedLength":4180,"gzipLength":0,"brotliLength":0,"metaUid":"5277-282"},"5277-285":{"renderedLength":712,"gzipLength":0,"brotliLength":0,"metaUid":"5277-284"},"5277-287":{"renderedLength":21110,"gzipLength":0,"brotliLength":0,"metaUid":"5277-286"},"5277-289":{"renderedLength":3315,"gzipLength":0,"brotliLength":0,"metaUid":"5277-288"},"5277-291":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-290"},"5277-293":{"renderedLength":8763,"gzipLength":0,"brotliLength":0,"metaUid":"5277-292"},"5277-295":{"renderedLength":2955,"gzipLength":0,"brotliLength":0,"metaUid":"5277-294"},"5277-297":{"renderedLength":6807,"gzipLength":0,"brotliLength":0,"metaUid":"5277-296"},"5277-299":{"renderedLength":280,"gzipLength":0,"brotliLength":0,"metaUid":"5277-298"},"5277-301":{"renderedLength":35846,"gzipLength":0,"brotliLength":0,"metaUid":"5277-300"},"5277-303":{"renderedLength":4496,"gzipLength":0,"brotliLength":0,"metaUid":"5277-302"},"5277-305":{"renderedLength":372,"gzipLength":0,"brotliLength":0,"metaUid":"5277-304"},"5277-307":{"renderedLength":2298,"gzipLength":0,"brotliLength":0,"metaUid":"5277-306"},"5277-309":{"renderedLength":502,"gzipLength":0,"brotliLength":0,"metaUid":"5277-308"},"5277-311":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-310"},"5277-313":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-312"},"5277-315":{"renderedLength":88794,"gzipLength":0,"brotliLength":0,"metaUid":"5277-314"},"5277-317":{"renderedLength":1118,"gzipLength":0,"brotliLength":0,"metaUid":"5277-316"},"5277-319":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-318"},"5277-321":{"renderedLength":1614,"gzipLength":0,"brotliLength":0,"metaUid":"5277-320"},"5277-323":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-322"},"5277-325":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-324"},"5277-327":{"renderedLength":90660,"gzipLength":0,"brotliLength":0,"metaUid":"5277-326"},"5277-329":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-328"},"5277-331":{"renderedLength":1214,"gzipLength":0,"brotliLength":0,"metaUid":"5277-330"},"5277-333":{"renderedLength":2438,"gzipLength":0,"brotliLength":0,"metaUid":"5277-332"},"5277-335":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-334"},"5277-337":{"renderedLength":9194,"gzipLength":0,"brotliLength":0,"metaUid":"5277-336"},"5277-339":{"renderedLength":23038,"gzipLength":0,"brotliLength":0,"metaUid":"5277-338"},"5277-341":{"renderedLength":4607,"gzipLength":0,"brotliLength":0,"metaUid":"5277-340"},"5277-343":{"renderedLength":10899,"gzipLength":0,"brotliLength":0,"metaUid":"5277-342"},"5277-345":{"renderedLength":148,"gzipLength":0,"brotliLength":0,"metaUid":"5277-344"},"5277-347":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-346"},"5277-349":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-348"},"5277-351":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-350"},"5277-353":{"renderedLength":6583,"gzipLength":0,"brotliLength":0,"metaUid":"5277-352"},"5277-355":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-354"},"5277-357":{"renderedLength":2294,"gzipLength":0,"brotliLength":0,"metaUid":"5277-356"},"5277-359":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-358"},"5277-361":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-360"},"5277-363":{"renderedLength":923,"gzipLength":0,"brotliLength":0,"metaUid":"5277-362"},"5277-365":{"renderedLength":1560,"gzipLength":0,"brotliLength":0,"metaUid":"5277-364"},"5277-367":{"renderedLength":2887,"gzipLength":0,"brotliLength":0,"metaUid":"5277-366"},"5277-369":{"renderedLength":631,"gzipLength":0,"brotliLength":0,"metaUid":"5277-368"},"5277-371":{"renderedLength":8344,"gzipLength":0,"brotliLength":0,"metaUid":"5277-370"},"5277-373":{"renderedLength":730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-372"},"5277-375":{"renderedLength":90,"gzipLength":0,"brotliLength":0,"metaUid":"5277-374"},"5277-377":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-376"},"5277-379":{"renderedLength":3538,"gzipLength":0,"brotliLength":0,"metaUid":"5277-378"},"5277-381":{"renderedLength":1102,"gzipLength":0,"brotliLength":0,"metaUid":"5277-380"},"5277-383":{"renderedLength":406,"gzipLength":0,"brotliLength":0,"metaUid":"5277-382"},"5277-385":{"renderedLength":33475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-384"},"5277-387":{"renderedLength":6619,"gzipLength":0,"brotliLength":0,"metaUid":"5277-386"},"5277-389":{"renderedLength":2943,"gzipLength":0,"brotliLength":0,"metaUid":"5277-388"},"5277-391":{"renderedLength":3129,"gzipLength":0,"brotliLength":0,"metaUid":"5277-390"},"5277-393":{"renderedLength":3261,"gzipLength":0,"brotliLength":0,"metaUid":"5277-392"},"5277-395":{"renderedLength":6474,"gzipLength":0,"brotliLength":0,"metaUid":"5277-394"},"5277-397":{"renderedLength":2539,"gzipLength":0,"brotliLength":0,"metaUid":"5277-396"},"5277-399":{"renderedLength":1707,"gzipLength":0,"brotliLength":0,"metaUid":"5277-398"},"5277-401":{"renderedLength":3434,"gzipLength":0,"brotliLength":0,"metaUid":"5277-400"},"5277-403":{"renderedLength":450,"gzipLength":0,"brotliLength":0,"metaUid":"5277-402"},"5277-405":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-404"},"5277-407":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-406"},"5277-409":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-408"},"5277-411":{"renderedLength":90660,"gzipLength":0,"brotliLength":0,"metaUid":"5277-410"},"5277-413":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-412"},"5277-415":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-414"},"5277-417":{"renderedLength":2084,"gzipLength":0,"brotliLength":0,"metaUid":"5277-416"},"5277-419":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-418"},"5277-421":{"renderedLength":2701,"gzipLength":0,"brotliLength":0,"metaUid":"5277-420"},"5277-423":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-422"},"5277-425":{"renderedLength":4160,"gzipLength":0,"brotliLength":0,"metaUid":"5277-424"},"5277-427":{"renderedLength":16714,"gzipLength":0,"brotliLength":0,"metaUid":"5277-426"},"5277-429":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-428"},"5277-431":{"renderedLength":1083,"gzipLength":0,"brotliLength":0,"metaUid":"5277-430"},"5277-433":{"renderedLength":7874,"gzipLength":0,"brotliLength":0,"metaUid":"5277-432"},"5277-435":{"renderedLength":592,"gzipLength":0,"brotliLength":0,"metaUid":"5277-434"},"5277-437":{"renderedLength":114,"gzipLength":0,"brotliLength":0,"metaUid":"5277-436"},"5277-439":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-438"},"5277-441":{"renderedLength":7990,"gzipLength":0,"brotliLength":0,"metaUid":"5277-440"},"5277-443":{"renderedLength":1177,"gzipLength":0,"brotliLength":0,"metaUid":"5277-442"},"5277-445":{"renderedLength":110,"gzipLength":0,"brotliLength":0,"metaUid":"5277-444"},"5277-447":{"renderedLength":1479,"gzipLength":0,"brotliLength":0,"metaUid":"5277-446"},"5277-449":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-448"},"5277-451":{"renderedLength":201,"gzipLength":0,"brotliLength":0,"metaUid":"5277-450"},"5277-453":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-452"},"5277-455":{"renderedLength":395,"gzipLength":0,"brotliLength":0,"metaUid":"5277-454"},"5277-457":{"renderedLength":218,"gzipLength":0,"brotliLength":0,"metaUid":"5277-456"},"5277-459":{"renderedLength":2300,"gzipLength":0,"brotliLength":0,"metaUid":"5277-458"},"5277-461":{"renderedLength":3126,"gzipLength":0,"brotliLength":0,"metaUid":"5277-460"},"5277-463":{"renderedLength":534,"gzipLength":0,"brotliLength":0,"metaUid":"5277-462"},"5277-465":{"renderedLength":1235,"gzipLength":0,"brotliLength":0,"metaUid":"5277-464"},"5277-467":{"renderedLength":3703,"gzipLength":0,"brotliLength":0,"metaUid":"5277-466"},"5277-469":{"renderedLength":189,"gzipLength":0,"brotliLength":0,"metaUid":"5277-468"},"5277-471":{"renderedLength":4183,"gzipLength":0,"brotliLength":0,"metaUid":"5277-470"},"5277-473":{"renderedLength":2654,"gzipLength":0,"brotliLength":0,"metaUid":"5277-472"},"5277-475":{"renderedLength":2466,"gzipLength":0,"brotliLength":0,"metaUid":"5277-474"},"5277-477":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-476"},"5277-479":{"renderedLength":90660,"gzipLength":0,"brotliLength":0,"metaUid":"5277-478"},"5277-481":{"renderedLength":2991,"gzipLength":0,"brotliLength":0,"metaUid":"5277-480"},"5277-483":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-482"},"5277-485":{"renderedLength":423,"gzipLength":0,"brotliLength":0,"metaUid":"5277-484"},"5277-487":{"renderedLength":127,"gzipLength":0,"brotliLength":0,"metaUid":"5277-486"},"5277-489":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-488"},"5277-491":{"renderedLength":90652,"gzipLength":0,"brotliLength":0,"metaUid":"5277-490"},"5277-493":{"renderedLength":283,"gzipLength":0,"brotliLength":0,"metaUid":"5277-492"},"5277-495":{"renderedLength":2351,"gzipLength":0,"brotliLength":0,"metaUid":"5277-494"},"5277-497":{"renderedLength":2417,"gzipLength":0,"brotliLength":0,"metaUid":"5277-496"},"5277-499":{"renderedLength":351,"gzipLength":0,"brotliLength":0,"metaUid":"5277-498"},"5277-501":{"renderedLength":21,"gzipLength":0,"brotliLength":0,"metaUid":"5277-500"},"5277-503":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-502"},"5277-505":{"renderedLength":2743,"gzipLength":0,"brotliLength":0,"metaUid":"5277-504"},"5277-507":{"renderedLength":3461,"gzipLength":0,"brotliLength":0,"metaUid":"5277-506"},"5277-509":{"renderedLength":5301,"gzipLength":0,"brotliLength":0,"metaUid":"5277-508"},"5277-511":{"renderedLength":10571,"gzipLength":0,"brotliLength":0,"metaUid":"5277-510"},"5277-513":{"renderedLength":10895,"gzipLength":0,"brotliLength":0,"metaUid":"5277-512"},"5277-515":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-514"},"5277-517":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-516"},"5277-519":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-518"},"5277-521":{"renderedLength":475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-520"},"5277-523":{"renderedLength":1833,"gzipLength":0,"brotliLength":0,"metaUid":"5277-522"},"5277-525":{"renderedLength":21,"gzipLength":0,"brotliLength":0,"metaUid":"5277-524"},"5277-527":{"renderedLength":1766,"gzipLength":0,"brotliLength":0,"metaUid":"5277-526"},"5277-529":{"renderedLength":1635,"gzipLength":0,"brotliLength":0,"metaUid":"5277-528"},"5277-531":{"renderedLength":649,"gzipLength":0,"brotliLength":0,"metaUid":"5277-530"},"5277-533":{"renderedLength":1714,"gzipLength":0,"brotliLength":0,"metaUid":"5277-532"},"5277-535":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-534"},"5277-537":{"renderedLength":45754,"gzipLength":0,"brotliLength":0,"metaUid":"5277-536"},"5277-539":{"renderedLength":1025,"gzipLength":0,"brotliLength":0,"metaUid":"5277-538"},"5277-541":{"renderedLength":130,"gzipLength":0,"brotliLength":0,"metaUid":"5277-540"},"5277-543":{"renderedLength":82,"gzipLength":0,"brotliLength":0,"metaUid":"5277-542"},"5277-545":{"renderedLength":1408,"gzipLength":0,"brotliLength":0,"metaUid":"5277-544"},"5277-547":{"renderedLength":457,"gzipLength":0,"brotliLength":0,"metaUid":"5277-546"},"5277-549":{"renderedLength":478,"gzipLength":0,"brotliLength":0,"metaUid":"5277-548"},"5277-551":{"renderedLength":2237,"gzipLength":0,"brotliLength":0,"metaUid":"5277-550"},"5277-553":{"renderedLength":1219,"gzipLength":0,"brotliLength":0,"metaUid":"5277-552"},"5277-555":{"renderedLength":1797,"gzipLength":0,"brotliLength":0,"metaUid":"5277-554"},"5277-557":{"renderedLength":1594,"gzipLength":0,"brotliLength":0,"metaUid":"5277-556"},"5277-559":{"renderedLength":3303,"gzipLength":0,"brotliLength":0,"metaUid":"5277-558"},"5277-561":{"renderedLength":237,"gzipLength":0,"brotliLength":0,"metaUid":"5277-560"},"5277-563":{"renderedLength":1599,"gzipLength":0,"brotliLength":0,"metaUid":"5277-562"},"5277-565":{"renderedLength":798,"gzipLength":0,"brotliLength":0,"metaUid":"5277-564"},"5277-567":{"renderedLength":3179,"gzipLength":0,"brotliLength":0,"metaUid":"5277-566"},"5277-569":{"renderedLength":922,"gzipLength":0,"brotliLength":0,"metaUid":"5277-568"},"5277-571":{"renderedLength":316,"gzipLength":0,"brotliLength":0,"metaUid":"5277-570"},"5277-573":{"renderedLength":507,"gzipLength":0,"brotliLength":0,"metaUid":"5277-572"},"5277-575":{"renderedLength":10930,"gzipLength":0,"brotliLength":0,"metaUid":"5277-574"},"5277-577":{"renderedLength":450,"gzipLength":0,"brotliLength":0,"metaUid":"5277-576"},"5277-579":{"renderedLength":4386,"gzipLength":0,"brotliLength":0,"metaUid":"5277-578"},"5277-581":{"renderedLength":3146,"gzipLength":0,"brotliLength":0,"metaUid":"5277-580"},"5277-583":{"renderedLength":86,"gzipLength":0,"brotliLength":0,"metaUid":"5277-582"},"5277-585":{"renderedLength":2442,"gzipLength":0,"brotliLength":0,"metaUid":"5277-584"},"5277-587":{"renderedLength":19386,"gzipLength":0,"brotliLength":0,"metaUid":"5277-586"},"5277-589":{"renderedLength":1672,"gzipLength":0,"brotliLength":0,"metaUid":"5277-588"},"5277-591":{"renderedLength":1567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-590"},"5277-593":{"renderedLength":2685,"gzipLength":0,"brotliLength":0,"metaUid":"5277-592"},"5277-595":{"renderedLength":9781,"gzipLength":0,"brotliLength":0,"metaUid":"5277-594"},"5277-597":{"renderedLength":115,"gzipLength":0,"brotliLength":0,"metaUid":"5277-596"},"5277-599":{"renderedLength":23673,"gzipLength":0,"brotliLength":0,"metaUid":"5277-598"},"5277-601":{"renderedLength":1376,"gzipLength":0,"brotliLength":0,"metaUid":"5277-600"},"5277-603":{"renderedLength":9984,"gzipLength":0,"brotliLength":0,"metaUid":"5277-602"},"5277-605":{"renderedLength":1106,"gzipLength":0,"brotliLength":0,"metaUid":"5277-604"},"5277-607":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-606"},"5277-609":{"renderedLength":16180,"gzipLength":0,"brotliLength":0,"metaUid":"5277-608"},"5277-611":{"renderedLength":65995,"gzipLength":0,"brotliLength":0,"metaUid":"5277-610"},"5277-613":{"renderedLength":2755,"gzipLength":0,"brotliLength":0,"metaUid":"5277-612"},"5277-615":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-614"},"5277-617":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-616"},"5277-619":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-618"},"5277-621":{"renderedLength":2124,"gzipLength":0,"brotliLength":0,"metaUid":"5277-620"},"5277-623":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-622"},"5277-625":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-624"},"5277-627":{"renderedLength":5882,"gzipLength":0,"brotliLength":0,"metaUid":"5277-626"},"5277-629":{"renderedLength":2294,"gzipLength":0,"brotliLength":0,"metaUid":"5277-628"},"5277-631":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-630"},"5277-633":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-632"},"5277-635":{"renderedLength":2564,"gzipLength":0,"brotliLength":0,"metaUid":"5277-634"},"5277-637":{"renderedLength":4140,"gzipLength":0,"brotliLength":0,"metaUid":"5277-636"},"5277-639":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-638"},"5277-641":{"renderedLength":5728,"gzipLength":0,"brotliLength":0,"metaUid":"5277-640"},"5277-643":{"renderedLength":1165,"gzipLength":0,"brotliLength":0,"metaUid":"5277-642"},"5277-645":{"renderedLength":1284,"gzipLength":0,"brotliLength":0,"metaUid":"5277-644"},"5277-647":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-646"},"5277-649":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-648"},"5277-651":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-650"},"5277-653":{"renderedLength":389,"gzipLength":0,"brotliLength":0,"metaUid":"5277-652"},"5277-655":{"renderedLength":572,"gzipLength":0,"brotliLength":0,"metaUid":"5277-654"},"5277-657":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-656"},"5277-659":{"renderedLength":2629,"gzipLength":0,"brotliLength":0,"metaUid":"5277-658"},"5277-661":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-660"},"5277-663":{"renderedLength":730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-662"},"5277-665":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-664"},"5277-667":{"renderedLength":9544,"gzipLength":0,"brotliLength":0,"metaUid":"5277-666"},"5277-669":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-668"},"5277-671":{"renderedLength":416,"gzipLength":0,"brotliLength":0,"metaUid":"5277-670"},"5277-673":{"renderedLength":929,"gzipLength":0,"brotliLength":0,"metaUid":"5277-672"},"5277-675":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-674"},"5277-677":{"renderedLength":3481,"gzipLength":0,"brotliLength":0,"metaUid":"5277-676"},"5277-679":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-678"},"5277-681":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-680"},"5277-683":{"renderedLength":1401,"gzipLength":0,"brotliLength":0,"metaUid":"5277-682"},"5277-685":{"renderedLength":3138,"gzipLength":0,"brotliLength":0,"metaUid":"5277-684"},"5277-687":{"renderedLength":12503,"gzipLength":0,"brotliLength":0,"metaUid":"5277-686"},"5277-689":{"renderedLength":43,"gzipLength":0,"brotliLength":0,"metaUid":"5277-688"},"5277-691":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-690"},"5277-693":{"renderedLength":2362,"gzipLength":0,"brotliLength":0,"metaUid":"5277-692"},"5277-695":{"renderedLength":7672,"gzipLength":0,"brotliLength":0,"metaUid":"5277-694"},"5277-697":{"renderedLength":58,"gzipLength":0,"brotliLength":0,"metaUid":"5277-696"},"5277-699":{"renderedLength":32,"gzipLength":0,"brotliLength":0,"metaUid":"5277-698"},"5277-701":{"renderedLength":22,"gzipLength":0,"brotliLength":0,"metaUid":"5277-700"},"5277-703":{"renderedLength":2663,"gzipLength":0,"brotliLength":0,"metaUid":"5277-702"},"5277-705":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-704"},"5277-707":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-706"},"5277-709":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-708"},"5277-711":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-710"},"5277-713":{"renderedLength":1122,"gzipLength":0,"brotliLength":0,"metaUid":"5277-712"},"5277-715":{"renderedLength":128,"gzipLength":0,"brotliLength":0,"metaUid":"5277-714"},"5277-717":{"renderedLength":46,"gzipLength":0,"brotliLength":0,"metaUid":"5277-716"},"5277-719":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-718"},"5277-721":{"renderedLength":1706,"gzipLength":0,"brotliLength":0,"metaUid":"5277-720"},"5277-723":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-722"},"5277-725":{"renderedLength":3018,"gzipLength":0,"brotliLength":0,"metaUid":"5277-724"},"5277-727":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-726"},"5277-729":{"renderedLength":2327,"gzipLength":0,"brotliLength":0,"metaUid":"5277-728"},"5277-731":{"renderedLength":2153,"gzipLength":0,"brotliLength":0,"metaUid":"5277-730"},"5277-733":{"renderedLength":19445,"gzipLength":0,"brotliLength":0,"metaUid":"5277-732"},"5277-735":{"renderedLength":2900,"gzipLength":0,"brotliLength":0,"metaUid":"5277-734"},"5277-737":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-736"},"5277-739":{"renderedLength":8747,"gzipLength":0,"brotliLength":0,"metaUid":"5277-738"},"5277-741":{"renderedLength":31221,"gzipLength":0,"brotliLength":0,"metaUid":"5277-740"},"5277-743":{"renderedLength":4260,"gzipLength":0,"brotliLength":0,"metaUid":"5277-742"},"5277-745":{"renderedLength":458,"gzipLength":0,"brotliLength":0,"metaUid":"5277-744"},"5277-747":{"renderedLength":417,"gzipLength":0,"brotliLength":0,"metaUid":"5277-746"},"5277-749":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-748"},"5277-751":{"renderedLength":917,"gzipLength":0,"brotliLength":0,"metaUid":"5277-750"},"5277-753":{"renderedLength":984,"gzipLength":0,"brotliLength":0,"metaUid":"5277-752"},"5277-755":{"renderedLength":2686,"gzipLength":0,"brotliLength":0,"metaUid":"5277-754"},"5277-757":{"renderedLength":21,"gzipLength":0,"brotliLength":0,"metaUid":"5277-756"},"5277-759":{"renderedLength":928,"gzipLength":0,"brotliLength":0,"metaUid":"5277-758"},"5277-761":{"renderedLength":3126,"gzipLength":0,"brotliLength":0,"metaUid":"5277-760"},"5277-763":{"renderedLength":92,"gzipLength":0,"brotliLength":0,"metaUid":"5277-762"},"5277-765":{"renderedLength":661,"gzipLength":0,"brotliLength":0,"metaUid":"5277-764"},"5277-767":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-766"},"5277-769":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-768"},"5277-771":{"renderedLength":1187,"gzipLength":0,"brotliLength":0,"metaUid":"5277-770"},"5277-773":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-772"},"5277-775":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-774"},"5277-777":{"renderedLength":2078,"gzipLength":0,"brotliLength":0,"metaUid":"5277-776"},"5277-779":{"renderedLength":3933,"gzipLength":0,"brotliLength":0,"metaUid":"5277-778"},"5277-781":{"renderedLength":552,"gzipLength":0,"brotliLength":0,"metaUid":"5277-780"},"5277-783":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-782"},"5277-785":{"renderedLength":61,"gzipLength":0,"brotliLength":0,"metaUid":"5277-784"},"5277-787":{"renderedLength":2248,"gzipLength":0,"brotliLength":0,"metaUid":"5277-786"},"5277-789":{"renderedLength":6959,"gzipLength":0,"brotliLength":0,"metaUid":"5277-788"},"5277-791":{"renderedLength":11887,"gzipLength":0,"brotliLength":0,"metaUid":"5277-790"},"5277-793":{"renderedLength":165,"gzipLength":0,"brotliLength":0,"metaUid":"5277-792"},"5277-795":{"renderedLength":2050,"gzipLength":0,"brotliLength":0,"metaUid":"5277-794"},"5277-797":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-796"},"5277-799":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-798"},"5277-801":{"renderedLength":2567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-800"},"5277-803":{"renderedLength":2141,"gzipLength":0,"brotliLength":0,"metaUid":"5277-802"},"5277-805":{"renderedLength":1874,"gzipLength":0,"brotliLength":0,"metaUid":"5277-804"},"5277-807":{"renderedLength":1852,"gzipLength":0,"brotliLength":0,"metaUid":"5277-806"},"5277-809":{"renderedLength":2372,"gzipLength":0,"brotliLength":0,"metaUid":"5277-808"},"5277-811":{"renderedLength":1080,"gzipLength":0,"brotliLength":0,"metaUid":"5277-810"},"5277-813":{"renderedLength":4108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-812"},"5277-815":{"renderedLength":2178,"gzipLength":0,"brotliLength":0,"metaUid":"5277-814"},"5277-817":{"renderedLength":341,"gzipLength":0,"brotliLength":0,"metaUid":"5277-816"},"5277-819":{"renderedLength":163,"gzipLength":0,"brotliLength":0,"metaUid":"5277-818"},"5277-821":{"renderedLength":409,"gzipLength":0,"brotliLength":0,"metaUid":"5277-820"},"5277-823":{"renderedLength":135,"gzipLength":0,"brotliLength":0,"metaUid":"5277-822"},"5277-825":{"renderedLength":667,"gzipLength":0,"brotliLength":0,"metaUid":"5277-824"},"5277-827":{"renderedLength":176,"gzipLength":0,"brotliLength":0,"metaUid":"5277-826"},"5277-829":{"renderedLength":214,"gzipLength":0,"brotliLength":0,"metaUid":"5277-828"},"5277-831":{"renderedLength":500,"gzipLength":0,"brotliLength":0,"metaUid":"5277-830"},"5277-833":{"renderedLength":306,"gzipLength":0,"brotliLength":0,"metaUid":"5277-832"},"5277-835":{"renderedLength":222,"gzipLength":0,"brotliLength":0,"metaUid":"5277-834"},"5277-837":{"renderedLength":284,"gzipLength":0,"brotliLength":0,"metaUid":"5277-836"},"5277-839":{"renderedLength":71,"gzipLength":0,"brotliLength":0,"metaUid":"5277-838"},"5277-841":{"renderedLength":160,"gzipLength":0,"brotliLength":0,"metaUid":"5277-840"},"5277-843":{"renderedLength":185,"gzipLength":0,"brotliLength":0,"metaUid":"5277-842"},"5277-845":{"renderedLength":428,"gzipLength":0,"brotliLength":0,"metaUid":"5277-844"},"5277-847":{"renderedLength":195,"gzipLength":0,"brotliLength":0,"metaUid":"5277-846"},"5277-849":{"renderedLength":140,"gzipLength":0,"brotliLength":0,"metaUid":"5277-848"},"5277-851":{"renderedLength":104975,"gzipLength":0,"brotliLength":0,"metaUid":"5277-850"},"5277-853":{"renderedLength":1218,"gzipLength":0,"brotliLength":0,"metaUid":"5277-852"},"5277-855":{"renderedLength":1090,"gzipLength":0,"brotliLength":0,"metaUid":"5277-854"},"5277-857":{"renderedLength":876,"gzipLength":0,"brotliLength":0,"metaUid":"5277-856"},"5277-859":{"renderedLength":285,"gzipLength":0,"brotliLength":0,"metaUid":"5277-858"},"5277-861":{"renderedLength":2011,"gzipLength":0,"brotliLength":0,"metaUid":"5277-860"},"5277-863":{"renderedLength":2422,"gzipLength":0,"brotliLength":0,"metaUid":"5277-862"},"5277-865":{"renderedLength":1541,"gzipLength":0,"brotliLength":0,"metaUid":"5277-864"},"5277-867":{"renderedLength":3110,"gzipLength":0,"brotliLength":0,"metaUid":"5277-866"},"5277-869":{"renderedLength":1035,"gzipLength":0,"brotliLength":0,"metaUid":"5277-868"},"5277-871":{"renderedLength":726,"gzipLength":0,"brotliLength":0,"metaUid":"5277-870"},"5277-873":{"renderedLength":1260,"gzipLength":0,"brotliLength":0,"metaUid":"5277-872"},"5277-875":{"renderedLength":2490,"gzipLength":0,"brotliLength":0,"metaUid":"5277-874"},"5277-877":{"renderedLength":442,"gzipLength":0,"brotliLength":0,"metaUid":"5277-876"},"5277-879":{"renderedLength":5525,"gzipLength":0,"brotliLength":0,"metaUid":"5277-878"},"5277-881":{"renderedLength":1125,"gzipLength":0,"brotliLength":0,"metaUid":"5277-880"},"5277-883":{"renderedLength":628,"gzipLength":0,"brotliLength":0,"metaUid":"5277-882"},"5277-885":{"renderedLength":151,"gzipLength":0,"brotliLength":0,"metaUid":"5277-884"},"5277-887":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-886"},"5277-889":{"renderedLength":20129,"gzipLength":0,"brotliLength":0,"metaUid":"5277-888"},"5277-891":{"renderedLength":1226,"gzipLength":0,"brotliLength":0,"metaUid":"5277-890"},"5277-893":{"renderedLength":4726,"gzipLength":0,"brotliLength":0,"metaUid":"5277-892"},"5277-895":{"renderedLength":12040,"gzipLength":0,"brotliLength":0,"metaUid":"5277-894"},"5277-897":{"renderedLength":1421,"gzipLength":0,"brotliLength":0,"metaUid":"5277-896"},"5277-899":{"renderedLength":1302,"gzipLength":0,"brotliLength":0,"metaUid":"5277-898"},"5277-901":{"renderedLength":529,"gzipLength":0,"brotliLength":0,"metaUid":"5277-900"},"5277-903":{"renderedLength":418,"gzipLength":0,"brotliLength":0,"metaUid":"5277-902"},"5277-905":{"renderedLength":1340,"gzipLength":0,"brotliLength":0,"metaUid":"5277-904"},"5277-907":{"renderedLength":1458,"gzipLength":0,"brotliLength":0,"metaUid":"5277-906"},"5277-909":{"renderedLength":1159,"gzipLength":0,"brotliLength":0,"metaUid":"5277-908"},"5277-911":{"renderedLength":1746,"gzipLength":0,"brotliLength":0,"metaUid":"5277-910"},"5277-913":{"renderedLength":3275,"gzipLength":0,"brotliLength":0,"metaUid":"5277-912"},"5277-915":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-914"},"5277-917":{"renderedLength":25965,"gzipLength":0,"brotliLength":0,"metaUid":"5277-916"},"5277-919":{"renderedLength":245,"gzipLength":0,"brotliLength":0,"metaUid":"5277-918"},"5277-921":{"renderedLength":288,"gzipLength":0,"brotliLength":0,"metaUid":"5277-920"},"5277-923":{"renderedLength":830,"gzipLength":0,"brotliLength":0,"metaUid":"5277-922"},"5277-925":{"renderedLength":488,"gzipLength":0,"brotliLength":0,"metaUid":"5277-924"},"5277-927":{"renderedLength":557,"gzipLength":0,"brotliLength":0,"metaUid":"5277-926"},"5277-929":{"renderedLength":1143,"gzipLength":0,"brotliLength":0,"metaUid":"5277-928"},"5277-931":{"renderedLength":96,"gzipLength":0,"brotliLength":0,"metaUid":"5277-930"},"5277-933":{"renderedLength":461,"gzipLength":0,"brotliLength":0,"metaUid":"5277-932"},"5277-935":{"renderedLength":12518,"gzipLength":0,"brotliLength":0,"metaUid":"5277-934"},"5277-937":{"renderedLength":6127,"gzipLength":0,"brotliLength":0,"metaUid":"5277-936"},"5277-939":{"renderedLength":3328,"gzipLength":0,"brotliLength":0,"metaUid":"5277-938"},"5277-941":{"renderedLength":1100,"gzipLength":0,"brotliLength":0,"metaUid":"5277-940"},"5277-943":{"renderedLength":1210,"gzipLength":0,"brotliLength":0,"metaUid":"5277-942"},"5277-945":{"renderedLength":2626,"gzipLength":0,"brotliLength":0,"metaUid":"5277-944"},"5277-947":{"renderedLength":11318,"gzipLength":0,"brotliLength":0,"metaUid":"5277-946"},"5277-949":{"renderedLength":972,"gzipLength":0,"brotliLength":0,"metaUid":"5277-948"},"5277-951":{"renderedLength":1278,"gzipLength":0,"brotliLength":0,"metaUid":"5277-950"},"5277-953":{"renderedLength":1179,"gzipLength":0,"brotliLength":0,"metaUid":"5277-952"},"5277-955":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-954"},"5277-957":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-956"},"5277-959":{"renderedLength":52501,"gzipLength":0,"brotliLength":0,"metaUid":"5277-958"},"5277-961":{"renderedLength":553639,"gzipLength":0,"brotliLength":0,"metaUid":"5277-960"},"5277-963":{"renderedLength":2475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-962"},"5277-965":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-964"},"5277-967":{"renderedLength":1502,"gzipLength":0,"brotliLength":0,"metaUid":"5277-966"},"5277-969":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-968"},"5277-971":{"renderedLength":1727,"gzipLength":0,"brotliLength":0,"metaUid":"5277-970"},"5277-973":{"renderedLength":838,"gzipLength":0,"brotliLength":0,"metaUid":"5277-972"},"5277-975":{"renderedLength":1033,"gzipLength":0,"brotliLength":0,"metaUid":"5277-974"},"5277-977":{"renderedLength":2053,"gzipLength":0,"brotliLength":0,"metaUid":"5277-976"},"5277-979":{"renderedLength":320,"gzipLength":0,"brotliLength":0,"metaUid":"5277-978"},"5277-981":{"renderedLength":272,"gzipLength":0,"brotliLength":0,"metaUid":"5277-980"},"5277-983":{"renderedLength":2862,"gzipLength":0,"brotliLength":0,"metaUid":"5277-982"},"5277-985":{"renderedLength":2567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-984"},"5277-987":{"renderedLength":6490,"gzipLength":0,"brotliLength":0,"metaUid":"5277-986"},"5277-989":{"renderedLength":803,"gzipLength":0,"brotliLength":0,"metaUid":"5277-988"},"5277-991":{"renderedLength":3833,"gzipLength":0,"brotliLength":0,"metaUid":"5277-990"},"5277-993":{"renderedLength":3011,"gzipLength":0,"brotliLength":0,"metaUid":"5277-992"},"5277-995":{"renderedLength":2078,"gzipLength":0,"brotliLength":0,"metaUid":"5277-994"},"5277-997":{"renderedLength":565,"gzipLength":0,"brotliLength":0,"metaUid":"5277-996"},"5277-999":{"renderedLength":1088,"gzipLength":0,"brotliLength":0,"metaUid":"5277-998"},"5277-1001":{"renderedLength":3835,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1000"},"5277-1003":{"renderedLength":524,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1002"},"5277-1005":{"renderedLength":161,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1004"},"5277-1007":{"renderedLength":335,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1006"},"5277-1009":{"renderedLength":403,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1008"},"5277-1011":{"renderedLength":129,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1010"},"5277-1013":{"renderedLength":657,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1012"},"5277-1015":{"renderedLength":12139,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1014"},"5277-1017":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1016"},"5277-1019":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1018"},"5277-1021":{"renderedLength":7617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1020"},"5277-1023":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1022"},"5277-1025":{"renderedLength":92188,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1024"},"5277-1027":{"renderedLength":185,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1026"},"5277-1029":{"renderedLength":613,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1028"},"5277-1031":{"renderedLength":435,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1030"},"5277-1033":{"renderedLength":113,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1032"},"5277-1035":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1034"},"5277-1037":{"renderedLength":1706,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1036"},"5277-1039":{"renderedLength":1903,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1038"},"5277-1041":{"renderedLength":1936,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1040"},"5277-1043":{"renderedLength":2219,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1042"},"5277-1045":{"renderedLength":1881,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1044"},"5277-1047":{"renderedLength":1825,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1046"},"5277-1049":{"renderedLength":1814,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1048"},"5277-1051":{"renderedLength":2617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1050"},"5277-1053":{"renderedLength":3311,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1052"},"5277-1055":{"renderedLength":1487,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1054"},"5277-1057":{"renderedLength":1256,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1056"},"5277-1059":{"renderedLength":5859,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1058"},"5277-1061":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1060"}},"nodeMetas":{"5277-0":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-globals/src/global.js","moduleParts":{"metamask-sdk.js":"5277-1"},"imported":[],"importedBy":[{"uid":"5277-610"},{"uid":"5277-8"},{"uid":"5277-22"},{"uid":"5277-46"}]},"5277-2":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/base64.js","moduleParts":{"metamask-sdk.js":"5277-3"},"imported":[],"importedBy":[{"uid":"5277-8"}]},"5277-4":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/ieee754.js","moduleParts":{"metamask-sdk.js":"5277-5"},"imported":[],"importedBy":[{"uid":"5277-8"}]},"5277-6":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/isArray.js","moduleParts":{"metamask-sdk.js":"5277-7"},"imported":[],"importedBy":[{"uid":"5277-8"}]},"5277-8":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/index.js","moduleParts":{"metamask-sdk.js":"5277-9"},"imported":[{"uid":"5277-0"},{"uid":"5277-2"},{"uid":"5277-4"},{"uid":"5277-6"}],"importedBy":[{"uid":"5277-532"},{"uid":"5277-522"},{"uid":"5277-528"},{"uid":"5277-526"},{"uid":"5277-270"},{"uid":"5277-480"},{"uid":"5277-578"},{"uid":"5277-692"},{"uid":"5277-268"},{"uid":"5277-872"},{"uid":"5277-46"},{"uid":"5277-114"},{"uid":"5277-116"},{"uid":"5277-876"},{"uid":"5277-18"},{"uid":"5277-316"},{"uid":"5277-110"},{"uid":"5277-112"},{"uid":"5277-210"},{"uid":"5277-192"}]},"5277-10":{"id":"\u0000commonjsHelpers.js","moduleParts":{"metamask-sdk.js":"5277-11"},"imported":[],"importedBy":[{"uid":"5277-532"},{"uid":"5277-536"},{"uid":"5277-608"},{"uid":"5277-804"},{"uid":"5277-642"},{"uid":"5277-530"},{"uid":"5277-522"},{"uid":"5277-520"},{"uid":"5277-686"},{"uid":"5277-794"},{"uid":"5277-802"},{"uid":"5277-790"},{"uid":"5277-800"},{"uid":"5277-788"},{"uid":"5277-506"},{"uid":"5277-696"},{"uid":"5277-628"},{"uid":"5277-636"},{"uid":"5277-640"},{"uid":"5277-634"},{"uid":"5277-916"},{"uid":"5277-528"},{"uid":"5277-526"},{"uid":"5277-270"},{"uid":"5277-474"},{"uid":"5277-480"},{"uid":"5277-514"},{"uid":"5277-620"},{"uid":"5277-644"},{"uid":"5277-672"},{"uid":"5277-676"},{"uid":"5277-684"},{"uid":"5277-692"},{"uid":"5277-694"},{"uid":"5277-702"},{"uid":"5277-762"},{"uid":"5277-764"},{"uid":"5277-780"},{"uid":"5277-786"},{"uid":"5277-888"},{"uid":"5277-30"},{"uid":"5277-132"},{"uid":"5277-138"},{"uid":"5277-142"},{"uid":"5277-156"},{"uid":"5277-246"},{"uid":"5277-264"},{"uid":"5277-268"},{"uid":"5277-470"},{"uid":"5277-472"},{"uid":"5277-402"},{"uid":"5277-498"},{"uid":"5277-504"},{"uid":"5277-40"},{"uid":"5277-126"},{"uid":"5277-784"},{"uid":"5277-626"},{"uid":"5277-1026"},{"uid":"5277-508"},{"uid":"5277-262"},{"uid":"5277-28"},{"uid":"5277-308"},{"uid":"5277-34"},{"uid":"5277-260"},{"uid":"5277-394"},{"uid":"5277-478"},{"uid":"5277-510"},{"uid":"5277-512"},{"uid":"5277-654"},{"uid":"5277-658"},{"uid":"5277-662"},{"uid":"5277-652"},{"uid":"5277-666"},{"uid":"5277-670"},{"uid":"5277-682"},{"uid":"5277-760"},{"uid":"5277-770"},{"uid":"5277-778"},{"uid":"5277-752"},{"uid":"5277-754"},{"uid":"5277-782"},{"uid":"5277-1020"},{"uid":"5277-1024"},{"uid":"5277-1179"},{"uid":"5277-960"},{"uid":"5277-18"},{"uid":"5277-88"},{"uid":"5277-90"},{"uid":"5277-108"},{"uid":"5277-130"},{"uid":"5277-134"},{"uid":"5277-136"},{"uid":"5277-154"},{"uid":"5277-152"},{"uid":"5277-180"},{"uid":"5277-240"},{"uid":"5277-220"},{"uid":"5277-244"},{"uid":"5277-232"},{"uid":"5277-252"},{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-288"},{"uid":"5277-316"},{"uid":"5277-314"},{"uid":"5277-466"},{"uid":"5277-332"},{"uid":"5277-344"},{"uid":"5277-386"},{"uid":"5277-400"},{"uid":"5277-494"},{"uid":"5277-496"},{"uid":"5277-958"},{"uid":"5277-128"},{"uid":"5277-256"},{"uid":"5277-48"},{"uid":"5277-276"},{"uid":"5277-292"},{"uid":"5277-296"},{"uid":"5277-298"},{"uid":"5277-302"},{"uid":"5277-304"},{"uid":"5277-294"},{"uid":"5277-306"},{"uid":"5277-384"},{"uid":"5277-326"},{"uid":"5277-388"},{"uid":"5277-390"},{"uid":"5277-392"},{"uid":"5277-746"},{"uid":"5277-758"},{"uid":"5277-776"},{"uid":"5277-750"},{"uid":"5277-86"},{"uid":"5277-96"},{"uid":"5277-98"},{"uid":"5277-102"},{"uid":"5277-100"},{"uid":"5277-106"},{"uid":"5277-104"},{"uid":"5277-146"},{"uid":"5277-148"},{"uid":"5277-150"},{"uid":"5277-178"},{"uid":"5277-234"},{"uid":"5277-238"},{"uid":"5277-188"},{"uid":"5277-194"},{"uid":"5277-198"},{"uid":"5277-202"},{"uid":"5277-206"},{"uid":"5277-210"},{"uid":"5277-216"},{"uid":"5277-274"},{"uid":"5277-278"},{"uid":"5277-284"},{"uid":"5277-282"},{"uid":"5277-60"},{"uid":"5277-460"},{"uid":"5277-464"},{"uid":"5277-166"},{"uid":"5277-330"},{"uid":"5277-336"},{"uid":"5277-338"},{"uid":"5277-340"},{"uid":"5277-342"},{"uid":"5277-382"},{"uid":"5277-396"},{"uid":"5277-398"},{"uid":"5277-484"},{"uid":"5277-486"},{"uid":"5277-490"},{"uid":"5277-492"},{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-734"},{"uid":"5277-728"},{"uid":"5277-738"},{"uid":"5277-742"},{"uid":"5277-744"},{"uid":"5277-84"},{"uid":"5277-94"},{"uid":"5277-164"},{"uid":"5277-168"},{"uid":"5277-170"},{"uid":"5277-174"},{"uid":"5277-176"},{"uid":"5277-228"},{"uid":"5277-230"},{"uid":"5277-224"},{"uid":"5277-192"},{"uid":"5277-214"},{"uid":"5277-456"},{"uid":"5277-458"},{"uid":"5277-352"},{"uid":"5277-356"},{"uid":"5277-374"},{"uid":"5277-378"},{"uid":"5277-380"},{"uid":"5277-712"},{"uid":"5277-714"},{"uid":"5277-716"},{"uid":"5277-720"},{"uid":"5277-724"},{"uid":"5277-730"},{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-64"},{"uid":"5277-50"},{"uid":"5277-68"},{"uid":"5277-72"},{"uid":"5277-74"},{"uid":"5277-78"},{"uid":"5277-80"},{"uid":"5277-70"},{"uid":"5277-82"},{"uid":"5277-226"},{"uid":"5277-410"},{"uid":"5277-446"},{"uid":"5277-450"},{"uid":"5277-454"},{"uid":"5277-444"},{"uid":"5277-436"},{"uid":"5277-364"},{"uid":"5277-368"},{"uid":"5277-366"},{"uid":"5277-372"},{"uid":"5277-370"},{"uid":"5277-42"},{"uid":"5277-52"},{"uid":"5277-58"},{"uid":"5277-56"},{"uid":"5277-420"},{"uid":"5277-424"},{"uid":"5277-426"},{"uid":"5277-430"},{"uid":"5277-440"},{"uid":"5277-442"},{"uid":"5277-432"},{"uid":"5277-434"},{"uid":"5277-362"},{"uid":"5277-416"}]},"5277-12":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-13"},"imported":[],"importedBy":[{"uid":"5277-532"}]},"5277-14":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-15"},"imported":[],"importedBy":[{"uid":"5277-530"}]},"5277-16":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-17"},"imported":[],"importedBy":[{"uid":"5277-528"}]},"5277-18":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/index.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-19"},"imported":[{"uid":"5277-10"},{"uid":"5277-8"}],"importedBy":[{"uid":"5277-508"},{"uid":"5277-28"},{"uid":"5277-478"},{"uid":"5277-90"},{"uid":"5277-252"},{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-314"},{"uid":"5277-256"},{"uid":"5277-276"},{"uid":"5277-326"},{"uid":"5277-490"},{"uid":"5277-720"},{"uid":"5277-724"},{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-50"},{"uid":"5277-410"},{"uid":"5277-416"}]},"5277-20":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/crypto-browserify/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-21"},"imported":[],"importedBy":[{"uid":"5277-506"}]},"5277-22":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-es6/browser.js","moduleParts":{"metamask-sdk.js":"5277-23"},"imported":[{"uid":"5277-0"}],"importedBy":[{"uid":"5277-536"},{"uid":"5277-694"},{"uid":"5277-786"},{"uid":"5277-30"},{"uid":"5277-504"},{"uid":"5277-1026"},{"uid":"5277-754"},{"uid":"5277-46"},{"uid":"5277-118"},{"uid":"5277-114"},{"uid":"5277-116"},{"uid":"5277-1024"},{"uid":"5277-960"},{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-288"},{"uid":"5277-296"},{"uid":"5277-148"},{"uid":"5277-278"},{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-712"},{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-64"},{"uid":"5277-72"},{"uid":"5277-52"},{"uid":"5277-416"}]},"5277-24":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randombytes/browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-25"},"imported":[],"importedBy":[{"uid":"5277-30"}]},"5277-26":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safe-buffer/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-27"},"imported":[],"importedBy":[{"uid":"5277-28"}]},"5277-28":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safe-buffer/index.js","moduleParts":{"metamask-sdk.js":"5277-29"},"imported":[{"uid":"5277-10"},{"uid":"5277-26"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1131"}]},"5277-30":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randombytes/browser.js","moduleParts":{"metamask-sdk.js":"5277-31"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-24"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1107"}]},"5277-32":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-33"},"imported":[],"importedBy":[{"uid":"5277-34"}]},"5277-34":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js","moduleParts":{"metamask-sdk.js":"5277-35"},"imported":[{"uid":"5277-10"},{"uid":"5277-32"}],"importedBy":[{"uid":"5277-1133"}]},"5277-36":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/readable-browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-37"},"imported":[],"importedBy":[{"uid":"5277-84"}]},"5277-38":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/events.js","moduleParts":{"metamask-sdk.js":"5277-39"},"imported":[],"importedBy":[{"uid":"5277-40"},{"uid":"5277-124"},{"uid":"5277-114"},{"uid":"5277-116"}]},"5277-40":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/events.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-41"},"imported":[{"uid":"5277-10"},{"uid":"5277-38"}],"importedBy":[{"uid":"5277-620"},{"uid":"5277-300"},{"uid":"5277-776"},{"uid":"5277-274"},{"uid":"5277-740"},{"uid":"5277-716"},{"uid":"5277-76"},{"uid":"5277-42"}]},"5277-42":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/stream-browser.js","moduleParts":{"metamask-sdk.js":"5277-43"},"imported":[{"uid":"5277-10"},{"uid":"5277-40"}],"importedBy":[{"uid":"5277-1278"}]},"5277-44":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/inherits.js","moduleParts":{"metamask-sdk.js":"5277-45"},"imported":[],"importedBy":[{"uid":"5277-46"}]},"5277-46":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/util.js","moduleParts":{"metamask-sdk.js":"5277-47"},"imported":[{"uid":"5277-0"},{"uid":"5277-8"},{"uid":"5277-22"},{"uid":"5277-44"}],"importedBy":[{"uid":"5277-124"},{"uid":"5277-118"},{"uid":"5277-114"},{"uid":"5277-116"},{"uid":"5277-120"},{"uid":"5277-122"},{"uid":"5277-48"}]},"5277-48":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/util.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-49"},"imported":[{"uid":"5277-10"},{"uid":"5277-46"}],"importedBy":[{"uid":"5277-300"},{"uid":"5277-276"},{"uid":"5277-740"},{"uid":"5277-728"},{"uid":"5277-76"},{"uid":"5277-50"}]},"5277-50":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/buffer_list.js","moduleParts":{"metamask-sdk.js":"5277-51"},"imported":[{"uid":"5277-10"},{"uid":"5277-18"},{"uid":"5277-48"}],"importedBy":[{"uid":"5277-76"}]},"5277-52":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-53"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1279"}]},"5277-54":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/errors-browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-55"},"imported":[],"importedBy":[{"uid":"5277-56"}]},"5277-56":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/errors-browser.js","moduleParts":{"metamask-sdk.js":"5277-57"},"imported":[{"uid":"5277-10"},{"uid":"5277-54"}],"importedBy":[{"uid":"5277-1281"}]},"5277-58":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/state.js","moduleParts":{"metamask-sdk.js":"5277-59"},"imported":[{"uid":"5277-10"},{"uid":"5277-1281"}],"importedBy":[{"uid":"5277-1280"}]},"5277-60":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/util-deprecate/browser.js","moduleParts":{"metamask-sdk.js":"5277-61"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1218"}]},"5277-62":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-63"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1218"},{"uid":"5277-1278"},{"uid":"5277-18"},{"uid":"5277-1279"},{"uid":"5277-1280"},{"uid":"5277-1281"},{"uid":"5277-1133"},{"uid":"5277-64"}],"importedBy":[{"uid":"5277-84"},{"uid":"5277-64"}]},"5277-64":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-65"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-84"},{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-78"}]},"5277-66":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-67"},"imported":[],"importedBy":[{"uid":"5277-68"}]},"5277-68":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-69"},"imported":[{"uid":"5277-10"},{"uid":"5277-66"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-76"}]},"5277-70":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/end-of-stream.js","moduleParts":{"metamask-sdk.js":"5277-71"},"imported":[{"uid":"5277-10"},{"uid":"5277-1281"}],"importedBy":[{"uid":"5277-1264"}]},"5277-72":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/async_iterator.js","moduleParts":{"metamask-sdk.js":"5277-73"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1264"}],"importedBy":[{"uid":"5277-76"}]},"5277-74":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/from-browser.js","moduleParts":{"metamask-sdk.js":"5277-75"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-76"}]},"5277-76":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-77"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-40"},{"uid":"5277-1278"},{"uid":"5277-18"},{"uid":"5277-48"},{"uid":"5277-50"},{"uid":"5277-1279"},{"uid":"5277-1280"},{"uid":"5277-1281"},{"uid":"5277-1133"},{"uid":"5277-64"},{"uid":"5277-68"},{"uid":"5277-72"},{"uid":"5277-74"}],"importedBy":[{"uid":"5277-84"},{"uid":"5277-64"}]},"5277-78":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-79"},"imported":[{"uid":"5277-10"},{"uid":"5277-1281"},{"uid":"5277-64"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1262"}]},"5277-80":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-81"},"imported":[{"uid":"5277-10"},{"uid":"5277-1262"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1263"}]},"5277-82":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/pipeline.js","moduleParts":{"metamask-sdk.js":"5277-83"},"imported":[{"uid":"5277-10"},{"uid":"5277-1281"},{"uid":"5277-1264"}],"importedBy":[{"uid":"5277-1265"}]},"5277-84":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/readable-browser.js","moduleParts":{"metamask-sdk.js":"5277-85"},"imported":[{"uid":"5277-10"},{"uid":"5277-36"},{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-64"},{"uid":"5277-1262"},{"uid":"5277-1263"},{"uid":"5277-1264"},{"uid":"5277-1265"}],"importedBy":[{"uid":"5277-1237"}]},"5277-86":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/index.js","moduleParts":{"metamask-sdk.js":"5277-87"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"},{"uid":"5277-1237"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1193"}]},"5277-88":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/md5.js/index.js","moduleParts":{"metamask-sdk.js":"5277-89"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1193"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1154"}]},"5277-90":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/ripemd160/index.js","moduleParts":{"metamask-sdk.js":"5277-91"},"imported":[{"uid":"5277-10"},{"uid":"5277-18"},{"uid":"5277-1133"},{"uid":"5277-1193"}],"importedBy":[{"uid":"5277-1155"}]},"5277-92":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-93"},"imported":[],"importedBy":[{"uid":"5277-108"}]},"5277-94":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/hash.js","moduleParts":{"metamask-sdk.js":"5277-95"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1238"}]},"5277-96":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha.js","moduleParts":{"metamask-sdk.js":"5277-97"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1238"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1194"}]},"5277-98":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha1.js","moduleParts":{"metamask-sdk.js":"5277-99"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1238"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1195"}]},"5277-100":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha256.js","moduleParts":{"metamask-sdk.js":"5277-101"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1238"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1197"}]},"5277-102":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha224.js","moduleParts":{"metamask-sdk.js":"5277-103"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1197"},{"uid":"5277-1238"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1196"}]},"5277-104":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha512.js","moduleParts":{"metamask-sdk.js":"5277-105"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1238"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1199"}]},"5277-106":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha384.js","moduleParts":{"metamask-sdk.js":"5277-107"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1199"},{"uid":"5277-1238"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1198"}]},"5277-108":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/index.js","moduleParts":{"metamask-sdk.js":"5277-109"},"imported":[{"uid":"5277-10"},{"uid":"5277-92"},{"uid":"5277-1194"},{"uid":"5277-1195"},{"uid":"5277-1196"},{"uid":"5277-1197"},{"uid":"5277-1198"},{"uid":"5277-1199"}],"importedBy":[{"uid":"5277-1156"}]},"5277-110":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/buffer-list.js","moduleParts":{"metamask-sdk.js":"5277-111"},"imported":[{"uid":"5277-8"}],"importedBy":[{"uid":"5277-114"}]},"5277-112":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/string-decoder.js","moduleParts":{"metamask-sdk.js":"5277-113"},"imported":[{"uid":"5277-8"}],"importedBy":[{"uid":"5277-114"},{"uid":"5277-128"}]},"5277-114":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/readable.js","moduleParts":{"metamask-sdk.js":"5277-115"},"imported":[{"uid":"5277-8"},{"uid":"5277-38"},{"uid":"5277-46"},{"uid":"5277-110"},{"uid":"5277-112"},{"uid":"5277-118"},{"uid":"5277-22"}],"importedBy":[{"uid":"5277-124"},{"uid":"5277-118"}]},"5277-116":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/writable.js","moduleParts":{"metamask-sdk.js":"5277-117"},"imported":[{"uid":"5277-46"},{"uid":"5277-8"},{"uid":"5277-38"},{"uid":"5277-118"},{"uid":"5277-22"}],"importedBy":[{"uid":"5277-124"},{"uid":"5277-118"}]},"5277-118":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/duplex.js","moduleParts":{"metamask-sdk.js":"5277-119"},"imported":[{"uid":"5277-46"},{"uid":"5277-22"},{"uid":"5277-114"},{"uid":"5277-116"}],"importedBy":[{"uid":"5277-124"},{"uid":"5277-114"},{"uid":"5277-116"},{"uid":"5277-120"}]},"5277-120":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/transform.js","moduleParts":{"metamask-sdk.js":"5277-121"},"imported":[{"uid":"5277-118"},{"uid":"5277-46"}],"importedBy":[{"uid":"5277-124"},{"uid":"5277-122"}]},"5277-122":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/passthrough.js","moduleParts":{"metamask-sdk.js":"5277-123"},"imported":[{"uid":"5277-120"},{"uid":"5277-46"}],"importedBy":[{"uid":"5277-124"}]},"5277-124":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/stream.js","moduleParts":{"metamask-sdk.js":"5277-125"},"imported":[{"uid":"5277-38"},{"uid":"5277-46"},{"uid":"5277-118"},{"uid":"5277-114"},{"uid":"5277-116"},{"uid":"5277-120"},{"uid":"5277-122"}],"importedBy":[{"uid":"5277-880"},{"uid":"5277-126"}]},"5277-126":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/stream.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-127"},"imported":[{"uid":"5277-10"},{"uid":"5277-124"}],"importedBy":[{"uid":"5277-692"},{"uid":"5277-130"}]},"5277-128":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/string-decoder.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-129"},"imported":[{"uid":"5277-10"},{"uid":"5277-112"}],"importedBy":[{"uid":"5277-130"}]},"5277-130":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cipher-base/index.js","moduleParts":{"metamask-sdk.js":"5277-131"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"},{"uid":"5277-126"},{"uid":"5277-128"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1157"}]},"5277-132":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/browser.js","moduleParts":{"metamask-sdk.js":"5277-133"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1154"},{"uid":"5277-1155"},{"uid":"5277-1156"},{"uid":"5277-1157"}],"importedBy":[{"uid":"5277-1108"}]},"5277-134":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/legacy.js","moduleParts":{"metamask-sdk.js":"5277-135"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1131"},{"uid":"5277-1157"}],"importedBy":[{"uid":"5277-1158"}]},"5277-136":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/md5.js","moduleParts":{"metamask-sdk.js":"5277-137"},"imported":[{"uid":"5277-10"},{"uid":"5277-1154"}],"importedBy":[{"uid":"5277-1159"}]},"5277-138":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/browser.js","moduleParts":{"metamask-sdk.js":"5277-139"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1158"},{"uid":"5277-1157"},{"uid":"5277-1131"},{"uid":"5277-1159"},{"uid":"5277-1155"},{"uid":"5277-1156"}],"importedBy":[{"uid":"5277-1109"}]},"5277-140":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/algorithms.json","moduleParts":{"metamask-sdk.js":"5277-141"},"imported":[],"importedBy":[{"uid":"5277-1134"}]},"5277-142":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/algos.js","moduleParts":{"metamask-sdk.js":"5277-143"},"imported":[{"uid":"5277-10"},{"uid":"5277-1134"}],"importedBy":[{"uid":"5277-1110"}]},"5277-144":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-145"},"imported":[],"importedBy":[{"uid":"5277-156"}]},"5277-146":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/precondition.js","moduleParts":{"metamask-sdk.js":"5277-147"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1200"}]},"5277-148":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/default-encoding.js","moduleParts":{"metamask-sdk.js":"5277-149"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1201"}]},"5277-150":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/to-buffer.js","moduleParts":{"metamask-sdk.js":"5277-151"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1202"}]},"5277-152":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/sync-browser.js","moduleParts":{"metamask-sdk.js":"5277-153"},"imported":[{"uid":"5277-10"},{"uid":"5277-1159"},{"uid":"5277-1155"},{"uid":"5277-1156"},{"uid":"5277-1131"},{"uid":"5277-1200"},{"uid":"5277-1201"},{"uid":"5277-1202"}],"importedBy":[{"uid":"5277-1161"}]},"5277-154":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/async.js","moduleParts":{"metamask-sdk.js":"5277-155"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"},{"uid":"5277-1200"},{"uid":"5277-1201"},{"uid":"5277-1161"},{"uid":"5277-1202"}],"importedBy":[{"uid":"5277-1160"}]},"5277-156":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/browser.js","moduleParts":{"metamask-sdk.js":"5277-157"},"imported":[{"uid":"5277-10"},{"uid":"5277-144"},{"uid":"5277-1160"},{"uid":"5277-1161"}],"importedBy":[{"uid":"5277-1111"}]},"5277-158":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-cipher/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-159"},"imported":[],"importedBy":[{"uid":"5277-246"}]},"5277-160":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-161"},"imported":[],"importedBy":[{"uid":"5277-178"}]},"5277-162":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-163"},"imported":[],"importedBy":[{"uid":"5277-164"}]},"5277-164":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/utils.js","moduleParts":{"metamask-sdk.js":"5277-165"},"imported":[{"uid":"5277-10"},{"uid":"5277-162"}],"importedBy":[{"uid":"5277-1239"}]},"5277-166":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-assert/index.js","moduleParts":{"metamask-sdk.js":"5277-167"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1222"}]},"5277-168":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cipher.js","moduleParts":{"metamask-sdk.js":"5277-169"},"imported":[{"uid":"5277-10"},{"uid":"5277-1222"}],"importedBy":[{"uid":"5277-1240"}]},"5277-170":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/des.js","moduleParts":{"metamask-sdk.js":"5277-171"},"imported":[{"uid":"5277-10"},{"uid":"5277-1222"},{"uid":"5277-1133"},{"uid":"5277-1239"},{"uid":"5277-1240"}],"importedBy":[{"uid":"5277-1241"}]},"5277-172":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cbc.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-173"},"imported":[],"importedBy":[{"uid":"5277-174"}]},"5277-174":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cbc.js","moduleParts":{"metamask-sdk.js":"5277-175"},"imported":[{"uid":"5277-10"},{"uid":"5277-172"},{"uid":"5277-1222"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1242"}]},"5277-176":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/ede.js","moduleParts":{"metamask-sdk.js":"5277-177"},"imported":[{"uid":"5277-10"},{"uid":"5277-1222"},{"uid":"5277-1133"},{"uid":"5277-1240"},{"uid":"5277-1241"}],"importedBy":[{"uid":"5277-1243"}]},"5277-178":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des.js","moduleParts":{"metamask-sdk.js":"5277-179"},"imported":[{"uid":"5277-10"},{"uid":"5277-160"},{"uid":"5277-1239"},{"uid":"5277-1240"},{"uid":"5277-1241"},{"uid":"5277-1242"},{"uid":"5277-1243"}],"importedBy":[{"uid":"5277-1203"}]},"5277-180":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/index.js","moduleParts":{"metamask-sdk.js":"5277-181"},"imported":[{"uid":"5277-10"},{"uid":"5277-1157"},{"uid":"5277-1203"},{"uid":"5277-1133"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1162"}]},"5277-182":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-183"},"imported":[],"importedBy":[{"uid":"5277-240"}]},"5277-184":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/encrypter.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-185"},"imported":[],"importedBy":[{"uid":"5277-234"}]},"5277-186":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ecb.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-187"},"imported":[],"importedBy":[{"uid":"5277-188"}]},"5277-188":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ecb.js","moduleParts":{"metamask-sdk.js":"5277-189"},"imported":[{"uid":"5277-10"},{"uid":"5277-186"}],"importedBy":[{"uid":"5277-1207"}]},"5277-190":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cbc.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-191"},"imported":[],"importedBy":[{"uid":"5277-194"}]},"5277-192":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-xor/index.js","moduleParts":{"metamask-sdk.js":"5277-193"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1247"}]},"5277-194":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cbc.js","moduleParts":{"metamask-sdk.js":"5277-195"},"imported":[{"uid":"5277-10"},{"uid":"5277-190"},{"uid":"5277-1247"}],"importedBy":[{"uid":"5277-1208"}]},"5277-196":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-197"},"imported":[],"importedBy":[{"uid":"5277-198"}]},"5277-198":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb.js","moduleParts":{"metamask-sdk.js":"5277-199"},"imported":[{"uid":"5277-10"},{"uid":"5277-196"},{"uid":"5277-1131"},{"uid":"5277-1247"}],"importedBy":[{"uid":"5277-1209"}]},"5277-200":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb8.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-201"},"imported":[],"importedBy":[{"uid":"5277-202"}]},"5277-202":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb8.js","moduleParts":{"metamask-sdk.js":"5277-203"},"imported":[{"uid":"5277-10"},{"uid":"5277-200"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1210"}]},"5277-204":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb1.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-205"},"imported":[],"importedBy":[{"uid":"5277-206"}]},"5277-206":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb1.js","moduleParts":{"metamask-sdk.js":"5277-207"},"imported":[{"uid":"5277-10"},{"uid":"5277-204"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1211"}]},"5277-208":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ofb.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-209"},"imported":[],"importedBy":[{"uid":"5277-210"}]},"5277-210":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ofb.js","moduleParts":{"metamask-sdk.js":"5277-211"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-208"},{"uid":"5277-1247"}],"importedBy":[{"uid":"5277-1212"}]},"5277-212":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ctr.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-213"},"imported":[],"importedBy":[{"uid":"5277-216"}]},"5277-214":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/incr32.js","moduleParts":{"metamask-sdk.js":"5277-215"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1248"}]},"5277-216":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ctr.js","moduleParts":{"metamask-sdk.js":"5277-217"},"imported":[{"uid":"5277-10"},{"uid":"5277-212"},{"uid":"5277-1247"},{"uid":"5277-1131"},{"uid":"5277-1248"}],"importedBy":[{"uid":"5277-1213"}]},"5277-218":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/list.json","moduleParts":{"metamask-sdk.js":"5277-219"},"imported":[],"importedBy":[{"uid":"5277-1206"}]},"5277-220":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/index.js","moduleParts":{"metamask-sdk.js":"5277-221"},"imported":[{"uid":"5277-10"},{"uid":"5277-1207"},{"uid":"5277-1208"},{"uid":"5277-1209"},{"uid":"5277-1210"},{"uid":"5277-1211"},{"uid":"5277-1212"},{"uid":"5277-1213"},{"uid":"5277-1206"}],"importedBy":[{"uid":"5277-1164"}]},"5277-222":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/aes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-223"},"imported":[],"importedBy":[{"uid":"5277-224"}]},"5277-224":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/aes.js","moduleParts":{"metamask-sdk.js":"5277-225"},"imported":[{"uid":"5277-10"},{"uid":"5277-222"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1246"}]},"5277-226":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/ghash.js","moduleParts":{"metamask-sdk.js":"5277-227"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1266"}]},"5277-228":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/authCipher.js","moduleParts":{"metamask-sdk.js":"5277-229"},"imported":[{"uid":"5277-10"},{"uid":"5277-1246"},{"uid":"5277-1131"},{"uid":"5277-1157"},{"uid":"5277-1133"},{"uid":"5277-1266"},{"uid":"5277-1247"},{"uid":"5277-1248"}],"importedBy":[{"uid":"5277-1244"}]},"5277-230":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/streamCipher.js","moduleParts":{"metamask-sdk.js":"5277-231"},"imported":[{"uid":"5277-10"},{"uid":"5277-1246"},{"uid":"5277-1131"},{"uid":"5277-1157"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1245"}]},"5277-232":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/evp_bytestokey/index.js","moduleParts":{"metamask-sdk.js":"5277-233"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"},{"uid":"5277-1154"}],"importedBy":[{"uid":"5277-1166"}]},"5277-234":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/encrypter.js","moduleParts":{"metamask-sdk.js":"5277-235"},"imported":[{"uid":"5277-10"},{"uid":"5277-184"},{"uid":"5277-1164"},{"uid":"5277-1244"},{"uid":"5277-1131"},{"uid":"5277-1245"},{"uid":"5277-1157"},{"uid":"5277-1246"},{"uid":"5277-1166"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1204"}]},"5277-236":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/decrypter.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-237"},"imported":[],"importedBy":[{"uid":"5277-238"}]},"5277-238":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/decrypter.js","moduleParts":{"metamask-sdk.js":"5277-239"},"imported":[{"uid":"5277-10"},{"uid":"5277-236"},{"uid":"5277-1244"},{"uid":"5277-1131"},{"uid":"5277-1164"},{"uid":"5277-1245"},{"uid":"5277-1157"},{"uid":"5277-1246"},{"uid":"5277-1166"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1205"}]},"5277-240":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/browser.js","moduleParts":{"metamask-sdk.js":"5277-241"},"imported":[{"uid":"5277-10"},{"uid":"5277-182"},{"uid":"5277-1204"},{"uid":"5277-1205"},{"uid":"5277-1206"}],"importedBy":[{"uid":"5277-1163"}]},"5277-242":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/modes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-243"},"imported":[],"importedBy":[{"uid":"5277-244"}]},"5277-244":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/modes.js","moduleParts":{"metamask-sdk.js":"5277-245"},"imported":[{"uid":"5277-10"},{"uid":"5277-242"}],"importedBy":[{"uid":"5277-1165"}]},"5277-246":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-cipher/browser.js","moduleParts":{"metamask-sdk.js":"5277-247"},"imported":[{"uid":"5277-10"},{"uid":"5277-158"},{"uid":"5277-1162"},{"uid":"5277-1163"},{"uid":"5277-1164"},{"uid":"5277-1165"},{"uid":"5277-1166"}],"importedBy":[{"uid":"5277-1112"}]},"5277-248":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-249"},"imported":[],"importedBy":[{"uid":"5277-270"}]},"5277-250":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-251"},"imported":[],"importedBy":[{"uid":"5277-252"}]},"5277-252":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-253"},"imported":[{"uid":"5277-10"},{"uid":"5277-250"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1167"}]},"5277-254":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-255"},"imported":[],"importedBy":[{"uid":"5277-256"}]},"5277-256":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-257"},"imported":[{"uid":"5277-10"},{"uid":"5277-254"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1180"}]},"5277-258":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-259"},"imported":[],"importedBy":[{"uid":"5277-260"}]},"5277-260":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js","moduleParts":{"metamask-sdk.js":"5277-261"},"imported":[{"uid":"5277-10"},{"uid":"5277-258"},{"uid":"5277-506"}],"importedBy":[{"uid":"5277-402"},{"uid":"5277-262"},{"uid":"5277-394"}]},"5277-262":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/lib/mr.js","moduleParts":{"metamask-sdk.js":"5277-263"},"imported":[{"uid":"5277-10"},{"uid":"5277-1180"},{"uid":"5277-260"}],"importedBy":[{"uid":"5277-264"},{"uid":"5277-268"}]},"5277-264":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/generatePrime.js","moduleParts":{"metamask-sdk.js":"5277-265"},"imported":[{"uid":"5277-10"},{"uid":"5277-1107"},{"uid":"5277-1167"},{"uid":"5277-262"}],"importedBy":[{"uid":"5277-270"},{"uid":"5277-268"}]},"5277-266":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/primes.json","moduleParts":{"metamask-sdk.js":"5277-267"},"imported":[],"importedBy":[{"uid":"5277-1130"}]},"5277-268":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/dh.js","moduleParts":{"metamask-sdk.js":"5277-269"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-1167"},{"uid":"5277-262"},{"uid":"5277-264"},{"uid":"5277-1107"}],"importedBy":[{"uid":"5277-270"}]},"5277-270":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/browser.js","moduleParts":{"metamask-sdk.js":"5277-271"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-248"},{"uid":"5277-264"},{"uid":"5277-1130"},{"uid":"5277-268"}],"importedBy":[{"uid":"5277-506"}]},"5277-272":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/readable-browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-273"},"imported":[],"importedBy":[{"uid":"5277-308"}]},"5277-274":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/stream-browser.js","moduleParts":{"metamask-sdk.js":"5277-275"},"imported":[{"uid":"5277-10"},{"uid":"5277-40"}],"importedBy":[{"uid":"5277-1214"}]},"5277-276":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/buffer_list.js","moduleParts":{"metamask-sdk.js":"5277-277"},"imported":[{"uid":"5277-10"},{"uid":"5277-18"},{"uid":"5277-48"}],"importedBy":[{"uid":"5277-300"}]},"5277-278":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-279"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1215"}]},"5277-280":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/errors-browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-281"},"imported":[],"importedBy":[{"uid":"5277-282"}]},"5277-282":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/errors-browser.js","moduleParts":{"metamask-sdk.js":"5277-283"},"imported":[{"uid":"5277-10"},{"uid":"5277-280"}],"importedBy":[{"uid":"5277-1217"}]},"5277-284":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/state.js","moduleParts":{"metamask-sdk.js":"5277-285"},"imported":[{"uid":"5277-10"},{"uid":"5277-1217"}],"importedBy":[{"uid":"5277-1216"}]},"5277-286":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-287"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1218"},{"uid":"5277-1214"},{"uid":"5277-18"},{"uid":"5277-1215"},{"uid":"5277-1216"},{"uid":"5277-1217"},{"uid":"5277-1133"},{"uid":"5277-288"}],"importedBy":[{"uid":"5277-308"},{"uid":"5277-288"}]},"5277-288":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-289"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-308"},{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-302"}]},"5277-290":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-291"},"imported":[],"importedBy":[{"uid":"5277-292"}]},"5277-292":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-293"},"imported":[{"uid":"5277-10"},{"uid":"5277-290"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-300"}]},"5277-294":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/end-of-stream.js","moduleParts":{"metamask-sdk.js":"5277-295"},"imported":[{"uid":"5277-10"},{"uid":"5277-1217"}],"importedBy":[{"uid":"5277-1183"}]},"5277-296":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/async_iterator.js","moduleParts":{"metamask-sdk.js":"5277-297"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1183"}],"importedBy":[{"uid":"5277-300"}]},"5277-298":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/from-browser.js","moduleParts":{"metamask-sdk.js":"5277-299"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-300"}]},"5277-300":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-301"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-40"},{"uid":"5277-1214"},{"uid":"5277-18"},{"uid":"5277-48"},{"uid":"5277-276"},{"uid":"5277-1215"},{"uid":"5277-1216"},{"uid":"5277-1217"},{"uid":"5277-1133"},{"uid":"5277-288"},{"uid":"5277-292"},{"uid":"5277-296"},{"uid":"5277-298"}],"importedBy":[{"uid":"5277-308"},{"uid":"5277-288"}]},"5277-302":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-303"},"imported":[{"uid":"5277-10"},{"uid":"5277-1217"},{"uid":"5277-288"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1181"}]},"5277-304":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-305"},"imported":[{"uid":"5277-10"},{"uid":"5277-1181"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1182"}]},"5277-306":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/pipeline.js","moduleParts":{"metamask-sdk.js":"5277-307"},"imported":[{"uid":"5277-10"},{"uid":"5277-1217"},{"uid":"5277-1183"}],"importedBy":[{"uid":"5277-1184"}]},"5277-308":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/readable-browser.js","moduleParts":{"metamask-sdk.js":"5277-309"},"imported":[{"uid":"5277-10"},{"uid":"5277-272"},{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-288"},{"uid":"5277-1181"},{"uid":"5277-1182"},{"uid":"5277-1183"},{"uid":"5277-1184"}],"importedBy":[{"uid":"5277-1132"}]},"5277-310":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/sign.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-311"},"imported":[],"importedBy":[{"uid":"5277-470"}]},"5277-312":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-313"},"imported":[],"importedBy":[{"uid":"5277-314"}]},"5277-314":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-315"},"imported":[{"uid":"5277-10"},{"uid":"5277-312"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1169"}]},"5277-316":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-rsa/index.js","moduleParts":{"metamask-sdk.js":"5277-317"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-1169"},{"uid":"5277-1107"}],"importedBy":[{"uid":"5277-1168"}]},"5277-318":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-319"},"imported":[],"importedBy":[{"uid":"5277-402"}]},"5277-320":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json","moduleParts":{"metamask-sdk.js":"5277-321"},"imported":[],"importedBy":[{"uid":"5277-1172"}]},"5277-322":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-323"},"imported":[],"importedBy":[{"uid":"5277-332"}]},"5277-324":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-325"},"imported":[],"importedBy":[{"uid":"5277-326"}]},"5277-326":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-327"},"imported":[{"uid":"5277-10"},{"uid":"5277-324"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1185"}]},"5277-328":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-329"},"imported":[],"importedBy":[{"uid":"5277-330"}]},"5277-330":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js","moduleParts":{"metamask-sdk.js":"5277-331"},"imported":[{"uid":"5277-10"},{"uid":"5277-328"}],"importedBy":[{"uid":"5277-1223"}]},"5277-332":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js","moduleParts":{"metamask-sdk.js":"5277-333"},"imported":[{"uid":"5277-10"},{"uid":"5277-322"},{"uid":"5277-1185"},{"uid":"5277-1222"},{"uid":"5277-1223"}],"importedBy":[{"uid":"5277-1173"}]},"5277-334":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-335"},"imported":[],"importedBy":[{"uid":"5277-344"}]},"5277-336":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/base.js","moduleParts":{"metamask-sdk.js":"5277-337"},"imported":[{"uid":"5277-10"},{"uid":"5277-1185"},{"uid":"5277-1173"}],"importedBy":[{"uid":"5277-1224"}]},"5277-338":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/short.js","moduleParts":{"metamask-sdk.js":"5277-339"},"imported":[{"uid":"5277-10"},{"uid":"5277-1173"},{"uid":"5277-1185"},{"uid":"5277-1133"},{"uid":"5277-1224"}],"importedBy":[{"uid":"5277-1225"}]},"5277-340":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/mont.js","moduleParts":{"metamask-sdk.js":"5277-341"},"imported":[{"uid":"5277-10"},{"uid":"5277-1185"},{"uid":"5277-1133"},{"uid":"5277-1224"},{"uid":"5277-1173"}],"importedBy":[{"uid":"5277-1226"}]},"5277-342":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/edwards.js","moduleParts":{"metamask-sdk.js":"5277-343"},"imported":[{"uid":"5277-10"},{"uid":"5277-1173"},{"uid":"5277-1185"},{"uid":"5277-1133"},{"uid":"5277-1224"}],"importedBy":[{"uid":"5277-1227"}]},"5277-344":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js","moduleParts":{"metamask-sdk.js":"5277-345"},"imported":[{"uid":"5277-10"},{"uid":"5277-334"},{"uid":"5277-1224"},{"uid":"5277-1225"},{"uid":"5277-1226"},{"uid":"5277-1227"}],"importedBy":[{"uid":"5277-1174"}]},"5277-346":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-347"},"imported":[],"importedBy":[{"uid":"5277-386"}]},"5277-348":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-349"},"imported":[],"importedBy":[{"uid":"5277-382"}]},"5277-350":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-351"},"imported":[],"importedBy":[{"uid":"5277-352"}]},"5277-352":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js","moduleParts":{"metamask-sdk.js":"5277-353"},"imported":[{"uid":"5277-10"},{"uid":"5277-350"},{"uid":"5277-1222"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1251"}]},"5277-354":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-355"},"imported":[],"importedBy":[{"uid":"5277-356"}]},"5277-356":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js","moduleParts":{"metamask-sdk.js":"5277-357"},"imported":[{"uid":"5277-10"},{"uid":"5277-354"},{"uid":"5277-1251"},{"uid":"5277-1222"}],"importedBy":[{"uid":"5277-1252"}]},"5277-358":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-359"},"imported":[],"importedBy":[{"uid":"5277-374"}]},"5277-360":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-361"},"imported":[],"importedBy":[{"uid":"5277-362"}]},"5277-362":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js","moduleParts":{"metamask-sdk.js":"5277-363"},"imported":[{"uid":"5277-10"},{"uid":"5277-360"},{"uid":"5277-1251"}],"importedBy":[{"uid":"5277-1290"}]},"5277-364":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/1.js","moduleParts":{"metamask-sdk.js":"5277-365"},"imported":[{"uid":"5277-10"},{"uid":"5277-1251"},{"uid":"5277-1252"},{"uid":"5277-1290"}],"importedBy":[{"uid":"5277-1273"}]},"5277-366":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/256.js","moduleParts":{"metamask-sdk.js":"5277-367"},"imported":[{"uid":"5277-10"},{"uid":"5277-1251"},{"uid":"5277-1252"},{"uid":"5277-1290"},{"uid":"5277-1222"}],"importedBy":[{"uid":"5277-1275"}]},"5277-368":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/224.js","moduleParts":{"metamask-sdk.js":"5277-369"},"imported":[{"uid":"5277-10"},{"uid":"5277-1251"},{"uid":"5277-1275"}],"importedBy":[{"uid":"5277-1274"}]},"5277-370":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/512.js","moduleParts":{"metamask-sdk.js":"5277-371"},"imported":[{"uid":"5277-10"},{"uid":"5277-1251"},{"uid":"5277-1252"},{"uid":"5277-1222"}],"importedBy":[{"uid":"5277-1277"}]},"5277-372":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/384.js","moduleParts":{"metamask-sdk.js":"5277-373"},"imported":[{"uid":"5277-10"},{"uid":"5277-1251"},{"uid":"5277-1277"}],"importedBy":[{"uid":"5277-1276"}]},"5277-374":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js","moduleParts":{"metamask-sdk.js":"5277-375"},"imported":[{"uid":"5277-10"},{"uid":"5277-358"},{"uid":"5277-1273"},{"uid":"5277-1274"},{"uid":"5277-1275"},{"uid":"5277-1276"},{"uid":"5277-1277"}],"importedBy":[{"uid":"5277-1253"}]},"5277-376":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-377"},"imported":[],"importedBy":[{"uid":"5277-378"}]},"5277-378":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js","moduleParts":{"metamask-sdk.js":"5277-379"},"imported":[{"uid":"5277-10"},{"uid":"5277-376"},{"uid":"5277-1251"},{"uid":"5277-1252"}],"importedBy":[{"uid":"5277-1254"}]},"5277-380":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/hmac.js","moduleParts":{"metamask-sdk.js":"5277-381"},"imported":[{"uid":"5277-10"},{"uid":"5277-1251"},{"uid":"5277-1222"}],"importedBy":[{"uid":"5277-1255"}]},"5277-382":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js","moduleParts":{"metamask-sdk.js":"5277-383"},"imported":[{"uid":"5277-10"},{"uid":"5277-348"},{"uid":"5277-1251"},{"uid":"5277-1252"},{"uid":"5277-1253"},{"uid":"5277-1254"},{"uid":"5277-1255"}],"importedBy":[{"uid":"5277-1228"}]},"5277-384":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/precomputed/secp256k1.js","moduleParts":{"metamask-sdk.js":"5277-385"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-386"}]},"5277-386":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js","moduleParts":{"metamask-sdk.js":"5277-387"},"imported":[{"uid":"5277-10"},{"uid":"5277-346"},{"uid":"5277-1228"},{"uid":"5277-1174"},{"uid":"5277-1173"},{"uid":"5277-384"}],"importedBy":[{"uid":"5277-1175"}]},"5277-388":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hmac-drbg/lib/hmac-drbg.js","moduleParts":{"metamask-sdk.js":"5277-389"},"imported":[{"uid":"5277-10"},{"uid":"5277-1228"},{"uid":"5277-1223"},{"uid":"5277-1222"}],"importedBy":[{"uid":"5277-1186"}]},"5277-390":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/key.js","moduleParts":{"metamask-sdk.js":"5277-391"},"imported":[{"uid":"5277-10"},{"uid":"5277-1185"},{"uid":"5277-1173"}],"importedBy":[{"uid":"5277-1187"}]},"5277-392":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/signature.js","moduleParts":{"metamask-sdk.js":"5277-393"},"imported":[{"uid":"5277-10"},{"uid":"5277-1185"},{"uid":"5277-1173"}],"importedBy":[{"uid":"5277-1188"}]},"5277-394":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/index.js","moduleParts":{"metamask-sdk.js":"5277-395"},"imported":[{"uid":"5277-10"},{"uid":"5277-1185"},{"uid":"5277-1186"},{"uid":"5277-1173"},{"uid":"5277-1175"},{"uid":"5277-260"},{"uid":"5277-1187"},{"uid":"5277-1188"}],"importedBy":[{"uid":"5277-402"}]},"5277-396":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/key.js","moduleParts":{"metamask-sdk.js":"5277-397"},"imported":[{"uid":"5277-10"},{"uid":"5277-1173"}],"importedBy":[{"uid":"5277-1229"}]},"5277-398":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/signature.js","moduleParts":{"metamask-sdk.js":"5277-399"},"imported":[{"uid":"5277-10"},{"uid":"5277-1185"},{"uid":"5277-1173"}],"importedBy":[{"uid":"5277-1230"}]},"5277-400":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/index.js","moduleParts":{"metamask-sdk.js":"5277-401"},"imported":[{"uid":"5277-10"},{"uid":"5277-1228"},{"uid":"5277-1175"},{"uid":"5277-1173"},{"uid":"5277-1229"},{"uid":"5277-1230"}],"importedBy":[{"uid":"5277-1176"}]},"5277-402":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-403"},"imported":[{"uid":"5277-10"},{"uid":"5277-318"},{"uid":"5277-1172"},{"uid":"5277-1173"},{"uid":"5277-260"},{"uid":"5277-1174"},{"uid":"5277-1175"},{"uid":"5277-394"},{"uid":"5277-1176"}],"importedBy":[{"uid":"5277-480"},{"uid":"5277-470"},{"uid":"5277-472"},{"uid":"5277-512"}]},"5277-404":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/asn1.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-405"},"imported":[],"importedBy":[{"uid":"5277-460"}]},"5277-406":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-407"},"imported":[],"importedBy":[{"uid":"5277-456"}]},"5277-408":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-409"},"imported":[],"importedBy":[{"uid":"5277-410"}]},"5277-410":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-411"},"imported":[{"uid":"5277-10"},{"uid":"5277-408"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1267"}]},"5277-412":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/api.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-413"},"imported":[],"importedBy":[{"uid":"5277-446"}]},"5277-414":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-415"},"imported":[],"importedBy":[{"uid":"5277-436"}]},"5277-416":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safer-buffer/safer.js","moduleParts":{"metamask-sdk.js":"5277-417"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1291"}]},"5277-418":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/reporter.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-419"},"imported":[],"importedBy":[{"uid":"5277-420"}]},"5277-420":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/reporter.js","moduleParts":{"metamask-sdk.js":"5277-421"},"imported":[{"uid":"5277-10"},{"uid":"5277-418"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1282"}]},"5277-422":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/buffer.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-423"},"imported":[],"importedBy":[{"uid":"5277-424"}]},"5277-424":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/buffer.js","moduleParts":{"metamask-sdk.js":"5277-425"},"imported":[{"uid":"5277-10"},{"uid":"5277-422"},{"uid":"5277-1133"},{"uid":"5277-1282"},{"uid":"5277-1291"}],"importedBy":[{"uid":"5277-1283"}]},"5277-426":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/node.js","moduleParts":{"metamask-sdk.js":"5277-427"},"imported":[{"uid":"5277-10"},{"uid":"5277-1282"},{"uid":"5277-1283"},{"uid":"5277-1222"}],"importedBy":[{"uid":"5277-1284"}]},"5277-428":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/der.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-429"},"imported":[],"importedBy":[{"uid":"5277-430"}]},"5277-430":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/der.js","moduleParts":{"metamask-sdk.js":"5277-431"},"imported":[{"uid":"5277-10"},{"uid":"5277-428"}],"importedBy":[{"uid":"5277-1285"}]},"5277-432":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/der.js","moduleParts":{"metamask-sdk.js":"5277-433"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1291"},{"uid":"5277-1284"},{"uid":"5277-1285"}],"importedBy":[{"uid":"5277-1288"}]},"5277-434":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/pem.js","moduleParts":{"metamask-sdk.js":"5277-435"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1288"}],"importedBy":[{"uid":"5277-1289"}]},"5277-436":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/index.js","moduleParts":{"metamask-sdk.js":"5277-437"},"imported":[{"uid":"5277-10"},{"uid":"5277-414"},{"uid":"5277-1288"},{"uid":"5277-1289"}],"importedBy":[{"uid":"5277-1272"}]},"5277-438":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-439"},"imported":[],"importedBy":[{"uid":"5277-444"}]},"5277-440":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/der.js","moduleParts":{"metamask-sdk.js":"5277-441"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1267"},{"uid":"5277-1283"},{"uid":"5277-1284"},{"uid":"5277-1285"}],"importedBy":[{"uid":"5277-1286"}]},"5277-442":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/pem.js","moduleParts":{"metamask-sdk.js":"5277-443"},"imported":[{"uid":"5277-10"},{"uid":"5277-1133"},{"uid":"5277-1291"},{"uid":"5277-1286"}],"importedBy":[{"uid":"5277-1287"}]},"5277-444":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/index.js","moduleParts":{"metamask-sdk.js":"5277-445"},"imported":[{"uid":"5277-10"},{"uid":"5277-438"},{"uid":"5277-1286"},{"uid":"5277-1287"}],"importedBy":[{"uid":"5277-1271"}]},"5277-446":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/api.js","moduleParts":{"metamask-sdk.js":"5277-447"},"imported":[{"uid":"5277-10"},{"uid":"5277-412"},{"uid":"5277-1272"},{"uid":"5277-1271"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1268"}]},"5277-448":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-449"},"imported":[],"importedBy":[{"uid":"5277-450"}]},"5277-450":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/index.js","moduleParts":{"metamask-sdk.js":"5277-451"},"imported":[{"uid":"5277-10"},{"uid":"5277-448"},{"uid":"5277-1282"},{"uid":"5277-1283"},{"uid":"5277-1284"}],"importedBy":[{"uid":"5277-1269"}]},"5277-452":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-453"},"imported":[],"importedBy":[{"uid":"5277-454"}]},"5277-454":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/index.js","moduleParts":{"metamask-sdk.js":"5277-455"},"imported":[{"uid":"5277-10"},{"uid":"5277-452"},{"uid":"5277-1285"}],"importedBy":[{"uid":"5277-1270"}]},"5277-456":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1.js","moduleParts":{"metamask-sdk.js":"5277-457"},"imported":[{"uid":"5277-10"},{"uid":"5277-406"},{"uid":"5277-1267"},{"uid":"5277-1268"},{"uid":"5277-1269"},{"uid":"5277-1270"},{"uid":"5277-1271"},{"uid":"5277-1272"}],"importedBy":[{"uid":"5277-1249"}]},"5277-458":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/certificate.js","moduleParts":{"metamask-sdk.js":"5277-459"},"imported":[{"uid":"5277-10"},{"uid":"5277-1249"}],"importedBy":[{"uid":"5277-1250"}]},"5277-460":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/asn1.js","moduleParts":{"metamask-sdk.js":"5277-461"},"imported":[{"uid":"5277-10"},{"uid":"5277-404"},{"uid":"5277-1249"},{"uid":"5277-1250"}],"importedBy":[{"uid":"5277-1219"}]},"5277-462":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/aesid.json","moduleParts":{"metamask-sdk.js":"5277-463"},"imported":[],"importedBy":[{"uid":"5277-1220"}]},"5277-464":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/fixProc.js","moduleParts":{"metamask-sdk.js":"5277-465"},"imported":[{"uid":"5277-10"},{"uid":"5277-1166"},{"uid":"5277-1163"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1221"}]},"5277-466":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/index.js","moduleParts":{"metamask-sdk.js":"5277-467"},"imported":[{"uid":"5277-10"},{"uid":"5277-1219"},{"uid":"5277-1220"},{"uid":"5277-1221"},{"uid":"5277-1163"},{"uid":"5277-1111"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1170"}]},"5277-468":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/curves.json","moduleParts":{"metamask-sdk.js":"5277-469"},"imported":[],"importedBy":[{"uid":"5277-1171"}]},"5277-470":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/sign.js","moduleParts":{"metamask-sdk.js":"5277-471"},"imported":[{"uid":"5277-10"},{"uid":"5277-310"},{"uid":"5277-1131"},{"uid":"5277-1109"},{"uid":"5277-1168"},{"uid":"5277-402"},{"uid":"5277-1169"},{"uid":"5277-1170"},{"uid":"5277-1171"}],"importedBy":[{"uid":"5277-474"}]},"5277-472":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/verify.js","moduleParts":{"metamask-sdk.js":"5277-473"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"},{"uid":"5277-1169"},{"uid":"5277-402"},{"uid":"5277-1170"},{"uid":"5277-1171"}],"importedBy":[{"uid":"5277-474"}]},"5277-474":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/index.js","moduleParts":{"metamask-sdk.js":"5277-475"},"imported":[{"uid":"5277-10"},{"uid":"5277-1131"},{"uid":"5277-1108"},{"uid":"5277-1132"},{"uid":"5277-1133"},{"uid":"5277-470"},{"uid":"5277-472"},{"uid":"5277-1134"}],"importedBy":[{"uid":"5277-506"}]},"5277-476":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-477"},"imported":[],"importedBy":[{"uid":"5277-478"}]},"5277-478":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-479"},"imported":[{"uid":"5277-10"},{"uid":"5277-476"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1135"}]},"5277-480":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/browser.js","moduleParts":{"metamask-sdk.js":"5277-481"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-402"},{"uid":"5277-1135"}],"importedBy":[{"uid":"5277-506"}]},"5277-482":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-483"},"imported":[],"importedBy":[{"uid":"5277-498"}]},"5277-484":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/mgf.js","moduleParts":{"metamask-sdk.js":"5277-485"},"imported":[{"uid":"5277-10"},{"uid":"5277-1108"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1231"}]},"5277-486":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/xor.js","moduleParts":{"metamask-sdk.js":"5277-487"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1232"}]},"5277-488":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-489"},"imported":[],"importedBy":[{"uid":"5277-490"}]},"5277-490":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-491"},"imported":[{"uid":"5277-10"},{"uid":"5277-488"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1233"}]},"5277-492":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/withPublic.js","moduleParts":{"metamask-sdk.js":"5277-493"},"imported":[{"uid":"5277-10"},{"uid":"5277-1233"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1234"}]},"5277-494":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/publicEncrypt.js","moduleParts":{"metamask-sdk.js":"5277-495"},"imported":[{"uid":"5277-10"},{"uid":"5277-1170"},{"uid":"5277-1107"},{"uid":"5277-1108"},{"uid":"5277-1231"},{"uid":"5277-1232"},{"uid":"5277-1233"},{"uid":"5277-1234"},{"uid":"5277-1168"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1177"}]},"5277-496":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/privateDecrypt.js","moduleParts":{"metamask-sdk.js":"5277-497"},"imported":[{"uid":"5277-10"},{"uid":"5277-1170"},{"uid":"5277-1231"},{"uid":"5277-1232"},{"uid":"5277-1233"},{"uid":"5277-1168"},{"uid":"5277-1108"},{"uid":"5277-1234"},{"uid":"5277-1131"}],"importedBy":[{"uid":"5277-1178"}]},"5277-498":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/browser.js","moduleParts":{"metamask-sdk.js":"5277-499"},"imported":[{"uid":"5277-10"},{"uid":"5277-482"},{"uid":"5277-1177"},{"uid":"5277-1178"}],"importedBy":[{"uid":"5277-1113"}]},"5277-500":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-globals/src/browser.js","moduleParts":{"metamask-sdk.js":"5277-501"},"imported":[],"importedBy":[{"uid":"5277-504"},{"uid":"5277-732"}]},"5277-502":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randomfill/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-503"},"imported":[],"importedBy":[{"uid":"5277-504"}]},"5277-504":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randomfill/browser.js","moduleParts":{"metamask-sdk.js":"5277-505"},"imported":[{"uid":"5277-500"},{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-502"},{"uid":"5277-1131"},{"uid":"5277-1107"}],"importedBy":[{"uid":"5277-1114"}]},"5277-506":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/crypto-browserify/index.js","moduleParts":{"metamask-sdk.js":"5277-507"},"imported":[{"uid":"5277-10"},{"uid":"5277-20"},{"uid":"5277-1107"},{"uid":"5277-1108"},{"uid":"5277-1109"},{"uid":"5277-1110"},{"uid":"5277-1111"},{"uid":"5277-1112"},{"uid":"5277-270"},{"uid":"5277-474"},{"uid":"5277-480"},{"uid":"5277-1113"},{"uid":"5277-1114"}],"importedBy":[{"uid":"5277-522"},{"uid":"5277-508"},{"uid":"5277-260"}]},"5277-508":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js","moduleParts":{"metamask-sdk.js":"5277-509"},"imported":[{"uid":"5277-10"},{"uid":"5277-18"},{"uid":"5277-506"}],"importedBy":[{"uid":"5277-1129"}]},"5277-510":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/index.js","moduleParts":{"metamask-sdk.js":"5277-511"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1136"}]},"5277-512":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-513"},"imported":[{"uid":"5277-10"},{"uid":"5277-402"}],"importedBy":[{"uid":"5277-1137"}]},"5277-514":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-515"},"imported":[{"uid":"5277-10"},{"uid":"5277-1136"},{"uid":"5277-1137"}],"importedBy":[{"uid":"5277-1092"}]},"5277-516":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-517"},"imported":[],"importedBy":[{"uid":"5277-522"}]},"5277-518":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-519"},"imported":[],"importedBy":[{"uid":"5277-520"}]},"5277-520":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js","moduleParts":{"metamask-sdk.js":"5277-521"},"imported":[{"uid":"5277-10"},{"uid":"5277-518"}],"importedBy":[{"uid":"5277-1067"}]},"5277-522":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-523"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-516"},{"uid":"5277-506"},{"uid":"5277-1092"},{"uid":"5277-1067"}],"importedBy":[{"uid":"5277-1066"}]},"5277-524":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-525"},"imported":[],"importedBy":[{"uid":"5277-526"}]},"5277-526":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js","moduleParts":{"metamask-sdk.js":"5277-527"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-524"},{"uid":"5277-1129"},{"uid":"5277-1092"},{"uid":"5277-1066"},{"uid":"5277-1067"}],"importedBy":[{"uid":"5277-1091"}]},"5277-528":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js","moduleParts":{"metamask-sdk.js":"5277-529"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-16"},{"uid":"5277-1129"},{"uid":"5277-1092"},{"uid":"5277-1066"},{"uid":"5277-1091"}],"importedBy":[{"uid":"5277-1090"}]},"5277-530":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js","moduleParts":{"metamask-sdk.js":"5277-531"},"imported":[{"uid":"5277-10"},{"uid":"5277-14"},{"uid":"5277-1090"},{"uid":"5277-1091"}],"importedBy":[{"uid":"5277-1065"}]},"5277-532":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-533"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-12"},{"uid":"5277-1065"},{"uid":"5277-1066"},{"uid":"5277-1067"}],"importedBy":[{"uid":"5277-610"}]},"5277-534":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-535"},"imported":[],"importedBy":[{"uid":"5277-536"}]},"5277-536":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js","moduleParts":{"metamask-sdk.js":"5277-537"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-534"}],"importedBy":[{"uid":"5277-610"},{"uid":"5277-1058"}]},"5277-538":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/rng.js","moduleParts":{"metamask-sdk.js":"5277-539"},"imported":[],"importedBy":[{"uid":"5277-1068"},{"uid":"5277-546"}]},"5277-540":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/regex.js","moduleParts":{"metamask-sdk.js":"5277-541"},"imported":[],"importedBy":[{"uid":"5277-542"}]},"5277-542":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/validate.js","moduleParts":{"metamask-sdk.js":"5277-543"},"imported":[{"uid":"5277-540"}],"importedBy":[{"uid":"5277-1062"},{"uid":"5277-1072"},{"uid":"5277-544"},{"uid":"5277-1073"}]},"5277-544":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/stringify.js","moduleParts":{"metamask-sdk.js":"5277-545"},"imported":[{"uid":"5277-542"}],"importedBy":[{"uid":"5277-1062"},{"uid":"5277-1068"},{"uid":"5277-546"},{"uid":"5277-1080"}]},"5277-546":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v4.js","moduleParts":{"metamask-sdk.js":"5277-547"},"imported":[{"uid":"5277-538"},{"uid":"5277-544"}],"importedBy":[{"uid":"5277-1062"}]},"5277-548":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/commons.js","moduleParts":{"metamask-sdk.js":"5277-549"},"imported":[],"importedBy":[{"uid":"5277-550"},{"uid":"5277-554"}]},"5277-550":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/encodePacket.browser.js","moduleParts":{"metamask-sdk.js":"5277-551"},"imported":[{"uid":"5277-548"}],"importedBy":[{"uid":"5277-556"}]},"5277-552":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/contrib/base64-arraybuffer.js","moduleParts":{"metamask-sdk.js":"5277-553"},"imported":[],"importedBy":[{"uid":"5277-554"}]},"5277-554":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/decodePacket.browser.js","moduleParts":{"metamask-sdk.js":"5277-555"},"imported":[{"uid":"5277-548"},{"uid":"5277-552"}],"importedBy":[{"uid":"5277-556"}]},"5277-556":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-557"},"imported":[{"uid":"5277-550"},{"uid":"5277-554"}],"importedBy":[{"uid":"5277-586"},{"uid":"5277-566"},{"uid":"5277-574"},{"uid":"5277-578"},{"uid":"5277-580"}]},"5277-558":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@socket.io/component-emitter/index.mjs","moduleParts":{"metamask-sdk.js":"5277-559"},"imported":[],"importedBy":[{"uid":"5277-602"},{"uid":"5277-598"},{"uid":"5277-594"},{"uid":"5277-586"},{"uid":"5277-566"},{"uid":"5277-574"}]},"5277-560":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/globalThis.browser.js","moduleParts":{"metamask-sdk.js":"5277-561"},"imported":[],"importedBy":[{"uid":"5277-562"},{"uid":"5277-576"},{"uid":"5277-574"},{"uid":"5277-572"}]},"5277-562":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/util.js","moduleParts":{"metamask-sdk.js":"5277-563"},"imported":[{"uid":"5277-560"}],"importedBy":[{"uid":"5277-1083"},{"uid":"5277-586"},{"uid":"5277-566"},{"uid":"5277-574"},{"uid":"5277-578"}]},"5277-564":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/parseqs.js","moduleParts":{"metamask-sdk.js":"5277-565"},"imported":[],"importedBy":[{"uid":"5277-586"},{"uid":"5277-566"}]},"5277-566":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transport.js","moduleParts":{"metamask-sdk.js":"5277-567"},"imported":[{"uid":"5277-556"},{"uid":"5277-558"},{"uid":"5277-562"},{"uid":"5277-564"}],"importedBy":[{"uid":"5277-1083"},{"uid":"5277-574"},{"uid":"5277-578"},{"uid":"5277-580"}]},"5277-568":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/yeast.js","moduleParts":{"metamask-sdk.js":"5277-569"},"imported":[],"importedBy":[{"uid":"5277-574"},{"uid":"5277-578"}]},"5277-570":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/has-cors.js","moduleParts":{"metamask-sdk.js":"5277-571"},"imported":[],"importedBy":[{"uid":"5277-572"}]},"5277-572":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/xmlhttprequest.browser.js","moduleParts":{"metamask-sdk.js":"5277-573"},"imported":[{"uid":"5277-570"},{"uid":"5277-560"}],"importedBy":[{"uid":"5277-574"}]},"5277-574":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/polling.js","moduleParts":{"metamask-sdk.js":"5277-575"},"imported":[{"uid":"5277-566"},{"uid":"5277-568"},{"uid":"5277-556"},{"uid":"5277-572"},{"uid":"5277-558"},{"uid":"5277-562"},{"uid":"5277-560"}],"importedBy":[{"uid":"5277-582"}]},"5277-576":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/websocket-constructor.browser.js","moduleParts":{"metamask-sdk.js":"5277-577"},"imported":[{"uid":"5277-560"}],"importedBy":[{"uid":"5277-1083"},{"uid":"5277-578"},{"uid":"5277-580"}]},"5277-578":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/websocket.js","moduleParts":{"metamask-sdk.js":"5277-579"},"imported":[{"uid":"5277-8"},{"uid":"5277-566"},{"uid":"5277-568"},{"uid":"5277-562"},{"uid":"5277-576"},{"uid":"5277-556"}],"importedBy":[{"uid":"5277-582"}]},"5277-580":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/webtransport.js","moduleParts":{"metamask-sdk.js":"5277-581"},"imported":[{"uid":"5277-566"},{"uid":"5277-576"},{"uid":"5277-556"}],"importedBy":[{"uid":"5277-582"}]},"5277-582":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/index.js","moduleParts":{"metamask-sdk.js":"5277-583"},"imported":[{"uid":"5277-574"},{"uid":"5277-578"},{"uid":"5277-580"}],"importedBy":[{"uid":"5277-1083"},{"uid":"5277-586"}]},"5277-584":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/parseuri.js","moduleParts":{"metamask-sdk.js":"5277-585"},"imported":[],"importedBy":[{"uid":"5277-1083"},{"uid":"5277-586"}]},"5277-586":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/socket.js","moduleParts":{"metamask-sdk.js":"5277-587"},"imported":[{"uid":"5277-582"},{"uid":"5277-562"},{"uid":"5277-564"},{"uid":"5277-584"},{"uid":"5277-558"},{"uid":"5277-556"}],"importedBy":[{"uid":"5277-1083"}]},"5277-588":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/url.js","moduleParts":{"metamask-sdk.js":"5277-589"},"imported":[{"uid":"5277-1083"}],"importedBy":[{"uid":"5277-604"}]},"5277-590":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm/is-binary.js","moduleParts":{"metamask-sdk.js":"5277-591"},"imported":[],"importedBy":[{"uid":"5277-594"},{"uid":"5277-592"}]},"5277-592":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm/binary.js","moduleParts":{"metamask-sdk.js":"5277-593"},"imported":[{"uid":"5277-590"}],"importedBy":[{"uid":"5277-594"}]},"5277-594":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-595"},"imported":[{"uid":"5277-558"},{"uid":"5277-592"},{"uid":"5277-590"}],"importedBy":[{"uid":"5277-604"},{"uid":"5277-602"},{"uid":"5277-598"}]},"5277-596":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/on.js","moduleParts":{"metamask-sdk.js":"5277-597"},"imported":[],"importedBy":[{"uid":"5277-602"},{"uid":"5277-598"}]},"5277-598":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/socket.js","moduleParts":{"metamask-sdk.js":"5277-599"},"imported":[{"uid":"5277-594"},{"uid":"5277-596"},{"uid":"5277-558"}],"importedBy":[{"uid":"5277-604"},{"uid":"5277-602"}]},"5277-600":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/contrib/backo2.js","moduleParts":{"metamask-sdk.js":"5277-601"},"imported":[],"importedBy":[{"uid":"5277-602"}]},"5277-602":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/manager.js","moduleParts":{"metamask-sdk.js":"5277-603"},"imported":[{"uid":"5277-1083"},{"uid":"5277-598"},{"uid":"5277-594"},{"uid":"5277-596"},{"uid":"5277-600"},{"uid":"5277-558"}],"importedBy":[{"uid":"5277-604"}]},"5277-604":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-605"},"imported":[{"uid":"5277-588"},{"uid":"5277-602"},{"uid":"5277-598"},{"uid":"5277-594"}],"importedBy":[{"uid":"5277-610"}]},"5277-606":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/browser-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-607"},"imported":[],"importedBy":[{"uid":"5277-608"}]},"5277-608":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/browser-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-609"},"imported":[{"uid":"5277-10"},{"uid":"5277-606"}],"importedBy":[{"uid":"5277-610"}]},"5277-610":{"id":"-communication-layer/dist/browser/es/metamask-sdk-communication-layer.js","moduleParts":{"metamask-sdk.js":"5277-611"},"imported":[{"uid":"5277-0"},{"uid":"5277-532"},{"uid":"5277-536"},{"uid":"5277-1062"},{"uid":"5277-604"},{"uid":"5277-608"}],"importedBy":[{"uid":"5277-1060"},{"uid":"5277-860"},{"uid":"5277-866"},{"uid":"5277-868"},{"uid":"5277-896"},{"uid":"5277-1052"},{"uid":"5277-898"},{"uid":"5277-912"},{"uid":"5277-992"},{"uid":"5277-864"},{"uid":"5277-894"},{"uid":"5277-938"},{"uid":"5277-862"},{"uid":"5277-924"},{"uid":"5277-944"},{"uid":"5277-880"},{"uid":"5277-970"},{"uid":"5277-976"},{"uid":"5277-986"}]},"5277-612":{"id":"\u0000tslib.js","moduleParts":{"metamask-sdk.js":"5277-613"},"imported":[],"importedBy":[{"uid":"5277-814"},{"uid":"5277-1058"},{"uid":"5277-812"},{"uid":"5277-1056"},{"uid":"5277-852"},{"uid":"5277-854"},{"uid":"5277-866"},{"uid":"5277-1054"},{"uid":"5277-896"},{"uid":"5277-1052"},{"uid":"5277-898"},{"uid":"5277-904"},{"uid":"5277-912"},{"uid":"5277-940"},{"uid":"5277-992"},{"uid":"5277-998"},{"uid":"5277-864"},{"uid":"5277-894"},{"uid":"5277-1000"},{"uid":"5277-1002"},{"uid":"5277-1050"},{"uid":"5277-902"},{"uid":"5277-910"},{"uid":"5277-952"},{"uid":"5277-862"},{"uid":"5277-890"},{"uid":"5277-906"},{"uid":"5277-936"},{"uid":"5277-942"},{"uid":"5277-944"},{"uid":"5277-948"},{"uid":"5277-950"},{"uid":"5277-990"},{"uid":"5277-994"},{"uid":"5277-880"},{"uid":"5277-878"},{"uid":"5277-972"},{"uid":"5277-976"},{"uid":"5277-1153"},{"uid":"5277-984"},{"uid":"5277-986"},{"uid":"5277-982"},{"uid":"5277-980"}]},"5277-614":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-615"},"imported":[],"importedBy":[{"uid":"5277-804"}]},"5277-616":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-617"},"imported":[],"importedBy":[{"uid":"5277-686"}]},"5277-618":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-619"},"imported":[],"importedBy":[{"uid":"5277-620"}]},"5277-620":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-621"},"imported":[{"uid":"5277-10"},{"uid":"5277-618"},{"uid":"5277-40"}],"importedBy":[{"uid":"5277-1093"}]},"5277-622":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-623"},"imported":[],"importedBy":[{"uid":"5277-642"}]},"5277-624":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-625"},"imported":[],"importedBy":[{"uid":"5277-628"}]},"5277-626":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js","moduleParts":{"metamask-sdk.js":"5277-627"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1115"}]},"5277-628":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js","moduleParts":{"metamask-sdk.js":"5277-629"},"imported":[{"uid":"5277-10"},{"uid":"5277-624"},{"uid":"5277-1115"}],"importedBy":[{"uid":"5277-1084"}]},"5277-630":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-631"},"imported":[],"importedBy":[{"uid":"5277-636"}]},"5277-632":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-633"},"imported":[],"importedBy":[{"uid":"5277-634"}]},"5277-634":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js","moduleParts":{"metamask-sdk.js":"5277-635"},"imported":[{"uid":"5277-10"},{"uid":"5277-632"}],"importedBy":[{"uid":"5277-1087"}]},"5277-636":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-637"},"imported":[{"uid":"5277-10"},{"uid":"5277-630"},{"uid":"5277-1087"},{"uid":"5277-1084"}],"importedBy":[{"uid":"5277-1085"}]},"5277-638":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-639"},"imported":[],"importedBy":[{"uid":"5277-640"}]},"5277-640":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js","moduleParts":{"metamask-sdk.js":"5277-641"},"imported":[{"uid":"5277-10"},{"uid":"5277-638"},{"uid":"5277-1084"},{"uid":"5277-1085"},{"uid":"5277-1087"}],"importedBy":[{"uid":"5277-1086"}]},"5277-642":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-643"},"imported":[{"uid":"5277-10"},{"uid":"5277-622"},{"uid":"5277-1084"},{"uid":"5277-1085"},{"uid":"5277-1086"},{"uid":"5277-1087"}],"importedBy":[{"uid":"5277-808"},{"uid":"5277-1094"}]},"5277-644":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js","moduleParts":{"metamask-sdk.js":"5277-645"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1095"}]},"5277-646":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-647"},"imported":[],"importedBy":[{"uid":"5277-672"}]},"5277-648":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-649"},"imported":[],"importedBy":[{"uid":"5277-654"}]},"5277-650":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-651"},"imported":[],"importedBy":[{"uid":"5277-652"}]},"5277-652":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js","moduleParts":{"metamask-sdk.js":"5277-653"},"imported":[{"uid":"5277-10"},{"uid":"5277-650"}],"importedBy":[{"uid":"5277-1141"}]},"5277-654":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-655"},"imported":[{"uid":"5277-10"},{"uid":"5277-648"},{"uid":"5277-1141"}],"importedBy":[{"uid":"5277-1138"}]},"5277-656":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-657"},"imported":[],"importedBy":[{"uid":"5277-658"}]},"5277-658":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-659"},"imported":[{"uid":"5277-10"},{"uid":"5277-656"}],"importedBy":[{"uid":"5277-1139"}]},"5277-660":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-661"},"imported":[],"importedBy":[{"uid":"5277-662"}]},"5277-662":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-663"},"imported":[{"uid":"5277-10"},{"uid":"5277-660"}],"importedBy":[{"uid":"5277-1140"}]},"5277-664":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-665"},"imported":[],"importedBy":[{"uid":"5277-666"}]},"5277-666":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js","moduleParts":{"metamask-sdk.js":"5277-667"},"imported":[{"uid":"5277-10"},{"uid":"5277-664"},{"uid":"5277-1093"},{"uid":"5277-1094"}],"importedBy":[{"uid":"5277-1142"}]},"5277-668":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-669"},"imported":[],"importedBy":[{"uid":"5277-670"}]},"5277-670":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-671"},"imported":[{"uid":"5277-10"},{"uid":"5277-668"},{"uid":"5277-1142"}],"importedBy":[{"uid":"5277-1143"}]},"5277-672":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-673"},"imported":[{"uid":"5277-10"},{"uid":"5277-646"},{"uid":"5277-1138"},{"uid":"5277-1139"},{"uid":"5277-1140"},{"uid":"5277-1141"},{"uid":"5277-1142"},{"uid":"5277-1143"}],"importedBy":[{"uid":"5277-1096"}]},"5277-674":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-675"},"imported":[],"importedBy":[{"uid":"5277-676"}]},"5277-676":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js","moduleParts":{"metamask-sdk.js":"5277-677"},"imported":[{"uid":"5277-10"},{"uid":"5277-674"}],"importedBy":[{"uid":"5277-1097"}]},"5277-678":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-679"},"imported":[],"importedBy":[{"uid":"5277-684"}]},"5277-680":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-681"},"imported":[],"importedBy":[{"uid":"5277-682"}]},"5277-682":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-683"},"imported":[{"uid":"5277-10"},{"uid":"5277-680"},{"uid":"5277-1097"}],"importedBy":[{"uid":"5277-1144"}]},"5277-684":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-685"},"imported":[{"uid":"5277-10"},{"uid":"5277-678"},{"uid":"5277-1096"},{"uid":"5277-1094"},{"uid":"5277-1144"}],"importedBy":[{"uid":"5277-1098"}]},"5277-686":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js","moduleParts":{"metamask-sdk.js":"5277-687"},"imported":[{"uid":"5277-10"},{"uid":"5277-616"},{"uid":"5277-1093"},{"uid":"5277-1094"},{"uid":"5277-1095"},{"uid":"5277-1096"},{"uid":"5277-1097"},{"uid":"5277-1098"}],"importedBy":[{"uid":"5277-1074"}]},"5277-688":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-689"},"imported":[],"importedBy":[{"uid":"5277-794"}]},"5277-690":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-691"},"imported":[],"importedBy":[{"uid":"5277-692"}]},"5277-692":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-693"},"imported":[{"uid":"5277-8"},{"uid":"5277-10"},{"uid":"5277-690"},{"uid":"5277-126"}],"importedBy":[{"uid":"5277-1099"}]},"5277-694":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/es/index.js","moduleParts":{"metamask-sdk.js":"5277-695"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"}],"importedBy":[{"uid":"5277-696"}]},"5277-696":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/es/index.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-697"},"imported":[{"uid":"5277-10"},{"uid":"5277-694"}],"importedBy":[{"uid":"5277-794"}]},"5277-698":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-699"},"imported":[],"importedBy":[{"uid":"5277-790"}]},"5277-700":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-701"},"imported":[],"importedBy":[{"uid":"5277-702"}]},"5277-702":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js","moduleParts":{"metamask-sdk.js":"5277-703"},"imported":[{"uid":"5277-10"},{"uid":"5277-700"},{"uid":"5277-1097"},{"uid":"5277-1098"}],"importedBy":[{"uid":"5277-1101"}]},"5277-704":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-705"},"imported":[],"importedBy":[{"uid":"5277-788"}]},"5277-706":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-707"},"imported":[],"importedBy":[{"uid":"5277-760"}]},"5277-708":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-709"},"imported":[],"importedBy":[{"uid":"5277-746"}]},"5277-710":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-711"},"imported":[],"importedBy":[{"uid":"5277-712"}]},"5277-712":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js","moduleParts":{"metamask-sdk.js":"5277-713"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-710"}],"importedBy":[{"uid":"5277-1256"}]},"5277-714":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/isarray/index.js","moduleParts":{"metamask-sdk.js":"5277-715"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1257"}]},"5277-716":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/stream-browser.js","moduleParts":{"metamask-sdk.js":"5277-717"},"imported":[{"uid":"5277-10"},{"uid":"5277-40"}],"importedBy":[{"uid":"5277-1258"}]},"5277-718":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-719"},"imported":[],"importedBy":[{"uid":"5277-720"}]},"5277-720":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js","moduleParts":{"metamask-sdk.js":"5277-721"},"imported":[{"uid":"5277-10"},{"uid":"5277-718"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1259"}]},"5277-722":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-723"},"imported":[],"importedBy":[{"uid":"5277-724"}]},"5277-724":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js","moduleParts":{"metamask-sdk.js":"5277-725"},"imported":[{"uid":"5277-10"},{"uid":"5277-722"},{"uid":"5277-18"}],"importedBy":[{"uid":"5277-1260"}]},"5277-726":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-727"},"imported":[],"importedBy":[{"uid":"5277-728"}]},"5277-728":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js","moduleParts":{"metamask-sdk.js":"5277-729"},"imported":[{"uid":"5277-10"},{"uid":"5277-726"},{"uid":"5277-1259"},{"uid":"5277-48"}],"importedBy":[{"uid":"5277-740"}]},"5277-730":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-731"},"imported":[{"uid":"5277-10"},{"uid":"5277-1256"}],"importedBy":[{"uid":"5277-1261"}]},"5277-732":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-733"},"imported":[{"uid":"5277-500"},{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1256"},{"uid":"5277-1260"},{"uid":"5277-1133"},{"uid":"5277-1218"},{"uid":"5277-1258"},{"uid":"5277-1259"},{"uid":"5277-1261"},{"uid":"5277-734"}],"importedBy":[{"uid":"5277-746"},{"uid":"5277-734"}]},"5277-734":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-735"},"imported":[{"uid":"5277-10"},{"uid":"5277-1256"},{"uid":"5277-1260"},{"uid":"5277-1133"},{"uid":"5277-740"},{"uid":"5277-732"}],"importedBy":[{"uid":"5277-746"},{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-742"}]},"5277-736":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-737"},"imported":[],"importedBy":[{"uid":"5277-738"}]},"5277-738":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-739"},"imported":[{"uid":"5277-10"},{"uid":"5277-736"},{"uid":"5277-1259"}],"importedBy":[{"uid":"5277-740"}]},"5277-740":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-741"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1256"},{"uid":"5277-1257"},{"uid":"5277-40"},{"uid":"5277-1258"},{"uid":"5277-1259"},{"uid":"5277-1260"},{"uid":"5277-1133"},{"uid":"5277-48"},{"uid":"5277-728"},{"uid":"5277-1261"},{"uid":"5277-734"},{"uid":"5277-738"}],"importedBy":[{"uid":"5277-746"},{"uid":"5277-734"}]},"5277-742":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-743"},"imported":[{"uid":"5277-10"},{"uid":"5277-734"},{"uid":"5277-1260"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1235"}]},"5277-744":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-745"},"imported":[{"uid":"5277-10"},{"uid":"5277-1235"},{"uid":"5277-1260"},{"uid":"5277-1133"}],"importedBy":[{"uid":"5277-1236"}]},"5277-746":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js","moduleParts":{"metamask-sdk.js":"5277-747"},"imported":[{"uid":"5277-10"},{"uid":"5277-708"},{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-734"},{"uid":"5277-1235"},{"uid":"5277-1236"}],"importedBy":[{"uid":"5277-1189"}]},"5277-748":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-749"},"imported":[],"importedBy":[{"uid":"5277-752"}]},"5277-750":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js","moduleParts":{"metamask-sdk.js":"5277-751"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1192"}]},"5277-752":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js","moduleParts":{"metamask-sdk.js":"5277-753"},"imported":[{"uid":"5277-10"},{"uid":"5277-748"},{"uid":"5277-1192"}],"importedBy":[{"uid":"5277-1148"}]},"5277-754":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-755"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1148"}],"importedBy":[{"uid":"5277-1149"}]},"5277-756":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-757"},"imported":[],"importedBy":[{"uid":"5277-758"}]},"5277-758":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js","moduleParts":{"metamask-sdk.js":"5277-759"},"imported":[{"uid":"5277-10"},{"uid":"5277-756"},{"uid":"5277-1189"}],"importedBy":[{"uid":"5277-1190"}]},"5277-760":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js","moduleParts":{"metamask-sdk.js":"5277-761"},"imported":[{"uid":"5277-10"},{"uid":"5277-706"},{"uid":"5277-1189"},{"uid":"5277-1149"},{"uid":"5277-1148"},{"uid":"5277-1190"}],"importedBy":[{"uid":"5277-1145"}]},"5277-762":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-763"},"imported":[{"uid":"5277-10"},{"uid":"5277-1145"}],"importedBy":[{"uid":"5277-1102"}]},"5277-764":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-765"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1103"}]},"5277-766":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-767"},"imported":[],"importedBy":[{"uid":"5277-780"}]},"5277-768":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-769"},"imported":[],"importedBy":[{"uid":"5277-770"}]},"5277-770":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js","moduleParts":{"metamask-sdk.js":"5277-771"},"imported":[{"uid":"5277-10"},{"uid":"5277-768"},{"uid":"5277-1189"}],"importedBy":[{"uid":"5277-1146"}]},"5277-772":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-773"},"imported":[],"importedBy":[{"uid":"5277-778"}]},"5277-774":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-775"},"imported":[],"importedBy":[{"uid":"5277-776"}]},"5277-776":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-777"},"imported":[{"uid":"5277-10"},{"uid":"5277-774"},{"uid":"5277-40"}],"importedBy":[{"uid":"5277-1191"}]},"5277-778":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-779"},"imported":[{"uid":"5277-10"},{"uid":"5277-772"},{"uid":"5277-1191"},{"uid":"5277-1189"}],"importedBy":[{"uid":"5277-1147"}]},"5277-780":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-781"},"imported":[{"uid":"5277-10"},{"uid":"5277-766"},{"uid":"5277-1146"},{"uid":"5277-1147"}],"importedBy":[{"uid":"5277-1104"}]},"5277-782":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/empty.js","moduleParts":{"metamask-sdk.js":"5277-783"},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-784"}]},"5277-784":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/empty.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-785"},"imported":[{"uid":"5277-10"},{"uid":"5277-782"}],"importedBy":[{"uid":"5277-786"}]},"5277-786":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js","moduleParts":{"metamask-sdk.js":"5277-787"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1148"},{"uid":"5277-1149"},{"uid":"5277-784"}],"importedBy":[{"uid":"5277-1105"}]},"5277-788":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js","moduleParts":{"metamask-sdk.js":"5277-789"},"imported":[{"uid":"5277-10"},{"uid":"5277-704"},{"uid":"5277-1102"},{"uid":"5277-1103"},{"uid":"5277-1104"},{"uid":"5277-1105"},{"uid":"5277-1097"},{"uid":"5277-1098"},{"uid":"5277-1074"}],"importedBy":[{"uid":"5277-1079"}]},"5277-790":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-791"},"imported":[{"uid":"5277-10"},{"uid":"5277-698"},{"uid":"5277-1094"},{"uid":"5277-1101"},{"uid":"5277-1097"},{"uid":"5277-1098"},{"uid":"5277-1079"}],"importedBy":[{"uid":"5277-1077"}]},"5277-792":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json","moduleParts":{"metamask-sdk.js":"5277-793"},"imported":[],"importedBy":[{"uid":"5277-1100"}]},"5277-794":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js","moduleParts":{"metamask-sdk.js":"5277-795"},"imported":[{"uid":"5277-10"},{"uid":"5277-688"},{"uid":"5277-1099"},{"uid":"5277-696"},{"uid":"5277-1077"},{"uid":"5277-1079"},{"uid":"5277-1098"},{"uid":"5277-1100"}],"importedBy":[{"uid":"5277-1075"}]},"5277-796":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-797"},"imported":[],"importedBy":[{"uid":"5277-802"}]},"5277-798":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-799"},"imported":[],"importedBy":[{"uid":"5277-800"}]},"5277-800":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js","moduleParts":{"metamask-sdk.js":"5277-801"},"imported":[{"uid":"5277-10"},{"uid":"5277-798"}],"importedBy":[{"uid":"5277-1078"}]},"5277-802":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-803"},"imported":[{"uid":"5277-10"},{"uid":"5277-796"},{"uid":"5277-1077"},{"uid":"5277-1078"}],"importedBy":[{"uid":"5277-1076"}]},"5277-804":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-805"},"imported":[{"uid":"5277-10"},{"uid":"5277-614"},{"uid":"5277-1074"},{"uid":"5277-1075"},{"uid":"5277-1076"},{"uid":"5277-1077"},{"uid":"5277-1078"},{"uid":"5277-1079"}],"importedBy":[{"uid":"5277-814"},{"uid":"5277-874"}]},"5277-806":{"id":"/src/services/SDKProvider/ChainManager/handleChainChanged.ts","moduleParts":{"metamask-sdk.js":"5277-807"},"imported":[],"importedBy":[{"uid":"5277-814"}]},"5277-808":{"id":"/src/services/SDKProvider/ConnectionManager/handleDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-809"},"imported":[{"uid":"5277-642"}],"importedBy":[{"uid":"5277-814"}]},"5277-810":{"id":"/src/services/SDKProvider/InitializationManager/initializeState.ts","moduleParts":{"metamask-sdk.js":"5277-811"},"imported":[],"importedBy":[{"uid":"5277-814"}]},"5277-812":{"id":"/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts","moduleParts":{"metamask-sdk.js":"5277-813"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-814"}]},"5277-814":{"id":"/src/provider/SDKProvider.ts","moduleParts":{"metamask-sdk.js":"5277-815"},"imported":[{"uid":"5277-612"},{"uid":"5277-804"},{"uid":"5277-806"},{"uid":"5277-808"},{"uid":"5277-810"},{"uid":"5277-812"}],"importedBy":[{"uid":"5277-1060"},{"uid":"5277-874"}]},"5277-816":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-817"},"imported":[],"importedBy":[{"uid":"5277-850"},{"uid":"5277-832"},{"uid":"5277-822"},{"uid":"5277-820"}]},"5277-818":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-819"},"imported":[],"importedBy":[{"uid":"5277-850"}]},"5277-820":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-821"},"imported":[{"uid":"5277-816"}],"importedBy":[{"uid":"5277-822"}]},"5277-822":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-823"},"imported":[{"uid":"5277-816"},{"uid":"5277-820"}],"importedBy":[{"uid":"5277-824"},{"uid":"5277-836"}]},"5277-824":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-825"},"imported":[{"uid":"5277-822"}],"importedBy":[{"uid":"5277-850"}]},"5277-826":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js","moduleParts":{"metamask-sdk.js":"5277-827"},"imported":[],"importedBy":[{"uid":"5277-850"},{"uid":"5277-832"}]},"5277-828":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-829"},"imported":[],"importedBy":[{"uid":"5277-830"}]},"5277-830":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/inherits.js","moduleParts":{"metamask-sdk.js":"5277-831"},"imported":[{"uid":"5277-828"}],"importedBy":[{"uid":"5277-850"}]},"5277-832":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js","moduleParts":{"metamask-sdk.js":"5277-833"},"imported":[{"uid":"5277-816"},{"uid":"5277-826"}],"importedBy":[{"uid":"5277-850"}]},"5277-834":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/getPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-835"},"imported":[],"importedBy":[{"uid":"5277-850"}]},"5277-836":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/defineProperty.js","moduleParts":{"metamask-sdk.js":"5277-837"},"imported":[{"uid":"5277-822"}],"importedBy":[{"uid":"5277-850"}]},"5277-838":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js","moduleParts":{"metamask-sdk.js":"5277-839"},"imported":[],"importedBy":[{"uid":"5277-848"}]},"5277-840":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/iterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-841"},"imported":[],"importedBy":[{"uid":"5277-848"}]},"5277-842":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js","moduleParts":{"metamask-sdk.js":"5277-843"},"imported":[],"importedBy":[{"uid":"5277-844"}]},"5277-844":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-845"},"imported":[{"uid":"5277-842"}],"importedBy":[{"uid":"5277-848"}]},"5277-846":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js","moduleParts":{"metamask-sdk.js":"5277-847"},"imported":[],"importedBy":[{"uid":"5277-848"}]},"5277-848":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toArray.js","moduleParts":{"metamask-sdk.js":"5277-849"},"imported":[{"uid":"5277-838"},{"uid":"5277-840"},{"uid":"5277-844"},{"uid":"5277-846"}],"importedBy":[{"uid":"5277-850"}]},"5277-850":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/dist/esm/i18next.js","moduleParts":{"metamask-sdk.js":"5277-851"},"imported":[{"uid":"5277-816"},{"uid":"5277-818"},{"uid":"5277-824"},{"uid":"5277-826"},{"uid":"5277-830"},{"uid":"5277-832"},{"uid":"5277-834"},{"uid":"5277-836"},{"uid":"5277-848"}],"importedBy":[{"uid":"5277-1058"}]},"5277-852":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connect.ts","moduleParts":{"metamask-sdk.js":"5277-853"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-1063"}]},"5277-854":{"id":"/src/services/MetaMaskSDK/ConnectionManager/resume.ts","moduleParts":{"metamask-sdk.js":"5277-855"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-1063"}]},"5277-856":{"id":"/src/config.ts","moduleParts":{"metamask-sdk.js":"5277-857"},"imported":[],"importedBy":[{"uid":"5277-1056"},{"uid":"5277-860"},{"uid":"5277-866"},{"uid":"5277-912"},{"uid":"5277-894"},{"uid":"5277-862"},{"uid":"5277-906"},{"uid":"5277-994"},{"uid":"5277-878"}]},"5277-858":{"id":"/src/types/ProviderUpdateType.ts","moduleParts":{"metamask-sdk.js":"5277-859"},"imported":[],"importedBy":[{"uid":"5277-1060"},{"uid":"5277-860"},{"uid":"5277-1052"},{"uid":"5277-894"},{"uid":"5277-862"}]},"5277-860":{"id":"/src/services/MetaMaskSDK/ConnectionManager/terminate.ts","moduleParts":{"metamask-sdk.js":"5277-861"},"imported":[{"uid":"5277-610"},{"uid":"5277-856"},{"uid":"5277-858"}],"importedBy":[{"uid":"5277-1063"}]},"5277-862":{"id":"/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-863"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-856"},{"uid":"5277-858"}],"importedBy":[{"uid":"5277-1088"}]},"5277-864":{"id":"/src/services/Analytics.ts","moduleParts":{"metamask-sdk.js":"5277-865"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"}],"importedBy":[{"uid":"5277-866"},{"uid":"5277-898"}]},"5277-866":{"id":"/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts","moduleParts":{"metamask-sdk.js":"5277-867"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-856"},{"uid":"5277-1088"},{"uid":"5277-864"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-868":{"id":"/src/services/MetaMaskSDK/InitializerManager/initEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-869"},"imported":[{"uid":"5277-610"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-896"}]},"5277-870":{"id":"/src/constants.ts","moduleParts":{"metamask-sdk.js":"5277-871"},"imported":[],"importedBy":[{"uid":"5277-894"},{"uid":"5277-908"},{"uid":"5277-872"},{"uid":"5277-878"},{"uid":"5277-972"},{"uid":"5277-976"},{"uid":"5277-984"},{"uid":"5277-982"}]},"5277-872":{"id":"/src/services/RemoteCommunicationPostMessageStream/onMessage.ts","moduleParts":{"metamask-sdk.js":"5277-873"},"imported":[{"uid":"5277-8"},{"uid":"5277-870"}],"importedBy":[{"uid":"5277-880"}]},"5277-874":{"id":"/src/services/Ethereum.ts","moduleParts":{"metamask-sdk.js":"5277-875"},"imported":[{"uid":"5277-804"},{"uid":"5277-814"}],"importedBy":[{"uid":"5277-912"},{"uid":"5277-894"},{"uid":"5277-926"},{"uid":"5277-948"},{"uid":"5277-990"},{"uid":"5277-878"},{"uid":"5277-1153"},{"uid":"5277-984"},{"uid":"5277-986"},{"uid":"5277-982"}]},"5277-876":{"id":"/src/services/RemoteCommunicationPostMessageStream/extractMethod.ts","moduleParts":{"metamask-sdk.js":"5277-877"},"imported":[{"uid":"5277-8"}],"importedBy":[{"uid":"5277-878"}]},"5277-878":{"id":"/src/services/RemoteCommunicationPostMessageStream/write.ts","moduleParts":{"metamask-sdk.js":"5277-879"},"imported":[{"uid":"5277-612"},{"uid":"5277-856"},{"uid":"5277-870"},{"uid":"5277-874"},{"uid":"5277-876"}],"importedBy":[{"uid":"5277-880"}]},"5277-880":{"id":"/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-881"},"imported":[{"uid":"5277-612"},{"uid":"5277-124"},{"uid":"5277-610"},{"uid":"5277-872"},{"uid":"5277-878"}],"importedBy":[{"uid":"5277-882"}]},"5277-882":{"id":"/src/PostMessageStream/getPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-883"},"imported":[{"uid":"5277-880"}],"importedBy":[{"uid":"5277-894"}]},"5277-884":{"id":"/src/utils/wait.ts","moduleParts":{"metamask-sdk.js":"5277-885"},"imported":[],"importedBy":[{"uid":"5277-894"},{"uid":"5277-950"}]},"5277-886":{"id":"\u0000/node_modules/cross-fetch/dist/browser-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-887"},"imported":[],"importedBy":[{"uid":"5277-888"}]},"5277-888":{"id":"/node_modules/cross-fetch/dist/browser-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-889"},"imported":[{"uid":"5277-10"},{"uid":"5277-886"}],"importedBy":[{"uid":"5277-890"}]},"5277-890":{"id":"/src/services/rpc-requests/RPCRequestHandler.ts","moduleParts":{"metamask-sdk.js":"5277-891"},"imported":[{"uid":"5277-612"},{"uid":"5277-888"}],"importedBy":[{"uid":"5277-894"}]},"5277-892":{"id":"/package.json","moduleParts":{"metamask-sdk.js":"5277-893"},"imported":[],"importedBy":[{"uid":"5277-894"},{"uid":"5277-962"},{"uid":"5277-966"},{"uid":"5277-970"}]},"5277-894":{"id":"/src/provider/initializeMobileProvider.ts","moduleParts":{"metamask-sdk.js":"5277-895"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-882"},{"uid":"5277-856"},{"uid":"5277-870"},{"uid":"5277-874"},{"uid":"5277-858"},{"uid":"5277-884"},{"uid":"5277-890"},{"uid":"5277-892"}],"importedBy":[{"uid":"5277-896"}]},"5277-896":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeProviderAndEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-897"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-894"},{"uid":"5277-868"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-898":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.ts","moduleParts":{"metamask-sdk.js":"5277-899"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-864"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-900":{"id":"/src/utils/extractFavicon.ts","moduleParts":{"metamask-sdk.js":"5277-901"},"imported":[],"importedBy":[{"uid":"5277-904"}]},"5277-902":{"id":"/src/utils/getBase64FromUrl.ts","moduleParts":{"metamask-sdk.js":"5277-903"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-904"}]},"5277-904":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.ts","moduleParts":{"metamask-sdk.js":"5277-905"},"imported":[{"uid":"5277-612"},{"uid":"5277-900"},{"uid":"5277-902"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-906":{"id":"/src/provider/wrapExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-907"},"imported":[{"uid":"5277-612"},{"uid":"5277-856"}],"importedBy":[{"uid":"5277-910"}]},"5277-908":{"id":"/src/utils/eip6963RequestProvider.ts","moduleParts":{"metamask-sdk.js":"5277-909"},"imported":[{"uid":"5277-870"}],"importedBy":[{"uid":"5277-910"}]},"5277-910":{"id":"/src/utils/get-browser-extension.ts","moduleParts":{"metamask-sdk.js":"5277-911"},"imported":[{"uid":"5277-612"},{"uid":"5277-906"},{"uid":"5277-908"}],"importedBy":[{"uid":"5277-912"}]},"5277-912":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts","moduleParts":{"metamask-sdk.js":"5277-913"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-856"},{"uid":"5277-910"},{"uid":"5277-874"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-914":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/es5.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-915"},"imported":[],"importedBy":[{"uid":"5277-916"}]},"5277-916":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/es5.js","moduleParts":{"metamask-sdk.js":"5277-917"},"imported":[{"uid":"5277-10"},{"uid":"5277-914"}],"importedBy":[{"uid":"5277-938"},{"uid":"5277-946"}]},"5277-918":{"id":"/src/types/WakeLockStatus.ts","moduleParts":{"metamask-sdk.js":"5277-919"},"imported":[],"importedBy":[{"uid":"5277-938"},{"uid":"5277-920"},{"uid":"5277-922"}]},"5277-920":{"id":"/src/services/PlatfformManager/disableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-921"},"imported":[{"uid":"5277-918"}],"importedBy":[{"uid":"5277-938"}]},"5277-922":{"id":"/src/services/PlatfformManager/enableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-923"},"imported":[{"uid":"5277-938"},{"uid":"5277-918"}],"importedBy":[{"uid":"5277-938"}]},"5277-924":{"id":"/src/services/PlatfformManager/getPlatformType.ts","moduleParts":{"metamask-sdk.js":"5277-925"},"imported":[{"uid":"5277-610"}],"importedBy":[{"uid":"5277-938"}]},"5277-926":{"id":"/src/services/PlatfformManager/isMetaMaskInstalled.ts","moduleParts":{"metamask-sdk.js":"5277-927"},"imported":[{"uid":"5277-874"}],"importedBy":[{"uid":"5277-938"}]},"5277-928":{"id":"/src/services/PlatfformManager/openDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-929"},"imported":[{"uid":"5277-938"}],"importedBy":[{"uid":"5277-938"}]},"5277-930":{"id":"/src/utils/hasNativeWakeLockSupport.ts","moduleParts":{"metamask-sdk.js":"5277-931"},"imported":[],"importedBy":[{"uid":"5277-936"}]},"5277-932":{"id":"/src/utils/isOldIOS.ts","moduleParts":{"metamask-sdk.js":"5277-933"},"imported":[],"importedBy":[{"uid":"5277-936"}]},"5277-934":{"id":"/src/Platform/Media.ts","moduleParts":{"metamask-sdk.js":"5277-935"},"imported":[],"importedBy":[{"uid":"5277-936"}]},"5277-936":{"id":"/src/Platform/WakeLockManager.ts","moduleParts":{"metamask-sdk.js":"5277-937"},"imported":[{"uid":"5277-612"},{"uid":"5277-930"},{"uid":"5277-932"},{"uid":"5277-934"}],"importedBy":[{"uid":"5277-938"}]},"5277-938":{"id":"/src/Platform/PlatfformManager.ts","moduleParts":{"metamask-sdk.js":"5277-939"},"imported":[{"uid":"5277-610"},{"uid":"5277-916"},{"uid":"5277-920"},{"uid":"5277-922"},{"uid":"5277-924"},{"uid":"5277-926"},{"uid":"5277-928"},{"uid":"5277-918"},{"uid":"5277-936"}],"importedBy":[{"uid":"5277-940"},{"uid":"5277-922"},{"uid":"5277-928"}]},"5277-940":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupPlatformManager.ts","moduleParts":{"metamask-sdk.js":"5277-941"},"imported":[{"uid":"5277-612"},{"uid":"5277-938"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-942":{"id":"/src/services/MetaMaskInstaller/checkInstallation.ts","moduleParts":{"metamask-sdk.js":"5277-943"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-952"}]},"5277-944":{"id":"/src/services/MetaMaskInstaller/redirectToProperInstall.ts","moduleParts":{"metamask-sdk.js":"5277-945"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"}],"importedBy":[{"uid":"5277-952"}]},"5277-946":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/onboarding/dist/metamask-onboarding.es.js","moduleParts":{"metamask-sdk.js":"5277-947"},"imported":[{"uid":"5277-916"}],"importedBy":[{"uid":"5277-948"}]},"5277-948":{"id":"/src/services/MetaMaskInstaller/startDesktopOnboarding.ts","moduleParts":{"metamask-sdk.js":"5277-949"},"imported":[{"uid":"5277-612"},{"uid":"5277-946"},{"uid":"5277-874"}],"importedBy":[{"uid":"5277-952"}]},"5277-950":{"id":"/src/services/MetaMaskInstaller/startInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-951"},"imported":[{"uid":"5277-612"},{"uid":"5277-884"}],"importedBy":[{"uid":"5277-952"}]},"5277-952":{"id":"/src/Platform/MetaMaskInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-953"},"imported":[{"uid":"5277-612"},{"uid":"5277-942"},{"uid":"5277-944"},{"uid":"5277-948"},{"uid":"5277-950"}],"importedBy":[{"uid":"5277-992"}]},"5277-954":{"id":"\u0000-install-modal-web/dist/umd/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-955"},"imported":[],"importedBy":[{"uid":"5277-960"}]},"5277-956":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/qr-code-styling/lib/qr-code-styling.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-957"},"imported":[],"importedBy":[{"uid":"5277-958"}]},"5277-958":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/qr-code-styling/lib/qr-code-styling.js","moduleParts":{"metamask-sdk.js":"5277-959"},"imported":[{"uid":"5277-10"},{"uid":"5277-956"}],"importedBy":[{"uid":"5277-960"}]},"5277-960":{"id":"-install-modal-web/dist/umd/index.js","moduleParts":{"metamask-sdk.js":"5277-961"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-954"},{"uid":"5277-958"}],"importedBy":[{"uid":"5277-962"},{"uid":"5277-966"}]},"5277-962":{"id":"/src/ui/InstallModal/InstallModal-web.ts","moduleParts":{"metamask-sdk.js":"5277-963"},"imported":[{"uid":"5277-960"},{"uid":"5277-892"}],"importedBy":[{"uid":"5277-964"}]},"5277-964":{"id":"/src/ui/InstallModal/installModal.ts","moduleParts":{"metamask-sdk.js":"5277-965"},"imported":[{"uid":"5277-962"}],"importedBy":[{"uid":"5277-990"}]},"5277-966":{"id":"/src/ui/InstallModal/pendingModal-web.ts","moduleParts":{"metamask-sdk.js":"5277-967"},"imported":[{"uid":"5277-960"},{"uid":"5277-892"}],"importedBy":[{"uid":"5277-968"}]},"5277-968":{"id":"/src/ui/InstallModal/pendingModal.ts","moduleParts":{"metamask-sdk.js":"5277-969"},"imported":[{"uid":"5277-966"}],"importedBy":[{"uid":"5277-990"}]},"5277-970":{"id":"/src/services/RemoteConnection/ConnectionInitializer/initializeConnector.ts","moduleParts":{"metamask-sdk.js":"5277-971"},"imported":[{"uid":"5277-610"},{"uid":"5277-892"}],"importedBy":[{"uid":"5277-1125"}]},"5277-972":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-973"},"imported":[{"uid":"5277-612"},{"uid":"5277-870"}],"importedBy":[{"uid":"5277-1126"},{"uid":"5277-984"}]},"5277-974":{"id":"/src/services/RemoteConnection/ModalManager/showInstallModal.ts","moduleParts":{"metamask-sdk.js":"5277-975"},"imported":[],"importedBy":[{"uid":"5277-1128"},{"uid":"5277-976"}]},"5277-976":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithModalInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-977"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-974"},{"uid":"5277-870"}],"importedBy":[{"uid":"5277-1126"},{"uid":"5277-984"}]},"5277-978":{"id":"/src/services/RemoteConnection/ModalManager/onOTPModalDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-979"},"imported":[],"importedBy":[{"uid":"5277-982"}]},"5277-980":{"id":"/src/services/RemoteConnection/ModalManager/waitForOTPAnswer.ts","moduleParts":{"metamask-sdk.js":"5277-981"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-982"}]},"5277-982":{"id":"/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts","moduleParts":{"metamask-sdk.js":"5277-983"},"imported":[{"uid":"5277-612"},{"uid":"5277-874"},{"uid":"5277-870"},{"uid":"5277-978"},{"uid":"5277-980"}],"importedBy":[{"uid":"5277-1128"},{"uid":"5277-984"}]},"5277-984":{"id":"/src/services/RemoteConnection/ConnectionManager/startConnection.ts","moduleParts":{"metamask-sdk.js":"5277-985"},"imported":[{"uid":"5277-612"},{"uid":"5277-870"},{"uid":"5277-874"},{"uid":"5277-982"},{"uid":"5277-972"},{"uid":"5277-976"}],"importedBy":[{"uid":"5277-1126"}]},"5277-986":{"id":"/src/services/RemoteConnection/EventListeners/setupListeners.ts","moduleParts":{"metamask-sdk.js":"5277-987"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-874"}],"importedBy":[{"uid":"5277-1127"}]},"5277-988":{"id":"/src/services/RemoteConnection/ModalManager/showActiveModal.ts","moduleParts":{"metamask-sdk.js":"5277-989"},"imported":[],"importedBy":[{"uid":"5277-1128"}]},"5277-990":{"id":"/src/services/RemoteConnection/RemoteConnection.ts","moduleParts":{"metamask-sdk.js":"5277-991"},"imported":[{"uid":"5277-612"},{"uid":"5277-964"},{"uid":"5277-968"},{"uid":"5277-874"},{"uid":"5277-1125"},{"uid":"5277-1126"},{"uid":"5277-1127"},{"uid":"5277-1128"}],"importedBy":[{"uid":"5277-1089"}]},"5277-992":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-993"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-952"},{"uid":"5277-1089"},{"uid":"5277-1088"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-994":{"id":"/src/storage-manager/StorageManagerWeb.ts","moduleParts":{"metamask-sdk.js":"5277-995"},"imported":[{"uid":"5277-612"},{"uid":"5277-856"}],"importedBy":[{"uid":"5277-996"}]},"5277-996":{"id":"/src/storage-manager/getStorageManager.ts","moduleParts":{"metamask-sdk.js":"5277-997"},"imported":[{"uid":"5277-994"}],"importedBy":[{"uid":"5277-998"}]},"5277-998":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupStorage.ts","moduleParts":{"metamask-sdk.js":"5277-999"},"imported":[{"uid":"5277-612"},{"uid":"5277-996"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1052"}]},"5277-1000":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupInfuraProvider.ts","moduleParts":{"metamask-sdk.js":"5277-1001"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-1052"}]},"5277-1002":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupReadOnlyRPCProviders.ts","moduleParts":{"metamask-sdk.js":"5277-1003"},"imported":[{"uid":"5277-612"}],"importedBy":[{"uid":"5277-1052"}]},"5277-1004":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-1005"},"imported":[],"importedBy":[{"uid":"5277-1014"}]},"5277-1006":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-1007"},"imported":[],"importedBy":[{"uid":"5277-1010"},{"uid":"5277-1008"}]},"5277-1008":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-1009"},"imported":[{"uid":"5277-1006"}],"importedBy":[{"uid":"5277-1010"}]},"5277-1010":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-1011"},"imported":[{"uid":"5277-1006"},{"uid":"5277-1008"}],"importedBy":[{"uid":"5277-1012"}]},"5277-1012":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-1013"},"imported":[{"uid":"5277-1010"}],"importedBy":[{"uid":"5277-1014"}]},"5277-1014":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/dist/esm/i18nextBrowserLanguageDetector.js","moduleParts":{"metamask-sdk.js":"5277-1015"},"imported":[{"uid":"5277-1004"},{"uid":"5277-1012"}],"importedBy":[{"uid":"5277-1050"}]},"5277-1016":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1017"},"imported":[],"importedBy":[{"uid":"5277-1026"}]},"5277-1018":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1019"},"imported":[],"importedBy":[{"uid":"5277-1020"}]},"5277-1020":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js","moduleParts":{"metamask-sdk.js":"5277-1021"},"imported":[{"uid":"5277-10"},{"uid":"5277-1018"}],"importedBy":[{"uid":"5277-1026"}]},"5277-1022":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1023"},"imported":[],"importedBy":[{"uid":"5277-1024"}]},"5277-1024":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js","moduleParts":{"metamask-sdk.js":"5277-1025"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1022"}],"importedBy":[{"uid":"5277-1026"}]},"5277-1026":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js","moduleParts":{"metamask-sdk.js":"5277-1027"},"imported":[{"uid":"5277-22"},{"uid":"5277-10"},{"uid":"5277-1016"},{"uid":"5277-1020"},{"uid":"5277-1024"}],"importedBy":[{"uid":"5277-1116"},{"uid":"5277-1117"},{"uid":"5277-1118"},{"uid":"5277-1119"},{"uid":"5277-1121"},{"uid":"5277-1122"},{"uid":"5277-1123"},{"uid":"5277-1034"}]},"5277-1028":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/unescape.js","moduleParts":{"metamask-sdk.js":"5277-1029"},"imported":[],"importedBy":[{"uid":"5277-1030"}]},"5277-1030":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/defaults.js","moduleParts":{"metamask-sdk.js":"5277-1031"},"imported":[{"uid":"5277-1028"}],"importedBy":[{"uid":"5277-1106"},{"uid":"5277-1117"},{"uid":"5277-1032"},{"uid":"5277-1034"}]},"5277-1032":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/initReactI18next.js","moduleParts":{"metamask-sdk.js":"5277-1033"},"imported":[{"uid":"5277-1030"},{"uid":"5277-1124"}],"importedBy":[{"uid":"5277-1106"},{"uid":"5277-1034"}]},"5277-1034":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/context.js","moduleParts":{"metamask-sdk.js":"5277-1035"},"imported":[{"uid":"5277-1026"},{"uid":"5277-1030"},{"uid":"5277-1124"},{"uid":"5277-1032"}],"importedBy":[{"uid":"5277-1106"},{"uid":"5277-1116"},{"uid":"5277-1118"},{"uid":"5277-1121"},{"uid":"5277-1122"},{"uid":"5277-1123"}]},"5277-1036":{"id":"/src/locales/en.json","moduleParts":{"metamask-sdk.js":"5277-1037"},"imported":[],"importedBy":[{"uid":"5277-1050"}]},"5277-1038":{"id":"/src/locales/es.json","moduleParts":{"metamask-sdk.js":"5277-1039"},"imported":[],"importedBy":[{"uid":"5277-1050"}]},"5277-1040":{"id":"/src/locales/fr.json","moduleParts":{"metamask-sdk.js":"5277-1041"},"imported":[],"importedBy":[{"uid":"5277-1050"}]},"5277-1042":{"id":"/src/locales/he.json","moduleParts":{"metamask-sdk.js":"5277-1043"},"imported":[],"importedBy":[{"uid":"5277-1050"}]},"5277-1044":{"id":"/src/locales/it.json","moduleParts":{"metamask-sdk.js":"5277-1045"},"imported":[],"importedBy":[{"uid":"5277-1050"}]},"5277-1046":{"id":"/src/locales/pt.json","moduleParts":{"metamask-sdk.js":"5277-1047"},"imported":[],"importedBy":[{"uid":"5277-1050"}]},"5277-1048":{"id":"/src/locales/tr.json","moduleParts":{"metamask-sdk.js":"5277-1049"},"imported":[],"importedBy":[{"uid":"5277-1050"}]},"5277-1050":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeI18next.ts","moduleParts":{"metamask-sdk.js":"5277-1051"},"imported":[{"uid":"5277-612"},{"uid":"5277-1014"},{"uid":"5277-1106"},{"uid":"5277-1036"},{"uid":"5277-1038"},{"uid":"5277-1040"},{"uid":"5277-1042"},{"uid":"5277-1044"},{"uid":"5277-1046"},{"uid":"5277-1048"}],"importedBy":[{"uid":"5277-1052"}]},"5277-1052":{"id":"/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts","moduleParts":{"metamask-sdk.js":"5277-1053"},"imported":[{"uid":"5277-612"},{"uid":"5277-610"},{"uid":"5277-858"},{"uid":"5277-866"},{"uid":"5277-896"},{"uid":"5277-898"},{"uid":"5277-904"},{"uid":"5277-912"},{"uid":"5277-940"},{"uid":"5277-992"},{"uid":"5277-998"},{"uid":"5277-1000"},{"uid":"5277-1002"},{"uid":"5277-1050"}],"importedBy":[{"uid":"5277-1064"},{"uid":"5277-1054"}]},"5277-1054":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeMetaMaskSDK.ts","moduleParts":{"metamask-sdk.js":"5277-1055"},"imported":[{"uid":"5277-612"},{"uid":"5277-1052"}],"importedBy":[{"uid":"5277-1064"}]},"5277-1056":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connectAndSign.ts","moduleParts":{"metamask-sdk.js":"5277-1057"},"imported":[{"uid":"5277-612"},{"uid":"5277-856"}],"importedBy":[{"uid":"5277-1058"}]},"5277-1058":{"id":"/src/sdk.ts","moduleParts":{"metamask-sdk.js":"5277-1059"},"imported":[{"uid":"5277-612"},{"uid":"5277-536"},{"uid":"5277-850"},{"uid":"5277-1063"},{"uid":"5277-1064"},{"uid":"5277-1056"}],"importedBy":[{"uid":"5277-1060"}]},"5277-1060":{"id":"/src/index.ts","moduleParts":{"metamask-sdk.js":"5277-1061"},"imported":[{"uid":"5277-610"},{"uid":"5277-814"},{"uid":"5277-1058"},{"uid":"5277-858"}],"importedBy":[],"isEntry":true},"5277-1062":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/index.js","moduleParts":{},"imported":[{"uid":"5277-1068"},{"uid":"5277-1069"},{"uid":"5277-546"},{"uid":"5277-1070"},{"uid":"5277-1071"},{"uid":"5277-1072"},{"uid":"5277-542"},{"uid":"5277-544"},{"uid":"5277-1073"}],"importedBy":[{"uid":"5277-610"}]},"5277-1063":{"id":"/src/services/MetaMaskSDK/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-852"},{"uid":"5277-854"},{"uid":"5277-860"}],"importedBy":[{"uid":"5277-1058"}]},"5277-1064":{"id":"/src/services/MetaMaskSDK/InitializerManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-866"},{"uid":"5277-868"},{"uid":"5277-1054"},{"uid":"5277-896"},{"uid":"5277-1052"},{"uid":"5277-898"},{"uid":"5277-904"},{"uid":"5277-912"},{"uid":"5277-940"},{"uid":"5277-992"},{"uid":"5277-998"}],"importedBy":[{"uid":"5277-1058"}]},"5277-1065":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-530"}],"importedBy":[{"uid":"5277-532"}]},"5277-1066":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-522"}],"importedBy":[{"uid":"5277-532"},{"uid":"5277-528"},{"uid":"5277-526"}]},"5277-1067":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-520"}],"importedBy":[{"uid":"5277-532"},{"uid":"5277-522"},{"uid":"5277-526"}]},"5277-1068":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v1.js","moduleParts":{},"imported":[{"uid":"5277-538"},{"uid":"5277-544"}],"importedBy":[{"uid":"5277-1062"}]},"5277-1069":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v3.js","moduleParts":{},"imported":[{"uid":"5277-1080"},{"uid":"5277-1081"}],"importedBy":[{"uid":"5277-1062"}]},"5277-1070":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v5.js","moduleParts":{},"imported":[{"uid":"5277-1080"},{"uid":"5277-1082"}],"importedBy":[{"uid":"5277-1062"}]},"5277-1071":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/nil.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-1062"}]},"5277-1072":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/version.js","moduleParts":{},"imported":[{"uid":"5277-542"}],"importedBy":[{"uid":"5277-1062"}]},"5277-1073":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/parse.js","moduleParts":{},"imported":[{"uid":"5277-542"}],"importedBy":[{"uid":"5277-1062"},{"uid":"5277-1080"}]},"5277-1074":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-686"}],"importedBy":[{"uid":"5277-804"},{"uid":"5277-788"}]},"5277-1075":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-794"}],"importedBy":[{"uid":"5277-804"}]},"5277-1076":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-802"}],"importedBy":[{"uid":"5277-804"}]},"5277-1077":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-790"}],"importedBy":[{"uid":"5277-804"},{"uid":"5277-794"},{"uid":"5277-802"}]},"5277-1078":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-800"}],"importedBy":[{"uid":"5277-804"},{"uid":"5277-802"}]},"5277-1079":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-788"}],"importedBy":[{"uid":"5277-804"},{"uid":"5277-794"},{"uid":"5277-790"}]},"5277-1080":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v35.js","moduleParts":{},"imported":[{"uid":"5277-544"},{"uid":"5277-1073"}],"importedBy":[{"uid":"5277-1069"},{"uid":"5277-1070"}]},"5277-1081":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/md5.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-1069"}]},"5277-1082":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/sha1.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-1070"}]},"5277-1083":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/index.js","moduleParts":{},"imported":[{"uid":"5277-586"},{"uid":"5277-566"},{"uid":"5277-582"},{"uid":"5277-562"},{"uid":"5277-584"},{"uid":"5277-576"}],"importedBy":[{"uid":"5277-588"},{"uid":"5277-602"}]},"5277-1084":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-628"}],"importedBy":[{"uid":"5277-642"},{"uid":"5277-636"},{"uid":"5277-640"}]},"5277-1085":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-636"}],"importedBy":[{"uid":"5277-642"},{"uid":"5277-640"}]},"5277-1086":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-640"}],"importedBy":[{"uid":"5277-642"}]},"5277-1087":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-634"}],"importedBy":[{"uid":"5277-642"},{"uid":"5277-636"},{"uid":"5277-640"}]},"5277-1088":{"id":"/src/services/MetaMaskSDK/ProviderManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-862"}],"importedBy":[{"uid":"5277-866"},{"uid":"5277-992"}]},"5277-1089":{"id":"/src/services/RemoteConnection/index.ts","moduleParts":{},"imported":[{"uid":"5277-990"}],"importedBy":[{"uid":"5277-992"}]},"5277-1090":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-528"}],"importedBy":[{"uid":"5277-530"}]},"5277-1091":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-526"}],"importedBy":[{"uid":"5277-530"},{"uid":"5277-528"}]},"5277-1092":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/elliptic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-514"}],"importedBy":[{"uid":"5277-522"},{"uid":"5277-528"},{"uid":"5277-526"}]},"5277-1093":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-620"}],"importedBy":[{"uid":"5277-686"},{"uid":"5277-666"}]},"5277-1094":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-642"}],"importedBy":[{"uid":"5277-686"},{"uid":"5277-790"},{"uid":"5277-684"},{"uid":"5277-666"}]},"5277-1095":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-644"}],"importedBy":[{"uid":"5277-686"}]},"5277-1096":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-672"}],"importedBy":[{"uid":"5277-686"},{"uid":"5277-684"}]},"5277-1097":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-676"}],"importedBy":[{"uid":"5277-686"},{"uid":"5277-790"},{"uid":"5277-788"},{"uid":"5277-702"},{"uid":"5277-682"}]},"5277-1098":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-684"}],"importedBy":[{"uid":"5277-686"},{"uid":"5277-794"},{"uid":"5277-790"},{"uid":"5277-788"},{"uid":"5277-702"}]},"5277-1099":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-692"}],"importedBy":[{"uid":"5277-794"}]},"5277-1100":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-792"}],"importedBy":[{"uid":"5277-794"}]},"5277-1101":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-702"}],"importedBy":[{"uid":"5277-790"}]},"5277-1102":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-762"}],"importedBy":[{"uid":"5277-788"}]},"5277-1103":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-764"}],"importedBy":[{"uid":"5277-788"}]},"5277-1104":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-780"}],"importedBy":[{"uid":"5277-788"}]},"5277-1105":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-786"}],"importedBy":[{"uid":"5277-788"}]},"5277-1106":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/index.js","moduleParts":{},"imported":[{"uid":"5277-1116"},{"uid":"5277-1117"},{"uid":"5277-1118"},{"uid":"5277-1119"},{"uid":"5277-1120"},{"uid":"5277-1121"},{"uid":"5277-1122"},{"uid":"5277-1123"},{"uid":"5277-1032"},{"uid":"5277-1030"},{"uid":"5277-1124"},{"uid":"5277-1034"}],"importedBy":[{"uid":"5277-1050"}]},"5277-1107":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randombytes/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-30"}],"importedBy":[{"uid":"5277-506"},{"uid":"5277-264"},{"uid":"5277-268"},{"uid":"5277-504"},{"uid":"5277-316"},{"uid":"5277-494"}]},"5277-1108":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-132"}],"importedBy":[{"uid":"5277-506"},{"uid":"5277-474"},{"uid":"5277-494"},{"uid":"5277-496"},{"uid":"5277-484"}]},"5277-1109":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-138"}],"importedBy":[{"uid":"5277-506"},{"uid":"5277-470"}]},"5277-1110":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/algos.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-142"}],"importedBy":[{"uid":"5277-506"}]},"5277-1111":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-156"}],"importedBy":[{"uid":"5277-506"},{"uid":"5277-466"}]},"5277-1112":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-cipher/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-246"}],"importedBy":[{"uid":"5277-506"}]},"5277-1113":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-498"}],"importedBy":[{"uid":"5277-506"}]},"5277-1114":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randomfill/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-504"}],"importedBy":[{"uid":"5277-506"}]},"5277-1115":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-626"}],"importedBy":[{"uid":"5277-628"}]},"5277-1116":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Trans.js","moduleParts":{},"imported":[{"uid":"5277-1026"},{"uid":"5277-1117"},{"uid":"5277-1034"}],"importedBy":[{"uid":"5277-1106"}]},"5277-1117":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/TransWithoutContext.js","moduleParts":{},"imported":[{"uid":"5277-1150"},{"uid":"5277-1026"},{"uid":"5277-1151"},{"uid":"5277-1152"},{"uid":"5277-1030"},{"uid":"5277-1124"}],"importedBy":[{"uid":"5277-1106"},{"uid":"5277-1116"}]},"5277-1118":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useTranslation.js","moduleParts":{},"imported":[{"uid":"5277-1026"},{"uid":"5277-1034"},{"uid":"5277-1152"}],"importedBy":[{"uid":"5277-1106"},{"uid":"5277-1119"},{"uid":"5277-1120"}]},"5277-1119":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withTranslation.js","moduleParts":{},"imported":[{"uid":"5277-1026"},{"uid":"5277-1118"},{"uid":"5277-1152"}],"importedBy":[{"uid":"5277-1106"}]},"5277-1120":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Translation.js","moduleParts":{},"imported":[{"uid":"5277-1118"}],"importedBy":[{"uid":"5277-1106"}]},"5277-1121":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/I18nextProvider.js","moduleParts":{},"imported":[{"uid":"5277-1026"},{"uid":"5277-1034"}],"importedBy":[{"uid":"5277-1106"}]},"5277-1122":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withSSR.js","moduleParts":{},"imported":[{"uid":"5277-1026"},{"uid":"5277-1123"},{"uid":"5277-1034"},{"uid":"5277-1152"}],"importedBy":[{"uid":"5277-1106"}]},"5277-1123":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useSSR.js","moduleParts":{},"imported":[{"uid":"5277-1026"},{"uid":"5277-1034"}],"importedBy":[{"uid":"5277-1106"},{"uid":"5277-1122"}]},"5277-1124":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/i18nInstance.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-1106"},{"uid":"5277-1117"},{"uid":"5277-1032"},{"uid":"5277-1034"}]},"5277-1125":{"id":"/src/services/RemoteConnection/ConnectionInitializer/index.ts","moduleParts":{},"imported":[{"uid":"5277-970"}],"importedBy":[{"uid":"5277-990"}]},"5277-1126":{"id":"/src/services/RemoteConnection/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-972"},{"uid":"5277-976"},{"uid":"5277-1153"},{"uid":"5277-984"}],"importedBy":[{"uid":"5277-990"}]},"5277-1127":{"id":"/src/services/RemoteConnection/EventListeners/index.ts","moduleParts":{},"imported":[{"uid":"5277-986"}],"importedBy":[{"uid":"5277-990"}]},"5277-1128":{"id":"/src/services/RemoteConnection/ModalManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-982"},{"uid":"5277-988"},{"uid":"5277-974"}],"importedBy":[{"uid":"5277-990"}]},"5277-1129":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-508"}],"importedBy":[{"uid":"5277-528"},{"uid":"5277-526"}]},"5277-1130":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/primes.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-266"}],"importedBy":[{"uid":"5277-270"}]},"5277-1131":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safe-buffer/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-28"}],"importedBy":[{"uid":"5277-474"},{"uid":"5277-30"},{"uid":"5277-138"},{"uid":"5277-470"},{"uid":"5277-472"},{"uid":"5277-504"},{"uid":"5277-88"},{"uid":"5277-130"},{"uid":"5277-134"},{"uid":"5277-154"},{"uid":"5277-152"},{"uid":"5277-180"},{"uid":"5277-232"},{"uid":"5277-466"},{"uid":"5277-494"},{"uid":"5277-496"},{"uid":"5277-292"},{"uid":"5277-86"},{"uid":"5277-96"},{"uid":"5277-98"},{"uid":"5277-102"},{"uid":"5277-100"},{"uid":"5277-106"},{"uid":"5277-104"},{"uid":"5277-150"},{"uid":"5277-234"},{"uid":"5277-238"},{"uid":"5277-198"},{"uid":"5277-202"},{"uid":"5277-206"},{"uid":"5277-216"},{"uid":"5277-464"},{"uid":"5277-484"},{"uid":"5277-492"},{"uid":"5277-94"},{"uid":"5277-228"},{"uid":"5277-230"},{"uid":"5277-224"},{"uid":"5277-68"},{"uid":"5277-226"}]},"5277-1132":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/readable-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-308"}],"importedBy":[{"uid":"5277-474"}]},"5277-1133":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-34"}],"importedBy":[{"uid":"5277-474"},{"uid":"5277-132"},{"uid":"5277-138"},{"uid":"5277-88"},{"uid":"5277-90"},{"uid":"5277-130"},{"uid":"5277-134"},{"uid":"5277-180"},{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-288"},{"uid":"5277-302"},{"uid":"5277-304"},{"uid":"5277-86"},{"uid":"5277-96"},{"uid":"5277-98"},{"uid":"5277-102"},{"uid":"5277-100"},{"uid":"5277-106"},{"uid":"5277-104"},{"uid":"5277-234"},{"uid":"5277-238"},{"uid":"5277-338"},{"uid":"5277-340"},{"uid":"5277-342"},{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-734"},{"uid":"5277-742"},{"uid":"5277-744"},{"uid":"5277-170"},{"uid":"5277-174"},{"uid":"5277-176"},{"uid":"5277-228"},{"uid":"5277-230"},{"uid":"5277-352"},{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-64"},{"uid":"5277-78"},{"uid":"5277-80"},{"uid":"5277-446"},{"uid":"5277-420"},{"uid":"5277-424"},{"uid":"5277-440"},{"uid":"5277-442"},{"uid":"5277-432"},{"uid":"5277-434"}]},"5277-1134":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/algorithms.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-140"}],"importedBy":[{"uid":"5277-474"},{"uid":"5277-142"}]},"5277-1135":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-478"}],"importedBy":[{"uid":"5277-480"}]},"5277-1136":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-510"}],"importedBy":[{"uid":"5277-514"}]},"5277-1137":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/elliptic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-512"}],"importedBy":[{"uid":"5277-514"}]},"5277-1138":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-654"}],"importedBy":[{"uid":"5277-672"}]},"5277-1139":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-658"}],"importedBy":[{"uid":"5277-672"}]},"5277-1140":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-662"}],"importedBy":[{"uid":"5277-672"}]},"5277-1141":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-652"}],"importedBy":[{"uid":"5277-672"},{"uid":"5277-654"}]},"5277-1142":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-666"}],"importedBy":[{"uid":"5277-672"},{"uid":"5277-670"}]},"5277-1143":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-670"}],"importedBy":[{"uid":"5277-672"}]},"5277-1144":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-682"}],"importedBy":[{"uid":"5277-684"}]},"5277-1145":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-760"}],"importedBy":[{"uid":"5277-762"}]},"5277-1146":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-770"}],"importedBy":[{"uid":"5277-780"}]},"5277-1147":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-778"}],"importedBy":[{"uid":"5277-780"}]},"5277-1148":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-752"}],"importedBy":[{"uid":"5277-786"},{"uid":"5277-760"},{"uid":"5277-754"}]},"5277-1149":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-754"}],"importedBy":[{"uid":"5277-786"},{"uid":"5277-760"}]},"5277-1150":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/node_modules/@babel/runtime/helpers/esm/extends.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-1117"}]},"5277-1151":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/html-parse-stringify/dist/html-parse-stringify.module.js","moduleParts":{},"imported":[{"uid":"5277-1179"}],"importedBy":[{"uid":"5277-1117"}]},"5277-1152":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/utils.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-1117"},{"uid":"5277-1118"},{"uid":"5277-1119"},{"uid":"5277-1122"}]},"5277-1153":{"id":"/src/services/RemoteConnection/ConnectionManager/handleDisconnect.ts","moduleParts":{},"imported":[{"uid":"5277-612"},{"uid":"5277-874"}],"importedBy":[{"uid":"5277-1126"}]},"5277-1154":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/md5.js/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-88"}],"importedBy":[{"uid":"5277-132"},{"uid":"5277-136"},{"uid":"5277-232"}]},"5277-1155":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/ripemd160/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-90"}],"importedBy":[{"uid":"5277-132"},{"uid":"5277-138"},{"uid":"5277-152"}]},"5277-1156":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-108"}],"importedBy":[{"uid":"5277-132"},{"uid":"5277-138"},{"uid":"5277-152"}]},"5277-1157":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cipher-base/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-130"}],"importedBy":[{"uid":"5277-132"},{"uid":"5277-138"},{"uid":"5277-134"},{"uid":"5277-180"},{"uid":"5277-234"},{"uid":"5277-238"},{"uid":"5277-228"},{"uid":"5277-230"}]},"5277-1158":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/legacy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-134"}],"importedBy":[{"uid":"5277-138"}]},"5277-1159":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/md5.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-136"}],"importedBy":[{"uid":"5277-138"},{"uid":"5277-152"}]},"5277-1160":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/async.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-154"}],"importedBy":[{"uid":"5277-156"}]},"5277-1161":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/sync-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-152"}],"importedBy":[{"uid":"5277-156"},{"uid":"5277-154"}]},"5277-1162":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-180"}],"importedBy":[{"uid":"5277-246"}]},"5277-1163":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-240"}],"importedBy":[{"uid":"5277-246"},{"uid":"5277-466"},{"uid":"5277-464"}]},"5277-1164":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-220"}],"importedBy":[{"uid":"5277-246"},{"uid":"5277-234"},{"uid":"5277-238"}]},"5277-1165":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/modes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-244"}],"importedBy":[{"uid":"5277-246"}]},"5277-1166":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/evp_bytestokey/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-232"}],"importedBy":[{"uid":"5277-246"},{"uid":"5277-234"},{"uid":"5277-238"},{"uid":"5277-464"}]},"5277-1167":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-252"}],"importedBy":[{"uid":"5277-264"},{"uid":"5277-268"}]},"5277-1168":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-rsa/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-316"}],"importedBy":[{"uid":"5277-470"},{"uid":"5277-494"},{"uid":"5277-496"}]},"5277-1169":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-314"}],"importedBy":[{"uid":"5277-470"},{"uid":"5277-472"},{"uid":"5277-316"}]},"5277-1170":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-466"}],"importedBy":[{"uid":"5277-470"},{"uid":"5277-472"},{"uid":"5277-494"},{"uid":"5277-496"}]},"5277-1171":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/curves.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-468"}],"importedBy":[{"uid":"5277-470"},{"uid":"5277-472"}]},"5277-1172":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-320"}],"importedBy":[{"uid":"5277-402"}]},"5277-1173":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-332"}],"importedBy":[{"uid":"5277-402"},{"uid":"5277-394"},{"uid":"5277-386"},{"uid":"5277-400"},{"uid":"5277-390"},{"uid":"5277-392"},{"uid":"5277-336"},{"uid":"5277-338"},{"uid":"5277-340"},{"uid":"5277-342"},{"uid":"5277-396"},{"uid":"5277-398"}]},"5277-1174":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-344"}],"importedBy":[{"uid":"5277-402"},{"uid":"5277-386"}]},"5277-1175":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-386"}],"importedBy":[{"uid":"5277-402"},{"uid":"5277-394"},{"uid":"5277-400"}]},"5277-1176":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-400"}],"importedBy":[{"uid":"5277-402"}]},"5277-1177":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/publicEncrypt.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-494"}],"importedBy":[{"uid":"5277-498"}]},"5277-1178":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/privateDecrypt.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-496"}],"importedBy":[{"uid":"5277-498"}]},"5277-1179":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/void-elements/index.js","moduleParts":{},"imported":[{"uid":"5277-10"}],"importedBy":[{"uid":"5277-1151"}]},"5277-1180":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-256"}],"importedBy":[{"uid":"5277-262"}]},"5277-1181":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_transform.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-302"}],"importedBy":[{"uid":"5277-308"},{"uid":"5277-304"}]},"5277-1182":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_passthrough.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-304"}],"importedBy":[{"uid":"5277-308"}]},"5277-1183":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/end-of-stream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-294"}],"importedBy":[{"uid":"5277-308"},{"uid":"5277-296"},{"uid":"5277-306"}]},"5277-1184":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/pipeline.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-306"}],"importedBy":[{"uid":"5277-308"}]},"5277-1185":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-326"}],"importedBy":[{"uid":"5277-394"},{"uid":"5277-332"},{"uid":"5277-390"},{"uid":"5277-392"},{"uid":"5277-336"},{"uid":"5277-338"},{"uid":"5277-340"},{"uid":"5277-342"},{"uid":"5277-398"}]},"5277-1186":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hmac-drbg/lib/hmac-drbg.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-388"}],"importedBy":[{"uid":"5277-394"}]},"5277-1187":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/key.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-390"}],"importedBy":[{"uid":"5277-394"}]},"5277-1188":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/signature.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-392"}],"importedBy":[{"uid":"5277-394"}]},"5277-1189":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-746"}],"importedBy":[{"uid":"5277-760"},{"uid":"5277-770"},{"uid":"5277-778"},{"uid":"5277-758"}]},"5277-1190":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-758"}],"importedBy":[{"uid":"5277-760"}]},"5277-1191":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-776"}],"importedBy":[{"uid":"5277-778"}]},"5277-1192":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-750"}],"importedBy":[{"uid":"5277-752"}]},"5277-1193":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-86"}],"importedBy":[{"uid":"5277-88"},{"uid":"5277-90"}]},"5277-1194":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-96"}],"importedBy":[{"uid":"5277-108"}]},"5277-1195":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-98"}],"importedBy":[{"uid":"5277-108"}]},"5277-1196":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha224.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-102"}],"importedBy":[{"uid":"5277-108"}]},"5277-1197":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha256.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-100"}],"importedBy":[{"uid":"5277-108"},{"uid":"5277-102"}]},"5277-1198":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha384.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-106"}],"importedBy":[{"uid":"5277-108"}]},"5277-1199":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha512.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-104"}],"importedBy":[{"uid":"5277-108"},{"uid":"5277-106"}]},"5277-1200":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/precondition.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-146"}],"importedBy":[{"uid":"5277-154"},{"uid":"5277-152"}]},"5277-1201":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/default-encoding.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-148"}],"importedBy":[{"uid":"5277-154"},{"uid":"5277-152"}]},"5277-1202":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/to-buffer.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-150"}],"importedBy":[{"uid":"5277-154"},{"uid":"5277-152"}]},"5277-1203":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-178"}],"importedBy":[{"uid":"5277-180"}]},"5277-1204":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/encrypter.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-234"}],"importedBy":[{"uid":"5277-240"}]},"5277-1205":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/decrypter.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-238"}],"importedBy":[{"uid":"5277-240"}]},"5277-1206":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/list.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-218"}],"importedBy":[{"uid":"5277-240"},{"uid":"5277-220"}]},"5277-1207":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ecb.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-188"}],"importedBy":[{"uid":"5277-220"}]},"5277-1208":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cbc.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-194"}],"importedBy":[{"uid":"5277-220"}]},"5277-1209":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-198"}],"importedBy":[{"uid":"5277-220"}]},"5277-1210":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb8.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-202"}],"importedBy":[{"uid":"5277-220"}]},"5277-1211":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-206"}],"importedBy":[{"uid":"5277-220"}]},"5277-1212":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ofb.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-210"}],"importedBy":[{"uid":"5277-220"}]},"5277-1213":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ctr.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-216"}],"importedBy":[{"uid":"5277-220"}]},"5277-1214":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/stream-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-274"}],"importedBy":[{"uid":"5277-300"},{"uid":"5277-286"}]},"5277-1215":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/destroy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-278"}],"importedBy":[{"uid":"5277-300"},{"uid":"5277-286"}]},"5277-1216":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/state.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-284"}],"importedBy":[{"uid":"5277-300"},{"uid":"5277-286"}]},"5277-1217":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/errors-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-282"}],"importedBy":[{"uid":"5277-300"},{"uid":"5277-286"},{"uid":"5277-302"},{"uid":"5277-294"},{"uid":"5277-306"},{"uid":"5277-284"}]},"5277-1218":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/util-deprecate/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-60"}],"importedBy":[{"uid":"5277-286"},{"uid":"5277-732"},{"uid":"5277-62"}]},"5277-1219":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/asn1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-460"}],"importedBy":[{"uid":"5277-466"}]},"5277-1220":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/aesid.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-462"}],"importedBy":[{"uid":"5277-466"}]},"5277-1221":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/fixProc.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-464"}],"importedBy":[{"uid":"5277-466"}]},"5277-1222":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-assert/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-166"}],"importedBy":[{"uid":"5277-332"},{"uid":"5277-388"},{"uid":"5277-168"},{"uid":"5277-170"},{"uid":"5277-174"},{"uid":"5277-176"},{"uid":"5277-352"},{"uid":"5277-356"},{"uid":"5277-380"},{"uid":"5277-366"},{"uid":"5277-370"},{"uid":"5277-426"}]},"5277-1223":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-330"}],"importedBy":[{"uid":"5277-332"},{"uid":"5277-388"}]},"5277-1224":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/base.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-336"}],"importedBy":[{"uid":"5277-344"},{"uid":"5277-338"},{"uid":"5277-340"},{"uid":"5277-342"}]},"5277-1225":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/short.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-338"}],"importedBy":[{"uid":"5277-344"}]},"5277-1226":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/mont.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-340"}],"importedBy":[{"uid":"5277-344"}]},"5277-1227":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/edwards.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-342"}],"importedBy":[{"uid":"5277-344"}]},"5277-1228":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-382"}],"importedBy":[{"uid":"5277-386"},{"uid":"5277-400"},{"uid":"5277-388"}]},"5277-1229":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/key.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-396"}],"importedBy":[{"uid":"5277-400"}]},"5277-1230":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/signature.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-398"}],"importedBy":[{"uid":"5277-400"}]},"5277-1231":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/mgf.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-484"}],"importedBy":[{"uid":"5277-494"},{"uid":"5277-496"}]},"5277-1232":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/xor.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-486"}],"importedBy":[{"uid":"5277-494"},{"uid":"5277-496"}]},"5277-1233":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-490"}],"importedBy":[{"uid":"5277-494"},{"uid":"5277-496"},{"uid":"5277-492"}]},"5277-1234":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/withPublic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-492"}],"importedBy":[{"uid":"5277-494"},{"uid":"5277-496"}]},"5277-1235":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_transform.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-742"}],"importedBy":[{"uid":"5277-746"},{"uid":"5277-744"}]},"5277-1236":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_passthrough.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-744"}],"importedBy":[{"uid":"5277-746"}]},"5277-1237":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/readable-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-84"}],"importedBy":[{"uid":"5277-86"}]},"5277-1238":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/hash.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-94"}],"importedBy":[{"uid":"5277-96"},{"uid":"5277-98"},{"uid":"5277-102"},{"uid":"5277-100"},{"uid":"5277-106"},{"uid":"5277-104"}]},"5277-1239":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-164"}],"importedBy":[{"uid":"5277-178"},{"uid":"5277-170"}]},"5277-1240":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cipher.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-168"}],"importedBy":[{"uid":"5277-178"},{"uid":"5277-170"},{"uid":"5277-176"}]},"5277-1241":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/des.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-170"}],"importedBy":[{"uid":"5277-178"},{"uid":"5277-176"}]},"5277-1242":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cbc.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-174"}],"importedBy":[{"uid":"5277-178"}]},"5277-1243":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/ede.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-176"}],"importedBy":[{"uid":"5277-178"}]},"5277-1244":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/authCipher.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-228"}],"importedBy":[{"uid":"5277-234"},{"uid":"5277-238"}]},"5277-1245":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/streamCipher.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-230"}],"importedBy":[{"uid":"5277-234"},{"uid":"5277-238"}]},"5277-1246":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/aes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-224"}],"importedBy":[{"uid":"5277-234"},{"uid":"5277-238"},{"uid":"5277-228"},{"uid":"5277-230"}]},"5277-1247":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-xor/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-192"}],"importedBy":[{"uid":"5277-194"},{"uid":"5277-198"},{"uid":"5277-210"},{"uid":"5277-216"},{"uid":"5277-228"}]},"5277-1248":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/incr32.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-214"}],"importedBy":[{"uid":"5277-216"},{"uid":"5277-228"}]},"5277-1249":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-456"}],"importedBy":[{"uid":"5277-460"},{"uid":"5277-458"}]},"5277-1250":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/certificate.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-458"}],"importedBy":[{"uid":"5277-460"}]},"5277-1251":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-352"}],"importedBy":[{"uid":"5277-382"},{"uid":"5277-356"},{"uid":"5277-378"},{"uid":"5277-380"},{"uid":"5277-364"},{"uid":"5277-368"},{"uid":"5277-366"},{"uid":"5277-372"},{"uid":"5277-370"},{"uid":"5277-362"}]},"5277-1252":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-356"}],"importedBy":[{"uid":"5277-382"},{"uid":"5277-378"},{"uid":"5277-364"},{"uid":"5277-366"},{"uid":"5277-370"}]},"5277-1253":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-374"}],"importedBy":[{"uid":"5277-382"}]},"5277-1254":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-378"}],"importedBy":[{"uid":"5277-382"}]},"5277-1255":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/hmac.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-380"}],"importedBy":[{"uid":"5277-382"}]},"5277-1256":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-712"}],"importedBy":[{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-734"},{"uid":"5277-730"}]},"5277-1257":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/isarray/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-714"}],"importedBy":[{"uid":"5277-740"}]},"5277-1258":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/stream-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-716"}],"importedBy":[{"uid":"5277-740"},{"uid":"5277-732"}]},"5277-1259":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-720"}],"importedBy":[{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-728"},{"uid":"5277-738"}]},"5277-1260":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-724"}],"importedBy":[{"uid":"5277-740"},{"uid":"5277-732"},{"uid":"5277-734"},{"uid":"5277-742"},{"uid":"5277-744"}]},"5277-1261":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/destroy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-730"}],"importedBy":[{"uid":"5277-740"},{"uid":"5277-732"}]},"5277-1262":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_transform.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-78"}],"importedBy":[{"uid":"5277-84"},{"uid":"5277-80"}]},"5277-1263":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_passthrough.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-80"}],"importedBy":[{"uid":"5277-84"}]},"5277-1264":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/end-of-stream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-70"}],"importedBy":[{"uid":"5277-84"},{"uid":"5277-72"},{"uid":"5277-82"}]},"5277-1265":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/pipeline.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-82"}],"importedBy":[{"uid":"5277-84"}]},"5277-1266":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/ghash.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-226"}],"importedBy":[{"uid":"5277-228"}]},"5277-1267":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-410"}],"importedBy":[{"uid":"5277-456"},{"uid":"5277-440"}]},"5277-1268":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/api.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-446"}],"importedBy":[{"uid":"5277-456"}]},"5277-1269":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-450"}],"importedBy":[{"uid":"5277-456"}]},"5277-1270":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-454"}],"importedBy":[{"uid":"5277-456"}]},"5277-1271":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-444"}],"importedBy":[{"uid":"5277-456"},{"uid":"5277-446"}]},"5277-1272":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-436"}],"importedBy":[{"uid":"5277-456"},{"uid":"5277-446"}]},"5277-1273":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-364"}],"importedBy":[{"uid":"5277-374"}]},"5277-1274":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/224.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-368"}],"importedBy":[{"uid":"5277-374"}]},"5277-1275":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/256.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-366"}],"importedBy":[{"uid":"5277-374"},{"uid":"5277-368"}]},"5277-1276":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/384.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-372"}],"importedBy":[{"uid":"5277-374"}]},"5277-1277":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/512.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-370"}],"importedBy":[{"uid":"5277-374"},{"uid":"5277-372"}]},"5277-1278":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/stream-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-42"}],"importedBy":[{"uid":"5277-76"},{"uid":"5277-62"}]},"5277-1279":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/destroy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-52"}],"importedBy":[{"uid":"5277-76"},{"uid":"5277-62"}]},"5277-1280":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/state.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-58"}],"importedBy":[{"uid":"5277-76"},{"uid":"5277-62"}]},"5277-1281":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/errors-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-56"}],"importedBy":[{"uid":"5277-76"},{"uid":"5277-62"},{"uid":"5277-78"},{"uid":"5277-70"},{"uid":"5277-82"},{"uid":"5277-58"}]},"5277-1282":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/reporter.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-420"}],"importedBy":[{"uid":"5277-450"},{"uid":"5277-424"},{"uid":"5277-426"}]},"5277-1283":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/buffer.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-424"}],"importedBy":[{"uid":"5277-450"},{"uid":"5277-426"},{"uid":"5277-440"}]},"5277-1284":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/node.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-426"}],"importedBy":[{"uid":"5277-450"},{"uid":"5277-440"},{"uid":"5277-432"}]},"5277-1285":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/der.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-430"}],"importedBy":[{"uid":"5277-454"},{"uid":"5277-440"},{"uid":"5277-432"}]},"5277-1286":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/der.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-440"}],"importedBy":[{"uid":"5277-444"},{"uid":"5277-442"}]},"5277-1287":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/pem.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-442"}],"importedBy":[{"uid":"5277-444"}]},"5277-1288":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/der.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-432"}],"importedBy":[{"uid":"5277-436"},{"uid":"5277-434"}]},"5277-1289":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/pem.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-434"}],"importedBy":[{"uid":"5277-436"}]},"5277-1290":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-362"}],"importedBy":[{"uid":"5277-364"},{"uid":"5277-366"}]},"5277-1291":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safer-buffer/safer.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-416"}],"importedBy":[{"uid":"5277-424"},{"uid":"5277-442"},{"uid":"5277-432"}]}},"env":{"rollup":"3.29.4"},"options":{"gzip":false,"brotli":false,"sourcemap":false}};
+
+    const run = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      const chartNode = document.querySelector("main");
+      drawChart.default(chartNode, data, width, height);
+    };
+
+    window.addEventListener('resize', run);
+
+    document.addEventListener('DOMContentLoaded', run);
+    /*-->*/
+  </script>
+</body>
+</html>
+

--- a/packages/sdk/bundle_stats/browser-umd-iife-stats-0.11.0.html
+++ b/packages/sdk/bundle_stats/browser-umd-iife-stats-0.11.0.html
@@ -1,0 +1,4838 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <title>Rollup Visualizer</title>
+  <style>
+:root {
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --background-color: #2b2d42;
+  --text-color: #edf2f4;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+html {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: var(--font-family);
+}
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+svg {
+  vertical-align: middle;
+  width: 100%;
+  height: 100%;
+  max-height: 100vh;
+}
+
+main {
+  flex-grow: 1;
+  height: 100vh;
+  padding: 20px;
+}
+
+.tooltip {
+  position: absolute;
+  z-index: 1070;
+  border: 2px solid;
+  border-radius: 5px;
+  padding: 5px;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.tooltip-hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  font-size: 0.7rem;
+  align-items: center;
+  margin: 0 50px;
+  height: 20px;
+}
+
+.size-selectors {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.size-selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+}
+.size-selector input {
+  margin: 0 0.3rem 0 0;
+}
+
+.filters {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.module-filters {
+  display: flex;
+  flex-grow: 1;
+}
+
+.module-filter {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+.module-filter input {
+  flex: 1;
+  height: 1rem;
+  padding: 0.01rem;
+  font-size: 0.7rem;
+  margin-left: 0.3rem;
+}
+.module-filter + .module-filter {
+  margin-left: 0.5rem;
+}
+  </style>
+</head>
+<body>
+  <main></main>
+  <script>
+  /*<!--*/
+var drawChart = (function (exports) {
+  'use strict';
+
+  var n,l$1,u$1,t$1,o$2,r$1,f$1,e$1,c$1={},s$1=[],a$1=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,v$1=Array.isArray;function h$1(n,l){for(var u in l)n[u]=l[u];return n}function p$1(n){var l=n.parentNode;l&&l.removeChild(n);}function y$1(l,u,i){var t,o,r,f={};for(r in u)"key"==r?t=u[r]:"ref"==r?o=u[r]:f[r]=u[r];if(arguments.length>2&&(f.children=arguments.length>3?n.call(arguments,2):i),"function"==typeof l&&null!=l.defaultProps)for(r in l.defaultProps)void 0===f[r]&&(f[r]=l.defaultProps[r]);return d$1(l,f,t,o,null)}function d$1(n,i,t,o,r){var f={type:n,props:i,key:t,ref:o,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:null==r?++u$1:r};return null==r&&null!=l$1.vnode&&l$1.vnode(f),f}function k$1(n){return n.children}function b$1(n,l){this.props=n,this.context=l;}function g$1(n,l){if(null==l)return n.__?g$1(n.__,n.__.__k.indexOf(n)+1):null;for(var u;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e)return u.__e;return "function"==typeof n.type?g$1(n):null}function m$1(n){var l,u;if(null!=(n=n.__)&&null!=n.__c){for(n.__e=n.__c.base=null,l=0;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e){n.__e=n.__c.base=u.__e;break}return m$1(n)}}function w$1(n){(!n.__d&&(n.__d=!0)&&t$1.push(n)&&!x.__r++||o$2!==l$1.debounceRendering)&&((o$2=l$1.debounceRendering)||r$1)(x);}function x(){var n,l,u,i,o,r,e,c;for(t$1.sort(f$1);n=t$1.shift();)n.__d&&(l=t$1.length,i=void 0,o=void 0,e=(r=(u=n).__v).__e,(c=u.__P)&&(i=[],(o=h$1({},r)).__v=r.__v+1,L(c,r,o,u.__n,void 0!==c.ownerSVGElement,null!=r.__h?[e]:null,i,null==e?g$1(r):e,r.__h),M(i,r),r.__e!=e&&m$1(r)),t$1.length>l&&t$1.sort(f$1));x.__r=0;}function P(n,l,u,i,t,o,r,f,e,a){var h,p,y,_,b,m,w,x=i&&i.__k||s$1,P=x.length;for(u.__k=[],h=0;h<l.length;h++)if(null!=(_=u.__k[h]=null==(_=l[h])||"boolean"==typeof _||"function"==typeof _?null:"string"==typeof _||"number"==typeof _||"bigint"==typeof _?d$1(null,_,null,null,_):v$1(_)?d$1(k$1,{children:_},null,null,null):_.__b>0?d$1(_.type,_.props,_.key,_.ref?_.ref:null,_.__v):_)){if(_.__=u,_.__b=u.__b+1,null===(y=x[h])||y&&_.key==y.key&&_.type===y.type)x[h]=void 0;else for(p=0;p<P;p++){if((y=x[p])&&_.key==y.key&&_.type===y.type){x[p]=void 0;break}y=null;}L(n,_,y=y||c$1,t,o,r,f,e,a),b=_.__e,(p=_.ref)&&y.ref!=p&&(w||(w=[]),y.ref&&w.push(y.ref,null,_),w.push(p,_.__c||b,_)),null!=b?(null==m&&(m=b),"function"==typeof _.type&&_.__k===y.__k?_.__d=e=C(_,e,n):e=$(n,_,y,x,b,e),"function"==typeof u.type&&(u.__d=e)):e&&y.__e==e&&e.parentNode!=n&&(e=g$1(y));}for(u.__e=m,h=P;h--;)null!=x[h]&&("function"==typeof u.type&&null!=x[h].__e&&x[h].__e==u.__d&&(u.__d=A(i).nextSibling),q$1(x[h],x[h]));if(w)for(h=0;h<w.length;h++)O(w[h],w[++h],w[++h]);}function C(n,l,u){for(var i,t=n.__k,o=0;t&&o<t.length;o++)(i=t[o])&&(i.__=n,l="function"==typeof i.type?C(i,l,u):$(u,i,i,t,i.__e,l));return l}function $(n,l,u,i,t,o){var r,f,e;if(void 0!==l.__d)r=l.__d,l.__d=void 0;else if(null==u||t!=o||null==t.parentNode)n:if(null==o||o.parentNode!==n)n.appendChild(t),r=null;else {for(f=o,e=0;(f=f.nextSibling)&&e<i.length;e+=1)if(f==t)break n;n.insertBefore(t,o),r=o;}return void 0!==r?r:t.nextSibling}function A(n){var l,u,i;if(null==n.type||"string"==typeof n.type)return n.__e;if(n.__k)for(l=n.__k.length-1;l>=0;l--)if((u=n.__k[l])&&(i=A(u)))return i;return null}function H(n,l,u,i,t){var o;for(o in u)"children"===o||"key"===o||o in l||T$1(n,o,null,u[o],i);for(o in l)t&&"function"!=typeof l[o]||"children"===o||"key"===o||"value"===o||"checked"===o||u[o]===l[o]||T$1(n,o,l[o],u[o],i);}function I(n,l,u){"-"===l[0]?n.setProperty(l,null==u?"":u):n[l]=null==u?"":"number"!=typeof u||a$1.test(l)?u:u+"px";}function T$1(n,l,u,i,t){var o;n:if("style"===l)if("string"==typeof u)n.style.cssText=u;else {if("string"==typeof i&&(n.style.cssText=i=""),i)for(l in i)u&&l in u||I(n.style,l,"");if(u)for(l in u)i&&u[l]===i[l]||I(n.style,l,u[l]);}else if("o"===l[0]&&"n"===l[1])o=l!==(l=l.replace(/Capture$/,"")),l=l.toLowerCase()in n?l.toLowerCase().slice(2):l.slice(2),n.l||(n.l={}),n.l[l+o]=u,u?i||n.addEventListener(l,o?z$1:j$1,o):n.removeEventListener(l,o?z$1:j$1,o);else if("dangerouslySetInnerHTML"!==l){if(t)l=l.replace(/xlink(H|:h)/,"h").replace(/sName$/,"s");else if("width"!==l&&"height"!==l&&"href"!==l&&"list"!==l&&"form"!==l&&"tabIndex"!==l&&"download"!==l&&"rowSpan"!==l&&"colSpan"!==l&&l in n)try{n[l]=null==u?"":u;break n}catch(n){}"function"==typeof u||(null==u||!1===u&&"-"!==l[4]?n.removeAttribute(l):n.setAttribute(l,u));}}function j$1(n){return this.l[n.type+!1](l$1.event?l$1.event(n):n)}function z$1(n){return this.l[n.type+!0](l$1.event?l$1.event(n):n)}function L(n,u,i,t,o,r,f,e,c){var s,a,p,y,d,_,g,m,w,x,C,S,$,A,H,I=u.type;if(void 0!==u.constructor)return null;null!=i.__h&&(c=i.__h,e=u.__e=i.__e,u.__h=null,r=[e]),(s=l$1.__b)&&s(u);try{n:if("function"==typeof I){if(m=u.props,w=(s=I.contextType)&&t[s.__c],x=s?w?w.props.value:s.__:t,i.__c?g=(a=u.__c=i.__c).__=a.__E:("prototype"in I&&I.prototype.render?u.__c=a=new I(m,x):(u.__c=a=new b$1(m,x),a.constructor=I,a.render=B$1),w&&w.sub(a),a.props=m,a.state||(a.state={}),a.context=x,a.__n=t,p=a.__d=!0,a.__h=[],a._sb=[]),null==a.__s&&(a.__s=a.state),null!=I.getDerivedStateFromProps&&(a.__s==a.state&&(a.__s=h$1({},a.__s)),h$1(a.__s,I.getDerivedStateFromProps(m,a.__s))),y=a.props,d=a.state,a.__v=u,p)null==I.getDerivedStateFromProps&&null!=a.componentWillMount&&a.componentWillMount(),null!=a.componentDidMount&&a.__h.push(a.componentDidMount);else {if(null==I.getDerivedStateFromProps&&m!==y&&null!=a.componentWillReceiveProps&&a.componentWillReceiveProps(m,x),!a.__e&&null!=a.shouldComponentUpdate&&!1===a.shouldComponentUpdate(m,a.__s,x)||u.__v===i.__v){for(u.__v!==i.__v&&(a.props=m,a.state=a.__s,a.__d=!1),a.__e=!1,u.__e=i.__e,u.__k=i.__k,u.__k.forEach(function(n){n&&(n.__=u);}),C=0;C<a._sb.length;C++)a.__h.push(a._sb[C]);a._sb=[],a.__h.length&&f.push(a);break n}null!=a.componentWillUpdate&&a.componentWillUpdate(m,a.__s,x),null!=a.componentDidUpdate&&a.__h.push(function(){a.componentDidUpdate(y,d,_);});}if(a.context=x,a.props=m,a.__P=n,S=l$1.__r,$=0,"prototype"in I&&I.prototype.render){for(a.state=a.__s,a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),A=0;A<a._sb.length;A++)a.__h.push(a._sb[A]);a._sb=[];}else do{a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),a.state=a.__s;}while(a.__d&&++$<25);a.state=a.__s,null!=a.getChildContext&&(t=h$1(h$1({},t),a.getChildContext())),p||null==a.getSnapshotBeforeUpdate||(_=a.getSnapshotBeforeUpdate(y,d)),P(n,v$1(H=null!=s&&s.type===k$1&&null==s.key?s.props.children:s)?H:[H],u,i,t,o,r,f,e,c),a.base=u.__e,u.__h=null,a.__h.length&&f.push(a),g&&(a.__E=a.__=null),a.__e=!1;}else null==r&&u.__v===i.__v?(u.__k=i.__k,u.__e=i.__e):u.__e=N(i.__e,u,i,t,o,r,f,c);(s=l$1.diffed)&&s(u);}catch(n){u.__v=null,(c||null!=r)&&(u.__e=e,u.__h=!!c,r[r.indexOf(e)]=null),l$1.__e(n,u,i);}}function M(n,u){l$1.__c&&l$1.__c(u,n),n.some(function(u){try{n=u.__h,u.__h=[],n.some(function(n){n.call(u);});}catch(n){l$1.__e(n,u.__v);}});}function N(l,u,i,t,o,r,f,e){var s,a,h,y=i.props,d=u.props,_=u.type,k=0;if("svg"===_&&(o=!0),null!=r)for(;k<r.length;k++)if((s=r[k])&&"setAttribute"in s==!!_&&(_?s.localName===_:3===s.nodeType)){l=s,r[k]=null;break}if(null==l){if(null===_)return document.createTextNode(d);l=o?document.createElementNS("http://www.w3.org/2000/svg",_):document.createElement(_,d.is&&d),r=null,e=!1;}if(null===_)y===d||e&&l.data===d||(l.data=d);else {if(r=r&&n.call(l.childNodes),a=(y=i.props||c$1).dangerouslySetInnerHTML,h=d.dangerouslySetInnerHTML,!e){if(null!=r)for(y={},k=0;k<l.attributes.length;k++)y[l.attributes[k].name]=l.attributes[k].value;(h||a)&&(h&&(a&&h.__html==a.__html||h.__html===l.innerHTML)||(l.innerHTML=h&&h.__html||""));}if(H(l,d,y,o,e),h)u.__k=[];else if(P(l,v$1(k=u.props.children)?k:[k],u,i,t,o&&"foreignObject"!==_,r,f,r?r[0]:i.__k&&g$1(i,0),e),null!=r)for(k=r.length;k--;)null!=r[k]&&p$1(r[k]);e||("value"in d&&void 0!==(k=d.value)&&(k!==l.value||"progress"===_&&!k||"option"===_&&k!==y.value)&&T$1(l,"value",k,y.value,!1),"checked"in d&&void 0!==(k=d.checked)&&k!==l.checked&&T$1(l,"checked",k,y.checked,!1));}return l}function O(n,u,i){try{"function"==typeof n?n(u):n.current=u;}catch(n){l$1.__e(n,i);}}function q$1(n,u,i){var t,o;if(l$1.unmount&&l$1.unmount(n),(t=n.ref)&&(t.current&&t.current!==n.__e||O(t,null,u)),null!=(t=n.__c)){if(t.componentWillUnmount)try{t.componentWillUnmount();}catch(n){l$1.__e(n,u);}t.base=t.__P=null,n.__c=void 0;}if(t=n.__k)for(o=0;o<t.length;o++)t[o]&&q$1(t[o],u,i||"function"!=typeof n.type);i||null==n.__e||p$1(n.__e),n.__=n.__e=n.__d=void 0;}function B$1(n,l,u){return this.constructor(n,u)}function D(u,i,t){var o,r,f;l$1.__&&l$1.__(u,i),r=(o="function"==typeof t)?null:t&&t.__k||i.__k,f=[],L(i,u=(!o&&t||i).__k=y$1(k$1,null,[u]),r||c$1,c$1,void 0!==i.ownerSVGElement,!o&&t?[t]:r?null:i.firstChild?n.call(i.childNodes):null,f,!o&&t?t:r?r.__e:i.firstChild,o),M(f,u);}function G(n,l){var u={__c:l="__cC"+e$1++,__:n,Consumer:function(n,l){return n.children(l)},Provider:function(n){var u,i;return this.getChildContext||(u=[],(i={})[l]=this,this.getChildContext=function(){return i},this.shouldComponentUpdate=function(n){this.props.value!==n.value&&u.some(function(n){n.__e=!0,w$1(n);});},this.sub=function(n){u.push(n);var l=n.componentWillUnmount;n.componentWillUnmount=function(){u.splice(u.indexOf(n),1),l&&l.call(n);};}),n.children}};return u.Provider.__=u.Consumer.contextType=u}n=s$1.slice,l$1={__e:function(n,l,u,i){for(var t,o,r;l=l.__;)if((t=l.__c)&&!t.__)try{if((o=t.constructor)&&null!=o.getDerivedStateFromError&&(t.setState(o.getDerivedStateFromError(n)),r=t.__d),null!=t.componentDidCatch&&(t.componentDidCatch(n,i||{}),r=t.__d),r)return t.__E=t}catch(l){n=l;}throw n}},u$1=0,b$1.prototype.setState=function(n,l){var u;u=null!=this.__s&&this.__s!==this.state?this.__s:this.__s=h$1({},this.state),"function"==typeof n&&(n=n(h$1({},u),this.props)),n&&h$1(u,n),null!=n&&this.__v&&(l&&this._sb.push(l),w$1(this));},b$1.prototype.forceUpdate=function(n){this.__v&&(this.__e=!0,n&&this.__h.push(n),w$1(this));},b$1.prototype.render=k$1,t$1=[],r$1="function"==typeof Promise?Promise.prototype.then.bind(Promise.resolve()):setTimeout,f$1=function(n,l){return n.__v.__b-l.__v.__b},x.__r=0,e$1=0;
+
+  var _$1=0;function o$1(o,e,n,t,f,l){var s,u,a={};for(u in e)"ref"==u?s=e[u]:a[u]=e[u];var i={type:o,props:a,key:n,ref:s,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:--_$1,__source:f,__self:l};if("function"==typeof o&&(s=o.defaultProps))for(u in s)void 0===a[u]&&(a[u]=s[u]);return l$1.vnode&&l$1.vnode(i),i}
+
+  function count$1(node) {
+    var sum = 0,
+        children = node.children,
+        i = children && children.length;
+    if (!i) sum = 1;
+    else while (--i >= 0) sum += children[i].value;
+    node.value = sum;
+  }
+
+  function node_count() {
+    return this.eachAfter(count$1);
+  }
+
+  function node_each(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_eachBefore(callback, that) {
+    var node = this, nodes = [node], children, i, index = -1;
+    while (node = nodes.pop()) {
+      callback.call(that, node, ++index, this);
+      if (children = node.children) {
+        for (i = children.length - 1; i >= 0; --i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    return this;
+  }
+
+  function node_eachAfter(callback, that) {
+    var node = this, nodes = [node], next = [], children, i, n, index = -1;
+    while (node = nodes.pop()) {
+      next.push(node);
+      if (children = node.children) {
+        for (i = 0, n = children.length; i < n; ++i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    while (node = next.pop()) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_find(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      if (callback.call(that, node, ++index, this)) {
+        return node;
+      }
+    }
+  }
+
+  function node_sum(value) {
+    return this.eachAfter(function(node) {
+      var sum = +value(node.data) || 0,
+          children = node.children,
+          i = children && children.length;
+      while (--i >= 0) sum += children[i].value;
+      node.value = sum;
+    });
+  }
+
+  function node_sort(compare) {
+    return this.eachBefore(function(node) {
+      if (node.children) {
+        node.children.sort(compare);
+      }
+    });
+  }
+
+  function node_path(end) {
+    var start = this,
+        ancestor = leastCommonAncestor(start, end),
+        nodes = [start];
+    while (start !== ancestor) {
+      start = start.parent;
+      nodes.push(start);
+    }
+    var k = nodes.length;
+    while (end !== ancestor) {
+      nodes.splice(k, 0, end);
+      end = end.parent;
+    }
+    return nodes;
+  }
+
+  function leastCommonAncestor(a, b) {
+    if (a === b) return a;
+    var aNodes = a.ancestors(),
+        bNodes = b.ancestors(),
+        c = null;
+    a = aNodes.pop();
+    b = bNodes.pop();
+    while (a === b) {
+      c = a;
+      a = aNodes.pop();
+      b = bNodes.pop();
+    }
+    return c;
+  }
+
+  function node_ancestors() {
+    var node = this, nodes = [node];
+    while (node = node.parent) {
+      nodes.push(node);
+    }
+    return nodes;
+  }
+
+  function node_descendants() {
+    return Array.from(this);
+  }
+
+  function node_leaves() {
+    var leaves = [];
+    this.eachBefore(function(node) {
+      if (!node.children) {
+        leaves.push(node);
+      }
+    });
+    return leaves;
+  }
+
+  function node_links() {
+    var root = this, links = [];
+    root.each(function(node) {
+      if (node !== root) { // Don’t include the root’s parent, if any.
+        links.push({source: node.parent, target: node});
+      }
+    });
+    return links;
+  }
+
+  function* node_iterator() {
+    var node = this, current, next = [node], children, i, n;
+    do {
+      current = next.reverse(), next = [];
+      while (node = current.pop()) {
+        yield node;
+        if (children = node.children) {
+          for (i = 0, n = children.length; i < n; ++i) {
+            next.push(children[i]);
+          }
+        }
+      }
+    } while (next.length);
+  }
+
+  function hierarchy(data, children) {
+    if (data instanceof Map) {
+      data = [undefined, data];
+      if (children === undefined) children = mapChildren;
+    } else if (children === undefined) {
+      children = objectChildren;
+    }
+
+    var root = new Node$1(data),
+        node,
+        nodes = [root],
+        child,
+        childs,
+        i,
+        n;
+
+    while (node = nodes.pop()) {
+      if ((childs = children(node.data)) && (n = (childs = Array.from(childs)).length)) {
+        node.children = childs;
+        for (i = n - 1; i >= 0; --i) {
+          nodes.push(child = childs[i] = new Node$1(childs[i]));
+          child.parent = node;
+          child.depth = node.depth + 1;
+        }
+      }
+    }
+
+    return root.eachBefore(computeHeight);
+  }
+
+  function node_copy() {
+    return hierarchy(this).eachBefore(copyData);
+  }
+
+  function objectChildren(d) {
+    return d.children;
+  }
+
+  function mapChildren(d) {
+    return Array.isArray(d) ? d[1] : null;
+  }
+
+  function copyData(node) {
+    if (node.data.value !== undefined) node.value = node.data.value;
+    node.data = node.data.data;
+  }
+
+  function computeHeight(node) {
+    var height = 0;
+    do node.height = height;
+    while ((node = node.parent) && (node.height < ++height));
+  }
+
+  function Node$1(data) {
+    this.data = data;
+    this.depth =
+    this.height = 0;
+    this.parent = null;
+  }
+
+  Node$1.prototype = hierarchy.prototype = {
+    constructor: Node$1,
+    count: node_count,
+    each: node_each,
+    eachAfter: node_eachAfter,
+    eachBefore: node_eachBefore,
+    find: node_find,
+    sum: node_sum,
+    sort: node_sort,
+    path: node_path,
+    ancestors: node_ancestors,
+    descendants: node_descendants,
+    leaves: node_leaves,
+    links: node_links,
+    copy: node_copy,
+    [Symbol.iterator]: node_iterator
+  };
+
+  function required(f) {
+    if (typeof f !== "function") throw new Error;
+    return f;
+  }
+
+  function constantZero() {
+    return 0;
+  }
+
+  function constant$1(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function roundNode(node) {
+    node.x0 = Math.round(node.x0);
+    node.y0 = Math.round(node.y0);
+    node.x1 = Math.round(node.x1);
+    node.y1 = Math.round(node.y1);
+  }
+
+  function treemapDice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (x1 - x0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.y0 = y0, node.y1 = y1;
+      node.x0 = x0, node.x1 = x0 += node.value * k;
+    }
+  }
+
+  function treemapSlice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (y1 - y0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.x0 = x0, node.x1 = x1;
+      node.y0 = y0, node.y1 = y0 += node.value * k;
+    }
+  }
+
+  var phi = (1 + Math.sqrt(5)) / 2;
+
+  function squarifyRatio(ratio, parent, x0, y0, x1, y1) {
+    var rows = [],
+        nodes = parent.children,
+        row,
+        nodeValue,
+        i0 = 0,
+        i1 = 0,
+        n = nodes.length,
+        dx, dy,
+        value = parent.value,
+        sumValue,
+        minValue,
+        maxValue,
+        newRatio,
+        minRatio,
+        alpha,
+        beta;
+
+    while (i0 < n) {
+      dx = x1 - x0, dy = y1 - y0;
+
+      // Find the next non-empty node.
+      do sumValue = nodes[i1++].value; while (!sumValue && i1 < n);
+      minValue = maxValue = sumValue;
+      alpha = Math.max(dy / dx, dx / dy) / (value * ratio);
+      beta = sumValue * sumValue * alpha;
+      minRatio = Math.max(maxValue / beta, beta / minValue);
+
+      // Keep adding nodes while the aspect ratio maintains or improves.
+      for (; i1 < n; ++i1) {
+        sumValue += nodeValue = nodes[i1].value;
+        if (nodeValue < minValue) minValue = nodeValue;
+        if (nodeValue > maxValue) maxValue = nodeValue;
+        beta = sumValue * sumValue * alpha;
+        newRatio = Math.max(maxValue / beta, beta / minValue);
+        if (newRatio > minRatio) { sumValue -= nodeValue; break; }
+        minRatio = newRatio;
+      }
+
+      // Position and record the row orientation.
+      rows.push(row = {value: sumValue, dice: dx < dy, children: nodes.slice(i0, i1)});
+      if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += dy * sumValue / value : y1);
+      else treemapSlice(row, x0, y0, value ? x0 += dx * sumValue / value : x1, y1);
+      value -= sumValue, i0 = i1;
+    }
+
+    return rows;
+  }
+
+  var squarify = (function custom(ratio) {
+
+    function squarify(parent, x0, y0, x1, y1) {
+      squarifyRatio(ratio, parent, x0, y0, x1, y1);
+    }
+
+    squarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return squarify;
+  })(phi);
+
+  function treemap() {
+    var tile = squarify,
+        round = false,
+        dx = 1,
+        dy = 1,
+        paddingStack = [0],
+        paddingInner = constantZero,
+        paddingTop = constantZero,
+        paddingRight = constantZero,
+        paddingBottom = constantZero,
+        paddingLeft = constantZero;
+
+    function treemap(root) {
+      root.x0 =
+      root.y0 = 0;
+      root.x1 = dx;
+      root.y1 = dy;
+      root.eachBefore(positionNode);
+      paddingStack = [0];
+      if (round) root.eachBefore(roundNode);
+      return root;
+    }
+
+    function positionNode(node) {
+      var p = paddingStack[node.depth],
+          x0 = node.x0 + p,
+          y0 = node.y0 + p,
+          x1 = node.x1 - p,
+          y1 = node.y1 - p;
+      if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+      if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+      node.x0 = x0;
+      node.y0 = y0;
+      node.x1 = x1;
+      node.y1 = y1;
+      if (node.children) {
+        p = paddingStack[node.depth + 1] = paddingInner(node) / 2;
+        x0 += paddingLeft(node) - p;
+        y0 += paddingTop(node) - p;
+        x1 -= paddingRight(node) - p;
+        y1 -= paddingBottom(node) - p;
+        if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+        if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+        tile(node, x0, y0, x1, y1);
+      }
+    }
+
+    treemap.round = function(x) {
+      return arguments.length ? (round = !!x, treemap) : round;
+    };
+
+    treemap.size = function(x) {
+      return arguments.length ? (dx = +x[0], dy = +x[1], treemap) : [dx, dy];
+    };
+
+    treemap.tile = function(x) {
+      return arguments.length ? (tile = required(x), treemap) : tile;
+    };
+
+    treemap.padding = function(x) {
+      return arguments.length ? treemap.paddingInner(x).paddingOuter(x) : treemap.paddingInner();
+    };
+
+    treemap.paddingInner = function(x) {
+      return arguments.length ? (paddingInner = typeof x === "function" ? x : constant$1(+x), treemap) : paddingInner;
+    };
+
+    treemap.paddingOuter = function(x) {
+      return arguments.length ? treemap.paddingTop(x).paddingRight(x).paddingBottom(x).paddingLeft(x) : treemap.paddingTop();
+    };
+
+    treemap.paddingTop = function(x) {
+      return arguments.length ? (paddingTop = typeof x === "function" ? x : constant$1(+x), treemap) : paddingTop;
+    };
+
+    treemap.paddingRight = function(x) {
+      return arguments.length ? (paddingRight = typeof x === "function" ? x : constant$1(+x), treemap) : paddingRight;
+    };
+
+    treemap.paddingBottom = function(x) {
+      return arguments.length ? (paddingBottom = typeof x === "function" ? x : constant$1(+x), treemap) : paddingBottom;
+    };
+
+    treemap.paddingLeft = function(x) {
+      return arguments.length ? (paddingLeft = typeof x === "function" ? x : constant$1(+x), treemap) : paddingLeft;
+    };
+
+    return treemap;
+  }
+
+  var treemapResquarify = (function custom(ratio) {
+
+    function resquarify(parent, x0, y0, x1, y1) {
+      if ((rows = parent._squarify) && (rows.ratio === ratio)) {
+        var rows,
+            row,
+            nodes,
+            i,
+            j = -1,
+            n,
+            m = rows.length,
+            value = parent.value;
+
+        while (++j < m) {
+          row = rows[j], nodes = row.children;
+          for (i = row.value = 0, n = nodes.length; i < n; ++i) row.value += nodes[i].value;
+          if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += (y1 - y0) * row.value / value : y1);
+          else treemapSlice(row, x0, y0, value ? x0 += (x1 - x0) * row.value / value : x1, y1);
+          value -= row.value;
+        }
+      } else {
+        parent._squarify = rows = squarifyRatio(ratio, parent, x0, y0, x1, y1);
+        rows.ratio = ratio;
+      }
+    }
+
+    resquarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return resquarify;
+  })(phi);
+
+  const isModuleTree = (mod) => "children" in mod;
+
+  let count = 0;
+  class Id {
+      constructor(id) {
+          this._id = id;
+          const url = new URL(window.location.href);
+          url.hash = id;
+          this._href = url.toString();
+      }
+      get id() {
+          return this._id;
+      }
+      get href() {
+          return this._href;
+      }
+      toString() {
+          return `url(${this.href})`;
+      }
+  }
+  function generateUniqueId(name) {
+      count += 1;
+      const id = ["O", name, count].filter(Boolean).join("-");
+      return new Id(id);
+  }
+
+  const LABELS = {
+      renderedLength: "Rendered",
+      gzipLength: "Gzip",
+      brotliLength: "Brotli",
+  };
+  const getAvailableSizeOptions = (options) => {
+      const availableSizeProperties = ["renderedLength"];
+      if (options.gzip) {
+          availableSizeProperties.push("gzipLength");
+      }
+      if (options.brotli) {
+          availableSizeProperties.push("brotliLength");
+      }
+      return availableSizeProperties;
+  };
+
+  var t,r,u,i,o=0,f=[],c=[],e=l$1.__b,a=l$1.__r,v=l$1.diffed,l=l$1.__c,m=l$1.unmount;function d(t,u){l$1.__h&&l$1.__h(r,t,o||u),o=0;var i=r.__H||(r.__H={__:[],__h:[]});return t>=i.__.length&&i.__.push({__V:c}),i.__[t]}function h(n){return o=1,s(B,n)}function s(n,u,i){var o=d(t++,2);if(o.t=n,!o.__c&&(o.__=[i?i(u):B(void 0,u),function(n){var t=o.__N?o.__N[0]:o.__[0],r=o.t(t,n);t!==r&&(o.__N=[r,o.__[1]],o.__c.setState({}));}],o.__c=r,!r.u)){var f=function(n,t,r){if(!o.__c.__H)return !0;var u=o.__c.__H.__.filter(function(n){return n.__c});if(u.every(function(n){return !n.__N}))return !c||c.call(this,n,t,r);var i=!1;return u.forEach(function(n){if(n.__N){var t=n.__[0];n.__=n.__N,n.__N=void 0,t!==n.__[0]&&(i=!0);}}),!(!i&&o.__c.props===n)&&(!c||c.call(this,n,t,r))};r.u=!0;var c=r.shouldComponentUpdate,e=r.componentWillUpdate;r.componentWillUpdate=function(n,t,r){if(this.__e){var u=c;c=void 0,f(n,t,r),c=u;}e&&e.call(this,n,t,r);},r.shouldComponentUpdate=f;}return o.__N||o.__}function p(u,i){var o=d(t++,3);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__H.__h.push(o));}function y(u,i){var o=d(t++,4);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__h.push(o));}function _(n){return o=5,F(function(){return {current:n}},[])}function F(n,r){var u=d(t++,7);return z(u.__H,r)?(u.__V=n(),u.i=r,u.__h=n,u.__V):u.__}function T(n,t){return o=8,F(function(){return n},t)}function q(n){var u=r.context[n.__c],i=d(t++,9);return i.c=n,u?(null==i.__&&(i.__=!0,u.sub(r)),u.props.value):n.__}function b(){for(var t;t=f.shift();)if(t.__P&&t.__H)try{t.__H.__h.forEach(k),t.__H.__h.forEach(w),t.__H.__h=[];}catch(r){t.__H.__h=[],l$1.__e(r,t.__v);}}l$1.__b=function(n){r=null,e&&e(n);},l$1.__r=function(n){a&&a(n),t=0;var i=(r=n.__c).__H;i&&(u===r?(i.__h=[],r.__h=[],i.__.forEach(function(n){n.__N&&(n.__=n.__N),n.__V=c,n.__N=n.i=void 0;})):(i.__h.forEach(k),i.__h.forEach(w),i.__h=[],t=0)),u=r;},l$1.diffed=function(t){v&&v(t);var o=t.__c;o&&o.__H&&(o.__H.__h.length&&(1!==f.push(o)&&i===l$1.requestAnimationFrame||((i=l$1.requestAnimationFrame)||j)(b)),o.__H.__.forEach(function(n){n.i&&(n.__H=n.i),n.__V!==c&&(n.__=n.__V),n.i=void 0,n.__V=c;})),u=r=null;},l$1.__c=function(t,r){r.some(function(t){try{t.__h.forEach(k),t.__h=t.__h.filter(function(n){return !n.__||w(n)});}catch(u){r.some(function(n){n.__h&&(n.__h=[]);}),r=[],l$1.__e(u,t.__v);}}),l&&l(t,r);},l$1.unmount=function(t){m&&m(t);var r,u=t.__c;u&&u.__H&&(u.__H.__.forEach(function(n){try{k(n);}catch(n){r=n;}}),u.__H=void 0,r&&l$1.__e(r,u.__v));};var g="function"==typeof requestAnimationFrame;function j(n){var t,r=function(){clearTimeout(u),g&&cancelAnimationFrame(t),setTimeout(n);},u=setTimeout(r,100);g&&(t=requestAnimationFrame(r));}function k(n){var t=r,u=n.__c;"function"==typeof u&&(n.__c=void 0,u()),r=t;}function w(n){var t=r;n.__c=n.__(),r=t;}function z(n,t){return !n||n.length!==t.length||t.some(function(t,r){return t!==n[r]})}function B(n,t){return "function"==typeof t?t(n):t}
+
+  const PLACEHOLDER = "bundle-*:**/file/**,**/file**, bundle-*:";
+  const SideBar = ({ availableSizeProperties, sizeProperty, setSizeProperty, onExcludeChange, onIncludeChange, }) => {
+      const [includeValue, setIncludeValue] = h("");
+      const [excludeValue, setExcludeValue] = h("");
+      const handleSizePropertyChange = (sizeProp) => () => {
+          if (sizeProp !== sizeProperty) {
+              setSizeProperty(sizeProp);
+          }
+      };
+      const handleIncludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setIncludeValue(value);
+          onIncludeChange(value);
+      };
+      const handleExcludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setExcludeValue(value);
+          onExcludeChange(value);
+      };
+      return (o$1("aside", { className: "sidebar", children: [o$1("div", { className: "size-selectors", children: availableSizeProperties.length > 1 &&
+                      availableSizeProperties.map((sizeProp) => {
+                          const id = `selector-${sizeProp}`;
+                          return (o$1("div", { className: "size-selector", children: [o$1("input", { type: "radio", id: id, checked: sizeProp === sizeProperty, onChange: handleSizePropertyChange(sizeProp) }), o$1("label", { htmlFor: id, children: LABELS[sizeProp] })] }, sizeProp));
+                      }) }), o$1("div", { className: "module-filters", children: [o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-exclude", children: "Exclude" }), o$1("input", { type: "text", id: "module-filter-exclude", value: excludeValue, onInput: handleExcludeChange, placeholder: PLACEHOLDER })] }), o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-include", children: "Include" }), o$1("input", { type: "text", id: "module-filter-include", value: includeValue, onInput: handleIncludeChange, placeholder: PLACEHOLDER })] })] })] }));
+  };
+
+  function getDefaultExportFromCjs (x) {
+  	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+  }
+
+  var utils$3 = {};
+
+  const WIN_SLASH = '\\\\/';
+  const WIN_NO_SLASH = `[^${WIN_SLASH}]`;
+
+  /**
+   * Posix glob regex
+   */
+
+  const DOT_LITERAL = '\\.';
+  const PLUS_LITERAL = '\\+';
+  const QMARK_LITERAL = '\\?';
+  const SLASH_LITERAL = '\\/';
+  const ONE_CHAR = '(?=.)';
+  const QMARK = '[^/]';
+  const END_ANCHOR = `(?:${SLASH_LITERAL}|$)`;
+  const START_ANCHOR = `(?:^|${SLASH_LITERAL})`;
+  const DOTS_SLASH = `${DOT_LITERAL}{1,2}${END_ANCHOR}`;
+  const NO_DOT = `(?!${DOT_LITERAL})`;
+  const NO_DOTS = `(?!${START_ANCHOR}${DOTS_SLASH})`;
+  const NO_DOT_SLASH = `(?!${DOT_LITERAL}{0,1}${END_ANCHOR})`;
+  const NO_DOTS_SLASH = `(?!${DOTS_SLASH})`;
+  const QMARK_NO_DOT = `[^.${SLASH_LITERAL}]`;
+  const STAR = `${QMARK}*?`;
+  const SEP = '/';
+
+  const POSIX_CHARS = {
+    DOT_LITERAL,
+    PLUS_LITERAL,
+    QMARK_LITERAL,
+    SLASH_LITERAL,
+    ONE_CHAR,
+    QMARK,
+    END_ANCHOR,
+    DOTS_SLASH,
+    NO_DOT,
+    NO_DOTS,
+    NO_DOT_SLASH,
+    NO_DOTS_SLASH,
+    QMARK_NO_DOT,
+    STAR,
+    START_ANCHOR,
+    SEP
+  };
+
+  /**
+   * Windows glob regex
+   */
+
+  const WINDOWS_CHARS = {
+    ...POSIX_CHARS,
+
+    SLASH_LITERAL: `[${WIN_SLASH}]`,
+    QMARK: WIN_NO_SLASH,
+    STAR: `${WIN_NO_SLASH}*?`,
+    DOTS_SLASH: `${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$)`,
+    NO_DOT: `(?!${DOT_LITERAL})`,
+    NO_DOTS: `(?!(?:^|[${WIN_SLASH}])${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    NO_DOT_SLASH: `(?!${DOT_LITERAL}{0,1}(?:[${WIN_SLASH}]|$))`,
+    NO_DOTS_SLASH: `(?!${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    QMARK_NO_DOT: `[^.${WIN_SLASH}]`,
+    START_ANCHOR: `(?:^|[${WIN_SLASH}])`,
+    END_ANCHOR: `(?:[${WIN_SLASH}]|$)`,
+    SEP: '\\'
+  };
+
+  /**
+   * POSIX Bracket Regex
+   */
+
+  const POSIX_REGEX_SOURCE$1 = {
+    alnum: 'a-zA-Z0-9',
+    alpha: 'a-zA-Z',
+    ascii: '\\x00-\\x7F',
+    blank: ' \\t',
+    cntrl: '\\x00-\\x1F\\x7F',
+    digit: '0-9',
+    graph: '\\x21-\\x7E',
+    lower: 'a-z',
+    print: '\\x20-\\x7E ',
+    punct: '\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~',
+    space: ' \\t\\r\\n\\v\\f',
+    upper: 'A-Z',
+    word: 'A-Za-z0-9_',
+    xdigit: 'A-Fa-f0-9'
+  };
+
+  var constants$3 = {
+    MAX_LENGTH: 1024 * 64,
+    POSIX_REGEX_SOURCE: POSIX_REGEX_SOURCE$1,
+
+    // regular expressions
+    REGEX_BACKSLASH: /\\(?![*+?^${}(|)[\]])/g,
+    REGEX_NON_SPECIAL_CHARS: /^[^@![\].,$*+?^{}()|\\/]+/,
+    REGEX_SPECIAL_CHARS: /[-*+?.^${}(|)[\]]/,
+    REGEX_SPECIAL_CHARS_BACKREF: /(\\?)((\W)(\3*))/g,
+    REGEX_SPECIAL_CHARS_GLOBAL: /([-*+?.^${}(|)[\]])/g,
+    REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
+
+    // Replace globs with equivalent patterns to reduce parsing time.
+    REPLACEMENTS: {
+      '***': '*',
+      '**/**': '**',
+      '**/**/**': '**'
+    },
+
+    // Digits
+    CHAR_0: 48, /* 0 */
+    CHAR_9: 57, /* 9 */
+
+    // Alphabet chars.
+    CHAR_UPPERCASE_A: 65, /* A */
+    CHAR_LOWERCASE_A: 97, /* a */
+    CHAR_UPPERCASE_Z: 90, /* Z */
+    CHAR_LOWERCASE_Z: 122, /* z */
+
+    CHAR_LEFT_PARENTHESES: 40, /* ( */
+    CHAR_RIGHT_PARENTHESES: 41, /* ) */
+
+    CHAR_ASTERISK: 42, /* * */
+
+    // Non-alphabetic chars.
+    CHAR_AMPERSAND: 38, /* & */
+    CHAR_AT: 64, /* @ */
+    CHAR_BACKWARD_SLASH: 92, /* \ */
+    CHAR_CARRIAGE_RETURN: 13, /* \r */
+    CHAR_CIRCUMFLEX_ACCENT: 94, /* ^ */
+    CHAR_COLON: 58, /* : */
+    CHAR_COMMA: 44, /* , */
+    CHAR_DOT: 46, /* . */
+    CHAR_DOUBLE_QUOTE: 34, /* " */
+    CHAR_EQUAL: 61, /* = */
+    CHAR_EXCLAMATION_MARK: 33, /* ! */
+    CHAR_FORM_FEED: 12, /* \f */
+    CHAR_FORWARD_SLASH: 47, /* / */
+    CHAR_GRAVE_ACCENT: 96, /* ` */
+    CHAR_HASH: 35, /* # */
+    CHAR_HYPHEN_MINUS: 45, /* - */
+    CHAR_LEFT_ANGLE_BRACKET: 60, /* < */
+    CHAR_LEFT_CURLY_BRACE: 123, /* { */
+    CHAR_LEFT_SQUARE_BRACKET: 91, /* [ */
+    CHAR_LINE_FEED: 10, /* \n */
+    CHAR_NO_BREAK_SPACE: 160, /* \u00A0 */
+    CHAR_PERCENT: 37, /* % */
+    CHAR_PLUS: 43, /* + */
+    CHAR_QUESTION_MARK: 63, /* ? */
+    CHAR_RIGHT_ANGLE_BRACKET: 62, /* > */
+    CHAR_RIGHT_CURLY_BRACE: 125, /* } */
+    CHAR_RIGHT_SQUARE_BRACKET: 93, /* ] */
+    CHAR_SEMICOLON: 59, /* ; */
+    CHAR_SINGLE_QUOTE: 39, /* ' */
+    CHAR_SPACE: 32, /*   */
+    CHAR_TAB: 9, /* \t */
+    CHAR_UNDERSCORE: 95, /* _ */
+    CHAR_VERTICAL_LINE: 124, /* | */
+    CHAR_ZERO_WIDTH_NOBREAK_SPACE: 65279, /* \uFEFF */
+
+    /**
+     * Create EXTGLOB_CHARS
+     */
+
+    extglobChars(chars) {
+      return {
+        '!': { type: 'negate', open: '(?:(?!(?:', close: `))${chars.STAR})` },
+        '?': { type: 'qmark', open: '(?:', close: ')?' },
+        '+': { type: 'plus', open: '(?:', close: ')+' },
+        '*': { type: 'star', open: '(?:', close: ')*' },
+        '@': { type: 'at', open: '(?:', close: ')' }
+      };
+    },
+
+    /**
+     * Create GLOB_CHARS
+     */
+
+    globChars(win32) {
+      return win32 === true ? WINDOWS_CHARS : POSIX_CHARS;
+    }
+  };
+
+  (function (exports) {
+
+  	const {
+  	  REGEX_BACKSLASH,
+  	  REGEX_REMOVE_BACKSLASH,
+  	  REGEX_SPECIAL_CHARS,
+  	  REGEX_SPECIAL_CHARS_GLOBAL
+  	} = constants$3;
+
+  	exports.isObject = val => val !== null && typeof val === 'object' && !Array.isArray(val);
+  	exports.hasRegexChars = str => REGEX_SPECIAL_CHARS.test(str);
+  	exports.isRegexChar = str => str.length === 1 && exports.hasRegexChars(str);
+  	exports.escapeRegex = str => str.replace(REGEX_SPECIAL_CHARS_GLOBAL, '\\$1');
+  	exports.toPosixSlashes = str => str.replace(REGEX_BACKSLASH, '/');
+
+  	exports.removeBackslashes = str => {
+  	  return str.replace(REGEX_REMOVE_BACKSLASH, match => {
+  	    return match === '\\' ? '' : match;
+  	  });
+  	};
+
+  	exports.supportsLookbehinds = () => {
+  	  const segs = process.version.slice(1).split('.').map(Number);
+  	  if (segs.length === 3 && segs[0] >= 9 || (segs[0] === 8 && segs[1] >= 10)) {
+  	    return true;
+  	  }
+  	  return false;
+  	};
+
+  	exports.escapeLast = (input, char, lastIdx) => {
+  	  const idx = input.lastIndexOf(char, lastIdx);
+  	  if (idx === -1) return input;
+  	  if (input[idx - 1] === '\\') return exports.escapeLast(input, char, idx - 1);
+  	  return `${input.slice(0, idx)}\\${input.slice(idx)}`;
+  	};
+
+  	exports.removePrefix = (input, state = {}) => {
+  	  let output = input;
+  	  if (output.startsWith('./')) {
+  	    output = output.slice(2);
+  	    state.prefix = './';
+  	  }
+  	  return output;
+  	};
+
+  	exports.wrapOutput = (input, state = {}, options = {}) => {
+  	  const prepend = options.contains ? '' : '^';
+  	  const append = options.contains ? '' : '$';
+
+  	  let output = `${prepend}(?:${input})${append}`;
+  	  if (state.negated === true) {
+  	    output = `(?:^(?!${output}).*$)`;
+  	  }
+  	  return output;
+  	};
+
+  	exports.basename = (path, { windows } = {}) => {
+  	  if (windows) {
+  	    return path.replace(/[\\/]$/, '').replace(/.*[\\/]/, '');
+  	  } else {
+  	    return path.replace(/\/$/, '').replace(/.*\//, '');
+  	  }
+  	}; 
+  } (utils$3));
+
+  const utils$2 = utils$3;
+  const {
+    CHAR_ASTERISK,             /* * */
+    CHAR_AT,                   /* @ */
+    CHAR_BACKWARD_SLASH,       /* \ */
+    CHAR_COMMA,                /* , */
+    CHAR_DOT,                  /* . */
+    CHAR_EXCLAMATION_MARK,     /* ! */
+    CHAR_FORWARD_SLASH,        /* / */
+    CHAR_LEFT_CURLY_BRACE,     /* { */
+    CHAR_LEFT_PARENTHESES,     /* ( */
+    CHAR_LEFT_SQUARE_BRACKET,  /* [ */
+    CHAR_PLUS,                 /* + */
+    CHAR_QUESTION_MARK,        /* ? */
+    CHAR_RIGHT_CURLY_BRACE,    /* } */
+    CHAR_RIGHT_PARENTHESES,    /* ) */
+    CHAR_RIGHT_SQUARE_BRACKET  /* ] */
+  } = constants$3;
+
+  const isPathSeparator = code => {
+    return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+  };
+
+  const depth = token => {
+    if (token.isPrefix !== true) {
+      token.depth = token.isGlobstar ? Infinity : 1;
+    }
+  };
+
+  /**
+   * Quickly scans a glob pattern and returns an object with a handful of
+   * useful properties, like `isGlob`, `path` (the leading non-glob, if it exists),
+   * `glob` (the actual pattern), and `negated` (true if the path starts with `!`).
+   *
+   * ```js
+   * const pm = require('picomatch');
+   * console.log(pm.scan('foo/bar/*.js'));
+   * { isGlob: true, input: 'foo/bar/*.js', base: 'foo/bar', glob: '*.js' }
+   * ```
+   * @param {String} `str`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with tokens and regex source string.
+   * @api public
+   */
+
+  const scan$1 = (input, options) => {
+    const opts = options || {};
+
+    const length = input.length - 1;
+    const scanToEnd = opts.parts === true || opts.scanToEnd === true;
+    const slashes = [];
+    const tokens = [];
+    const parts = [];
+
+    let str = input;
+    let index = -1;
+    let start = 0;
+    let lastIndex = 0;
+    let isBrace = false;
+    let isBracket = false;
+    let isGlob = false;
+    let isExtglob = false;
+    let isGlobstar = false;
+    let braceEscaped = false;
+    let backslashes = false;
+    let negated = false;
+    let finished = false;
+    let braces = 0;
+    let prev;
+    let code;
+    let token = { value: '', depth: 0, isGlob: false };
+
+    const eos = () => index >= length;
+    const peek = () => str.charCodeAt(index + 1);
+    const advance = () => {
+      prev = code;
+      return str.charCodeAt(++index);
+    };
+
+    while (index < length) {
+      code = advance();
+      let next;
+
+      if (code === CHAR_BACKWARD_SLASH) {
+        backslashes = token.backslashes = true;
+        code = advance();
+
+        if (code === CHAR_LEFT_CURLY_BRACE) {
+          braceEscaped = true;
+        }
+        continue;
+      }
+
+      if (braceEscaped === true || code === CHAR_LEFT_CURLY_BRACE) {
+        braces++;
+
+        while (eos() !== true && (code = advance())) {
+          if (code === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (code === CHAR_LEFT_CURLY_BRACE) {
+            braces++;
+            continue;
+          }
+
+          if (braceEscaped !== true && code === CHAR_DOT && (code = advance()) === CHAR_DOT) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (braceEscaped !== true && code === CHAR_COMMA) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (code === CHAR_RIGHT_CURLY_BRACE) {
+            braces--;
+
+            if (braces === 0) {
+              braceEscaped = false;
+              isBrace = token.isBrace = true;
+              finished = true;
+              break;
+            }
+          }
+        }
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+
+      if (code === CHAR_FORWARD_SLASH) {
+        slashes.push(index);
+        tokens.push(token);
+        token = { value: '', depth: 0, isGlob: false };
+
+        if (finished === true) continue;
+        if (prev === CHAR_DOT && index === (start + 1)) {
+          start += 2;
+          continue;
+        }
+
+        lastIndex = index + 1;
+        continue;
+      }
+
+      if (opts.noext !== true) {
+        const isExtglobChar = code === CHAR_PLUS
+          || code === CHAR_AT
+          || code === CHAR_ASTERISK
+          || code === CHAR_QUESTION_MARK
+          || code === CHAR_EXCLAMATION_MARK;
+
+        if (isExtglobChar === true && peek() === CHAR_LEFT_PARENTHESES) {
+          isGlob = token.isGlob = true;
+          isExtglob = token.isExtglob = true;
+          finished = true;
+
+          if (scanToEnd === true) {
+            while (eos() !== true && (code = advance())) {
+              if (code === CHAR_BACKWARD_SLASH) {
+                backslashes = token.backslashes = true;
+                code = advance();
+                continue;
+              }
+
+              if (code === CHAR_RIGHT_PARENTHESES) {
+                isGlob = token.isGlob = true;
+                finished = true;
+                break;
+              }
+            }
+            continue;
+          }
+          break;
+        }
+      }
+
+      if (code === CHAR_ASTERISK) {
+        if (prev === CHAR_ASTERISK) isGlobstar = token.isGlobstar = true;
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_QUESTION_MARK) {
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_LEFT_SQUARE_BRACKET) {
+        while (eos() !== true && (next = advance())) {
+          if (next === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (next === CHAR_RIGHT_SQUARE_BRACKET) {
+            isBracket = token.isBracket = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+            break;
+          }
+        }
+      }
+
+      if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index === start) {
+        negated = token.negated = true;
+        start++;
+        continue;
+      }
+
+      if (opts.noparen !== true && code === CHAR_LEFT_PARENTHESES) {
+        isGlob = token.isGlob = true;
+
+        if (scanToEnd === true) {
+          while (eos() !== true && (code = advance())) {
+            if (code === CHAR_LEFT_PARENTHESES) {
+              backslashes = token.backslashes = true;
+              code = advance();
+              continue;
+            }
+
+            if (code === CHAR_RIGHT_PARENTHESES) {
+              finished = true;
+              break;
+            }
+          }
+          continue;
+        }
+        break;
+      }
+
+      if (isGlob === true) {
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+    }
+
+    if (opts.noext === true) {
+      isExtglob = false;
+      isGlob = false;
+    }
+
+    let base = str;
+    let prefix = '';
+    let glob = '';
+
+    if (start > 0) {
+      prefix = str.slice(0, start);
+      str = str.slice(start);
+      lastIndex -= start;
+    }
+
+    if (base && isGlob === true && lastIndex > 0) {
+      base = str.slice(0, lastIndex);
+      glob = str.slice(lastIndex);
+    } else if (isGlob === true) {
+      base = '';
+      glob = str;
+    } else {
+      base = str;
+    }
+
+    if (base && base !== '' && base !== '/' && base !== str) {
+      if (isPathSeparator(base.charCodeAt(base.length - 1))) {
+        base = base.slice(0, -1);
+      }
+    }
+
+    if (opts.unescape === true) {
+      if (glob) glob = utils$2.removeBackslashes(glob);
+
+      if (base && backslashes === true) {
+        base = utils$2.removeBackslashes(base);
+      }
+    }
+
+    const state = {
+      prefix,
+      input,
+      start,
+      base,
+      glob,
+      isBrace,
+      isBracket,
+      isGlob,
+      isExtglob,
+      isGlobstar,
+      negated
+    };
+
+    if (opts.tokens === true) {
+      state.maxDepth = 0;
+      if (!isPathSeparator(code)) {
+        tokens.push(token);
+      }
+      state.tokens = tokens;
+    }
+
+    if (opts.parts === true || opts.tokens === true) {
+      let prevIndex;
+
+      for (let idx = 0; idx < slashes.length; idx++) {
+        const n = prevIndex ? prevIndex + 1 : start;
+        const i = slashes[idx];
+        const value = input.slice(n, i);
+        if (opts.tokens) {
+          if (idx === 0 && start !== 0) {
+            tokens[idx].isPrefix = true;
+            tokens[idx].value = prefix;
+          } else {
+            tokens[idx].value = value;
+          }
+          depth(tokens[idx]);
+          state.maxDepth += tokens[idx].depth;
+        }
+        if (idx !== 0 || value !== '') {
+          parts.push(value);
+        }
+        prevIndex = i;
+      }
+
+      if (prevIndex && prevIndex + 1 < input.length) {
+        const value = input.slice(prevIndex + 1);
+        parts.push(value);
+
+        if (opts.tokens) {
+          tokens[tokens.length - 1].value = value;
+          depth(tokens[tokens.length - 1]);
+          state.maxDepth += tokens[tokens.length - 1].depth;
+        }
+      }
+
+      state.slashes = slashes;
+      state.parts = parts;
+    }
+
+    return state;
+  };
+
+  var scan_1 = scan$1;
+
+  const constants$2 = constants$3;
+  const utils$1 = utils$3;
+
+  /**
+   * Constants
+   */
+
+  const {
+    MAX_LENGTH,
+    POSIX_REGEX_SOURCE,
+    REGEX_NON_SPECIAL_CHARS,
+    REGEX_SPECIAL_CHARS_BACKREF,
+    REPLACEMENTS
+  } = constants$2;
+
+  /**
+   * Helpers
+   */
+
+  const expandRange = (args, options) => {
+    if (typeof options.expandRange === 'function') {
+      return options.expandRange(...args, options);
+    }
+
+    args.sort();
+    const value = `[${args.join('-')}]`;
+
+    try {
+      /* eslint-disable-next-line no-new */
+      new RegExp(value);
+    } catch (ex) {
+      return args.map(v => utils$1.escapeRegex(v)).join('..');
+    }
+
+    return value;
+  };
+
+  /**
+   * Create the message for a syntax error
+   */
+
+  const syntaxError = (type, char) => {
+    return `Missing ${type}: "${char}" - use "\\\\${char}" to match literal characters`;
+  };
+
+  /**
+   * Parse the given input string.
+   * @param {String} input
+   * @param {Object} options
+   * @return {Object}
+   */
+
+  const parse$2 = (input, options) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected a string');
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+
+    let len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    const bos = { type: 'bos', value: '', output: opts.prepend || '' };
+    const tokens = [bos];
+
+    const capture = opts.capture ? '' : '?:';
+
+    // create constants based on platform, for windows or posix
+    const PLATFORM_CHARS = constants$2.globChars(opts.windows);
+    const EXTGLOB_CHARS = constants$2.extglobChars(PLATFORM_CHARS);
+
+    const {
+      DOT_LITERAL,
+      PLUS_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOT_SLASH,
+      NO_DOTS_SLASH,
+      QMARK,
+      QMARK_NO_DOT,
+      STAR,
+      START_ANCHOR
+    } = PLATFORM_CHARS;
+
+    const globstar = (opts) => {
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const nodot = opts.dot ? '' : NO_DOT;
+    const qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
+    let star = opts.bash === true ? globstar(opts) : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    // minimatch options support
+    if (typeof opts.noext === 'boolean') {
+      opts.noextglob = opts.noext;
+    }
+
+    const state = {
+      input,
+      index: -1,
+      start: 0,
+      dot: opts.dot === true,
+      consumed: '',
+      output: '',
+      prefix: '',
+      backtrack: false,
+      negated: false,
+      brackets: 0,
+      braces: 0,
+      parens: 0,
+      quotes: 0,
+      globstar: false,
+      tokens
+    };
+
+    input = utils$1.removePrefix(input, state);
+    len = input.length;
+
+    const extglobs = [];
+    const braces = [];
+    const stack = [];
+    let prev = bos;
+    let value;
+
+    /**
+     * Tokenizing helpers
+     */
+
+    const eos = () => state.index === len - 1;
+    const peek = state.peek = (n = 1) => input[state.index + n];
+    const advance = state.advance = () => input[++state.index];
+    const remaining = () => input.slice(state.index + 1);
+    const consume = (value = '', num = 0) => {
+      state.consumed += value;
+      state.index += num;
+    };
+    const append = token => {
+      state.output += token.output != null ? token.output : token.value;
+      consume(token.value);
+    };
+
+    const negate = () => {
+      let count = 1;
+
+      while (peek() === '!' && (peek(2) !== '(' || peek(3) === '?')) {
+        advance();
+        state.start++;
+        count++;
+      }
+
+      if (count % 2 === 0) {
+        return false;
+      }
+
+      state.negated = true;
+      state.start++;
+      return true;
+    };
+
+    const increment = type => {
+      state[type]++;
+      stack.push(type);
+    };
+
+    const decrement = type => {
+      state[type]--;
+      stack.pop();
+    };
+
+    /**
+     * Push tokens onto the tokens array. This helper speeds up
+     * tokenizing by 1) helping us avoid backtracking as much as possible,
+     * and 2) helping us avoid creating extra tokens when consecutive
+     * characters are plain text. This improves performance and simplifies
+     * lookbehinds.
+     */
+
+    const push = tok => {
+      if (prev.type === 'globstar') {
+        const isBrace = state.braces > 0 && (tok.type === 'comma' || tok.type === 'brace');
+        const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.type === 'paren'));
+
+        if (tok.type !== 'slash' && tok.type !== 'paren' && !isBrace && !isExtglob) {
+          state.output = state.output.slice(0, -prev.output.length);
+          prev.type = 'star';
+          prev.value = '*';
+          prev.output = star;
+          state.output += prev.output;
+        }
+      }
+
+      if (extglobs.length && tok.type !== 'paren' && !EXTGLOB_CHARS[tok.value]) {
+        extglobs[extglobs.length - 1].inner += tok.value;
+      }
+
+      if (tok.value || tok.output) append(tok);
+      if (prev && prev.type === 'text' && tok.type === 'text') {
+        prev.value += tok.value;
+        prev.output = (prev.output || '') + tok.value;
+        return;
+      }
+
+      tok.prev = prev;
+      tokens.push(tok);
+      prev = tok;
+    };
+
+    const extglobOpen = (type, value) => {
+      const token = { ...EXTGLOB_CHARS[value], conditions: 1, inner: '' };
+
+      token.prev = prev;
+      token.parens = state.parens;
+      token.output = state.output;
+      const output = (opts.capture ? '(' : '') + token.open;
+
+      increment('parens');
+      push({ type, value, output: state.output ? '' : ONE_CHAR });
+      push({ type: 'paren', extglob: true, value: advance(), output });
+      extglobs.push(token);
+    };
+
+    const extglobClose = token => {
+      let output = token.close + (opts.capture ? ')' : '');
+
+      if (token.type === 'negate') {
+        let extglobStar = star;
+
+        if (token.inner && token.inner.length > 1 && token.inner.includes('/')) {
+          extglobStar = globstar(opts);
+        }
+
+        if (extglobStar !== star || eos() || /^\)+$/.test(remaining())) {
+          output = token.close = `)$))${extglobStar}`;
+        }
+
+        if (token.prev.type === 'bos' && eos()) {
+          state.negatedExtglob = true;
+        }
+      }
+
+      push({ type: 'paren', extglob: true, value, output });
+      decrement('parens');
+    };
+
+    /**
+     * Fast paths
+     */
+
+    if (opts.fastpaths !== false && !/(^[*!]|[/()[\]{}"])/.test(input)) {
+      let backslashes = false;
+
+      let output = input.replace(REGEX_SPECIAL_CHARS_BACKREF, (m, esc, chars, first, rest, index) => {
+        if (first === '\\') {
+          backslashes = true;
+          return m;
+        }
+
+        if (first === '?') {
+          if (esc) {
+            return esc + first + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          if (index === 0) {
+            return qmarkNoDot + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          return QMARK.repeat(chars.length);
+        }
+
+        if (first === '.') {
+          return DOT_LITERAL.repeat(chars.length);
+        }
+
+        if (first === '*') {
+          if (esc) {
+            return esc + first + (rest ? star : '');
+          }
+          return star;
+        }
+        return esc ? m : `\\${m}`;
+      });
+
+      if (backslashes === true) {
+        if (opts.unescape === true) {
+          output = output.replace(/\\/g, '');
+        } else {
+          output = output.replace(/\\+/g, m => {
+            return m.length % 2 === 0 ? '\\\\' : (m ? '\\' : '');
+          });
+        }
+      }
+
+      if (output === input && opts.contains === true) {
+        state.output = input;
+        return state;
+      }
+
+      state.output = utils$1.wrapOutput(output, state, options);
+      return state;
+    }
+
+    /**
+     * Tokenize input until we reach end-of-string
+     */
+
+    while (!eos()) {
+      value = advance();
+
+      if (value === '\u0000') {
+        continue;
+      }
+
+      /**
+       * Escaped characters
+       */
+
+      if (value === '\\') {
+        const next = peek();
+
+        if (next === '/' && opts.bash !== true) {
+          continue;
+        }
+
+        if (next === '.' || next === ';') {
+          continue;
+        }
+
+        if (!next) {
+          value += '\\';
+          push({ type: 'text', value });
+          continue;
+        }
+
+        // collapse slashes to reduce potential for exploits
+        const match = /^\\+/.exec(remaining());
+        let slashes = 0;
+
+        if (match && match[0].length > 2) {
+          slashes = match[0].length;
+          state.index += slashes;
+          if (slashes % 2 !== 0) {
+            value += '\\';
+          }
+        }
+
+        if (opts.unescape === true) {
+          value = advance() || '';
+        } else {
+          value += advance() || '';
+        }
+
+        if (state.brackets === 0) {
+          push({ type: 'text', value });
+          continue;
+        }
+      }
+
+      /**
+       * If we're inside a regex character class, continue
+       * until we reach the closing bracket.
+       */
+
+      if (state.brackets > 0 && (value !== ']' || prev.value === '[' || prev.value === '[^')) {
+        if (opts.posix !== false && value === ':') {
+          const inner = prev.value.slice(1);
+          if (inner.includes('[')) {
+            prev.posix = true;
+
+            if (inner.includes(':')) {
+              const idx = prev.value.lastIndexOf('[');
+              const pre = prev.value.slice(0, idx);
+              const rest = prev.value.slice(idx + 2);
+              const posix = POSIX_REGEX_SOURCE[rest];
+              if (posix) {
+                prev.value = pre + posix;
+                state.backtrack = true;
+                advance();
+
+                if (!bos.output && tokens.indexOf(prev) === 1) {
+                  bos.output = ONE_CHAR;
+                }
+                continue;
+              }
+            }
+          }
+        }
+
+        if ((value === '[' && peek() !== ':') || (value === '-' && peek() === ']')) {
+          value = `\\${value}`;
+        }
+
+        if (value === ']' && (prev.value === '[' || prev.value === '[^')) {
+          value = `\\${value}`;
+        }
+
+        if (opts.posix === true && value === '!' && prev.value === '[') {
+          value = '^';
+        }
+
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * If we're inside a quoted string, continue
+       * until we reach the closing double quote.
+       */
+
+      if (state.quotes === 1 && value !== '"') {
+        value = utils$1.escapeRegex(value);
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * Double quotes
+       */
+
+      if (value === '"') {
+        state.quotes = state.quotes === 1 ? 0 : 1;
+        if (opts.keepQuotes === true) {
+          push({ type: 'text', value });
+        }
+        continue;
+      }
+
+      /**
+       * Parentheses
+       */
+
+      if (value === '(') {
+        increment('parens');
+        push({ type: 'paren', value });
+        continue;
+      }
+
+      if (value === ')') {
+        if (state.parens === 0 && opts.strictBrackets === true) {
+          throw new SyntaxError(syntaxError('opening', '('));
+        }
+
+        const extglob = extglobs[extglobs.length - 1];
+        if (extglob && state.parens === extglob.parens + 1) {
+          extglobClose(extglobs.pop());
+          continue;
+        }
+
+        push({ type: 'paren', value, output: state.parens ? ')' : '\\)' });
+        decrement('parens');
+        continue;
+      }
+
+      /**
+       * Square brackets
+       */
+
+      if (value === '[') {
+        if (opts.nobracket === true || !remaining().includes(']')) {
+          if (opts.nobracket !== true && opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('closing', ']'));
+          }
+
+          value = `\\${value}`;
+        } else {
+          increment('brackets');
+        }
+
+        push({ type: 'bracket', value });
+        continue;
+      }
+
+      if (value === ']') {
+        if (opts.nobracket === true || (prev && prev.type === 'bracket' && prev.value.length === 1)) {
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        if (state.brackets === 0) {
+          if (opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('opening', '['));
+          }
+
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        decrement('brackets');
+
+        const prevValue = prev.value.slice(1);
+        if (prev.posix !== true && prevValue[0] === '^' && !prevValue.includes('/')) {
+          value = `/${value}`;
+        }
+
+        prev.value += value;
+        append({ value });
+
+        // when literal brackets are explicitly disabled
+        // assume we should match with a regex character class
+        if (opts.literalBrackets === false || utils$1.hasRegexChars(prevValue)) {
+          continue;
+        }
+
+        const escaped = utils$1.escapeRegex(prev.value);
+        state.output = state.output.slice(0, -prev.value.length);
+
+        // when literal brackets are explicitly enabled
+        // assume we should escape the brackets to match literal characters
+        if (opts.literalBrackets === true) {
+          state.output += escaped;
+          prev.value = escaped;
+          continue;
+        }
+
+        // when the user specifies nothing, try to match both
+        prev.value = `(${capture}${escaped}|${prev.value})`;
+        state.output += prev.value;
+        continue;
+      }
+
+      /**
+       * Braces
+       */
+
+      if (value === '{' && opts.nobrace !== true) {
+        increment('braces');
+
+        const open = {
+          type: 'brace',
+          value,
+          output: '(',
+          outputIndex: state.output.length,
+          tokensIndex: state.tokens.length
+        };
+
+        braces.push(open);
+        push(open);
+        continue;
+      }
+
+      if (value === '}') {
+        const brace = braces[braces.length - 1];
+
+        if (opts.nobrace === true || !brace) {
+          push({ type: 'text', value, output: value });
+          continue;
+        }
+
+        let output = ')';
+
+        if (brace.dots === true) {
+          const arr = tokens.slice();
+          const range = [];
+
+          for (let i = arr.length - 1; i >= 0; i--) {
+            tokens.pop();
+            if (arr[i].type === 'brace') {
+              break;
+            }
+            if (arr[i].type !== 'dots') {
+              range.unshift(arr[i].value);
+            }
+          }
+
+          output = expandRange(range, opts);
+          state.backtrack = true;
+        }
+
+        if (brace.comma !== true && brace.dots !== true) {
+          const out = state.output.slice(0, brace.outputIndex);
+          const toks = state.tokens.slice(brace.tokensIndex);
+          brace.value = brace.output = '\\{';
+          value = output = '\\}';
+          state.output = out;
+          for (const t of toks) {
+            state.output += (t.output || t.value);
+          }
+        }
+
+        push({ type: 'brace', value, output });
+        decrement('braces');
+        braces.pop();
+        continue;
+      }
+
+      /**
+       * Pipes
+       */
+
+      if (value === '|') {
+        if (extglobs.length > 0) {
+          extglobs[extglobs.length - 1].conditions++;
+        }
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Commas
+       */
+
+      if (value === ',') {
+        let output = value;
+
+        const brace = braces[braces.length - 1];
+        if (brace && stack[stack.length - 1] === 'braces') {
+          brace.comma = true;
+          output = '|';
+        }
+
+        push({ type: 'comma', value, output });
+        continue;
+      }
+
+      /**
+       * Slashes
+       */
+
+      if (value === '/') {
+        // if the beginning of the glob is "./", advance the start
+        // to the current index, and don't add the "./" characters
+        // to the state. This greatly simplifies lookbehinds when
+        // checking for BOS characters like "!" and "." (not "./")
+        if (prev.type === 'dot' && state.index === state.start + 1) {
+          state.start = state.index + 1;
+          state.consumed = '';
+          state.output = '';
+          tokens.pop();
+          prev = bos; // reset "prev" to the first token
+          continue;
+        }
+
+        push({ type: 'slash', value, output: SLASH_LITERAL });
+        continue;
+      }
+
+      /**
+       * Dots
+       */
+
+      if (value === '.') {
+        if (state.braces > 0 && prev.type === 'dot') {
+          if (prev.value === '.') prev.output = DOT_LITERAL;
+          const brace = braces[braces.length - 1];
+          prev.type = 'dots';
+          prev.output += value;
+          prev.value += value;
+          brace.dots = true;
+          continue;
+        }
+
+        if ((state.braces + state.parens) === 0 && prev.type !== 'bos' && prev.type !== 'slash') {
+          push({ type: 'text', value, output: DOT_LITERAL });
+          continue;
+        }
+
+        push({ type: 'dot', value, output: DOT_LITERAL });
+        continue;
+      }
+
+      /**
+       * Question marks
+       */
+
+      if (value === '?') {
+        const isGroup = prev && prev.value === '(';
+        if (!isGroup && opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('qmark', value);
+          continue;
+        }
+
+        if (prev && prev.type === 'paren') {
+          const next = peek();
+          let output = value;
+
+          if (next === '<' && !utils$1.supportsLookbehinds()) {
+            throw new Error('Node.js v10 or higher is required for regex lookbehinds');
+          }
+
+          if ((prev.value === '(' && !/[!=<:]/.test(next)) || (next === '<' && !/<([!=]|\w+>)/.test(remaining()))) {
+            output = `\\${value}`;
+          }
+
+          push({ type: 'text', value, output });
+          continue;
+        }
+
+        if (opts.dot !== true && (prev.type === 'slash' || prev.type === 'bos')) {
+          push({ type: 'qmark', value, output: QMARK_NO_DOT });
+          continue;
+        }
+
+        push({ type: 'qmark', value, output: QMARK });
+        continue;
+      }
+
+      /**
+       * Exclamation
+       */
+
+      if (value === '!') {
+        if (opts.noextglob !== true && peek() === '(') {
+          if (peek(2) !== '?' || !/[!=<:]/.test(peek(3))) {
+            extglobOpen('negate', value);
+            continue;
+          }
+        }
+
+        if (opts.nonegate !== true && state.index === 0) {
+          negate();
+          continue;
+        }
+      }
+
+      /**
+       * Plus
+       */
+
+      if (value === '+') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('plus', value);
+          continue;
+        }
+
+        if ((prev && prev.value === '(') || opts.regex === false) {
+          push({ type: 'plus', value, output: PLUS_LITERAL });
+          continue;
+        }
+
+        if ((prev && (prev.type === 'bracket' || prev.type === 'paren' || prev.type === 'brace')) || state.parens > 0) {
+          push({ type: 'plus', value });
+          continue;
+        }
+
+        push({ type: 'plus', value: PLUS_LITERAL });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value === '@') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          push({ type: 'at', extglob: true, value, output: '' });
+          continue;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value !== '*') {
+        if (value === '$' || value === '^') {
+          value = `\\${value}`;
+        }
+
+        const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
+        if (match) {
+          value += match[0];
+          state.index += match[0].length;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Stars
+       */
+
+      if (prev && (prev.type === 'globstar' || prev.star === true)) {
+        prev.type = 'star';
+        prev.star = true;
+        prev.value += value;
+        prev.output = star;
+        state.backtrack = true;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      let rest = remaining();
+      if (opts.noextglob !== true && /^\([^?]/.test(rest)) {
+        extglobOpen('star', value);
+        continue;
+      }
+
+      if (prev.type === 'star') {
+        if (opts.noglobstar === true) {
+          consume(value);
+          continue;
+        }
+
+        const prior = prev.prev;
+        const before = prior.prev;
+        const isStart = prior.type === 'slash' || prior.type === 'bos';
+        const afterStar = before && (before.type === 'star' || before.type === 'globstar');
+
+        if (opts.bash === true && (!isStart || (rest[0] && rest[0] !== '/'))) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        const isBrace = state.braces > 0 && (prior.type === 'comma' || prior.type === 'brace');
+        const isExtglob = extglobs.length && (prior.type === 'pipe' || prior.type === 'paren');
+        if (!isStart && prior.type !== 'paren' && !isBrace && !isExtglob) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        // strip consecutive `/**/`
+        while (rest.slice(0, 3) === '/**') {
+          const after = input[state.index + 4];
+          if (after && after !== '/') {
+            break;
+          }
+          rest = rest.slice(3);
+          consume('/**', 3);
+        }
+
+        if (prior.type === 'bos' && eos()) {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = globstar(opts);
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && !afterStar && eos()) {
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = globstar(opts) + (opts.strictSlashes ? ')' : '|$)');
+          prev.value += value;
+          state.globstar = true;
+          state.output += prior.output + prev.output;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && rest[0] === '/') {
+          const end = rest[1] !== void 0 ? '|$' : '';
+
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = `${globstar(opts)}${SLASH_LITERAL}|${SLASH_LITERAL}${end})`;
+          prev.value += value;
+
+          state.output += prior.output + prev.output;
+          state.globstar = true;
+
+          consume(value + advance());
+
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        if (prior.type === 'bos' && rest[0] === '/') {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value + advance());
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        // remove single star from output
+        state.output = state.output.slice(0, -prev.output.length);
+
+        // reset previous token to globstar
+        prev.type = 'globstar';
+        prev.output = globstar(opts);
+        prev.value += value;
+
+        // reset output with globstar
+        state.output += prev.output;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      const token = { type: 'star', value, output: star };
+
+      if (opts.bash === true) {
+        token.output = '.*?';
+        if (prev.type === 'bos' || prev.type === 'slash') {
+          token.output = nodot + token.output;
+        }
+        push(token);
+        continue;
+      }
+
+      if (prev && (prev.type === 'bracket' || prev.type === 'paren') && opts.regex === true) {
+        token.output = value;
+        push(token);
+        continue;
+      }
+
+      if (state.index === state.start || prev.type === 'slash' || prev.type === 'dot') {
+        if (prev.type === 'dot') {
+          state.output += NO_DOT_SLASH;
+          prev.output += NO_DOT_SLASH;
+
+        } else if (opts.dot === true) {
+          state.output += NO_DOTS_SLASH;
+          prev.output += NO_DOTS_SLASH;
+
+        } else {
+          state.output += nodot;
+          prev.output += nodot;
+        }
+
+        if (peek() !== '*') {
+          state.output += ONE_CHAR;
+          prev.output += ONE_CHAR;
+        }
+      }
+
+      push(token);
+    }
+
+    while (state.brackets > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ']'));
+      state.output = utils$1.escapeLast(state.output, '[');
+      decrement('brackets');
+    }
+
+    while (state.parens > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ')'));
+      state.output = utils$1.escapeLast(state.output, '(');
+      decrement('parens');
+    }
+
+    while (state.braces > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', '}'));
+      state.output = utils$1.escapeLast(state.output, '{');
+      decrement('braces');
+    }
+
+    if (opts.strictSlashes !== true && (prev.type === 'star' || prev.type === 'bracket')) {
+      push({ type: 'maybe_slash', value: '', output: `${SLASH_LITERAL}?` });
+    }
+
+    // rebuild the output if we had to backtrack at any point
+    if (state.backtrack === true) {
+      state.output = '';
+
+      for (const token of state.tokens) {
+        state.output += token.output != null ? token.output : token.value;
+
+        if (token.suffix) {
+          state.output += token.suffix;
+        }
+      }
+    }
+
+    return state;
+  };
+
+  /**
+   * Fast paths for creating regular expressions for common glob patterns.
+   * This can significantly speed up processing and has very little downside
+   * impact when none of the fast paths match.
+   */
+
+  parse$2.fastpaths = (input, options) => {
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+    const len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    // create constants based on platform, for windows or posix
+    const {
+      DOT_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOTS,
+      NO_DOTS_SLASH,
+      STAR,
+      START_ANCHOR
+    } = constants$2.globChars(opts.windows);
+
+    const nodot = opts.dot ? NO_DOTS : NO_DOT;
+    const slashDot = opts.dot ? NO_DOTS_SLASH : NO_DOT;
+    const capture = opts.capture ? '' : '?:';
+    const state = { negated: false, prefix: '' };
+    let star = opts.bash === true ? '.*?' : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    const globstar = (opts) => {
+      if (opts.noglobstar === true) return star;
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const create = str => {
+      switch (str) {
+        case '*':
+          return `${nodot}${ONE_CHAR}${star}`;
+
+        case '.*':
+          return `${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*.*':
+          return `${nodot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*/*':
+          return `${nodot}${star}${SLASH_LITERAL}${ONE_CHAR}${slashDot}${star}`;
+
+        case '**':
+          return nodot + globstar(opts);
+
+        case '**/*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${ONE_CHAR}${star}`;
+
+        case '**/*.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '**/.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        default: {
+          const match = /^(.*?)\.(\w+)$/.exec(str);
+          if (!match) return;
+
+          const source = create(match[1]);
+          if (!source) return;
+
+          return source + DOT_LITERAL + match[2];
+        }
+      }
+    };
+
+    const output = utils$1.removePrefix(input, state);
+    let source = create(output);
+
+    if (source && opts.strictSlashes !== true) {
+      source += `${SLASH_LITERAL}?`;
+    }
+
+    return source;
+  };
+
+  var parse_1 = parse$2;
+
+  const scan = scan_1;
+  const parse$1 = parse_1;
+  const utils = utils$3;
+  const constants$1 = constants$3;
+  const isObject = val => val && typeof val === 'object' && !Array.isArray(val);
+
+  /**
+   * Creates a matcher function from one or more glob patterns. The
+   * returned function takes a string to match as its first argument,
+   * and returns true if the string is a match. The returned matcher
+   * function also takes a boolean as the second argument that, when true,
+   * returns an object with additional information.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch(glob[, options]);
+   *
+   * const isMatch = picomatch('*.!(*a)');
+   * console.log(isMatch('a.a')); //=> false
+   * console.log(isMatch('a.b')); //=> true
+   * ```
+   * @name picomatch
+   * @param {String|Array} `globs` One or more glob patterns.
+   * @param {Object=} `options`
+   * @return {Function=} Returns a matcher function.
+   * @api public
+   */
+
+  const picomatch = (glob, options, returnState = false) => {
+    if (Array.isArray(glob)) {
+      const fns = glob.map(input => picomatch(input, options, returnState));
+      const arrayMatcher = str => {
+        for (const isMatch of fns) {
+          const state = isMatch(str);
+          if (state) return state;
+        }
+        return false;
+      };
+      return arrayMatcher;
+    }
+
+    const isState = isObject(glob) && glob.tokens && glob.input;
+
+    if (glob === '' || (typeof glob !== 'string' && !isState)) {
+      throw new TypeError('Expected pattern to be a non-empty string');
+    }
+
+    const opts = options || {};
+    const posix = opts.windows;
+    const regex = isState
+      ? picomatch.compileRe(glob, options)
+      : picomatch.makeRe(glob, options, false, true);
+
+    const state = regex.state;
+    delete regex.state;
+
+    let isIgnored = () => false;
+    if (opts.ignore) {
+      const ignoreOpts = { ...options, ignore: null, onMatch: null, onResult: null };
+      isIgnored = picomatch(opts.ignore, ignoreOpts, returnState);
+    }
+
+    const matcher = (input, returnObject = false) => {
+      const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+      const result = { glob, state, regex, posix, input, output, match, isMatch };
+
+      if (typeof opts.onResult === 'function') {
+        opts.onResult(result);
+      }
+
+      if (isMatch === false) {
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (isIgnored(input)) {
+        if (typeof opts.onIgnore === 'function') {
+          opts.onIgnore(result);
+        }
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (typeof opts.onMatch === 'function') {
+        opts.onMatch(result);
+      }
+      return returnObject ? result : true;
+    };
+
+    if (returnState) {
+      matcher.state = state;
+    }
+
+    return matcher;
+  };
+
+  /**
+   * Test `input` with the given `regex`. This is used by the main
+   * `picomatch()` function to test the input string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.test(input, regex[, options]);
+   *
+   * console.log(picomatch.test('foo/bar', /^(?:([^/]*?)\/([^/]*?))$/));
+   * // { isMatch: true, match: [ 'foo/', 'foo', 'bar' ], output: 'foo/bar' }
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp} `regex`
+   * @return {Object} Returns an object with matching info.
+   * @api public
+   */
+
+  picomatch.test = (input, regex, options, { glob, posix } = {}) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected input to be a string');
+    }
+
+    if (input === '') {
+      return { isMatch: false, output: '' };
+    }
+
+    const opts = options || {};
+    const format = opts.format || (posix ? utils.toPosixSlashes : null);
+    let match = input === glob;
+    let output = (match && format) ? format(input) : input;
+
+    if (match === false) {
+      output = format ? format(input) : input;
+      match = output === glob;
+    }
+
+    if (match === false || opts.capture === true) {
+      if (opts.matchBase === true || opts.basename === true) {
+        match = picomatch.matchBase(input, regex, options, posix);
+      } else {
+        match = regex.exec(output);
+      }
+    }
+
+    return { isMatch: Boolean(match), match, output };
+  };
+
+  /**
+   * Match the basename of a filepath.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.matchBase(input, glob[, options]);
+   * console.log(picomatch.matchBase('foo/bar.js', '*.js'); // true
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp|String} `glob` Glob pattern or regex created by [.makeRe](#makeRe).
+   * @return {Boolean}
+   * @api public
+   */
+
+  picomatch.matchBase = (input, glob, options) => {
+    const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
+    return regex.test(utils.basename(input));
+  };
+
+  /**
+   * Returns true if **any** of the given glob `patterns` match the specified `string`.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.isMatch(string, patterns[, options]);
+   *
+   * console.log(picomatch.isMatch('a.a', ['b.*', '*.a'])); //=> true
+   * console.log(picomatch.isMatch('a.a', 'b.*')); //=> false
+   * ```
+   * @param {String|Array} str The string to test.
+   * @param {String|Array} patterns One or more glob patterns to use for matching.
+   * @param {Object} [options] See available [options](#options).
+   * @return {Boolean} Returns true if any patterns match `str`
+   * @api public
+   */
+
+  picomatch.isMatch = (str, patterns, options) => picomatch(patterns, options)(str);
+
+  /**
+   * Parse a glob pattern to create the source string for a regular
+   * expression.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const result = picomatch.parse(pattern[, options]);
+   * ```
+   * @param {String} `pattern`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with useful properties and output to be used as a regex source string.
+   * @api public
+   */
+
+  picomatch.parse = (pattern, options) => {
+    if (Array.isArray(pattern)) return pattern.map(p => picomatch.parse(p, options));
+    return parse$1(pattern, { ...options, fastpaths: false });
+  };
+
+  /**
+   * Scan a glob pattern to separate the pattern into segments.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.scan(input[, options]);
+   *
+   * const result = picomatch.scan('!./foo/*.js');
+   * console.log(result);
+   * { prefix: '!./',
+   *   input: '!./foo/*.js',
+   *   start: 3,
+   *   base: 'foo',
+   *   glob: '*.js',
+   *   isBrace: false,
+   *   isBracket: false,
+   *   isGlob: true,
+   *   isExtglob: false,
+   *   isGlobstar: false,
+   *   negated: true }
+   * ```
+   * @param {String} `input` Glob pattern to scan.
+   * @param {Object} `options`
+   * @return {Object} Returns an object with
+   * @api public
+   */
+
+  picomatch.scan = (input, options) => scan(input, options);
+
+  /**
+   * Create a regular expression from a parsed glob pattern.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const state = picomatch.parse('*.js');
+   * // picomatch.compileRe(state[, options]);
+   *
+   * console.log(picomatch.compileRe(state));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `state` The object returned from the `.parse` method.
+   * @param {Object} `options`
+   * @return {RegExp} Returns a regex created from the given pattern.
+   * @api public
+   */
+
+  picomatch.compileRe = (parsed, options, returnOutput = false, returnState = false) => {
+    if (returnOutput === true) {
+      return parsed.output;
+    }
+
+    const opts = options || {};
+    const prepend = opts.contains ? '' : '^';
+    const append = opts.contains ? '' : '$';
+
+    let source = `${prepend}(?:${parsed.output})${append}`;
+    if (parsed && parsed.negated === true) {
+      source = `^(?!${source}).*$`;
+    }
+
+    const regex = picomatch.toRegex(source, options);
+    if (returnState === true) {
+      regex.state = parsed;
+    }
+
+    return regex;
+  };
+
+  picomatch.makeRe = (input, options, returnOutput = false, returnState = false) => {
+    if (!input || typeof input !== 'string') {
+      throw new TypeError('Expected a non-empty string');
+    }
+
+    const opts = options || {};
+    let parsed = { negated: false, fastpaths: true };
+    let prefix = '';
+    let output;
+
+    if (input.startsWith('./')) {
+      input = input.slice(2);
+      prefix = parsed.prefix = './';
+    }
+
+    if (opts.fastpaths !== false && (input[0] === '.' || input[0] === '*')) {
+      output = parse$1.fastpaths(input, options);
+    }
+
+    if (output === undefined) {
+      parsed = parse$1(input, options);
+      parsed.prefix = prefix + (parsed.prefix || '');
+    } else {
+      parsed.output = output;
+    }
+
+    return picomatch.compileRe(parsed, options, returnOutput, returnState);
+  };
+
+  /**
+   * Create a regular expression from the given regex source string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.toRegex(source[, options]);
+   *
+   * const { output } = picomatch.parse('*.js');
+   * console.log(picomatch.toRegex(output));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `source` Regular expression source string.
+   * @param {Object} `options`
+   * @return {RegExp}
+   * @api public
+   */
+
+  picomatch.toRegex = (source, options) => {
+    try {
+      const opts = options || {};
+      return new RegExp(source, opts.flags || (opts.nocase ? 'i' : ''));
+    } catch (err) {
+      if (options && options.debug === true) throw err;
+      return /$^/;
+    }
+  };
+
+  /**
+   * Picomatch constants.
+   * @return {Object}
+   */
+
+  picomatch.constants = constants$1;
+
+  /**
+   * Expose "picomatch"
+   */
+
+  var picomatch_1 = picomatch;
+
+  var picomatchBrowser = picomatch_1;
+
+  var pm = /*@__PURE__*/getDefaultExportFromCjs(picomatchBrowser);
+
+  function isArray(arg) {
+      return Array.isArray(arg);
+  }
+  function ensureArray(thing) {
+      if (isArray(thing))
+          return thing;
+      if (thing == null)
+          return [];
+      return [thing];
+  }
+  const globToTest = (glob) => {
+      const pattern = glob;
+      const fn = pm(pattern, { dot: true });
+      return {
+          test: (what) => {
+              const result = fn(what);
+              return result;
+          },
+      };
+  };
+  const testTrue = {
+      test: () => true,
+  };
+  const getMatcher = (filter) => {
+      const bundleTest = "bundle" in filter && filter.bundle != null ? globToTest(filter.bundle) : testTrue;
+      const fileTest = "file" in filter && filter.file != null ? globToTest(filter.file) : testTrue;
+      return { bundleTest, fileTest };
+  };
+  const createFilter = (include, exclude) => {
+      const includeMatchers = ensureArray(include).map(getMatcher);
+      const excludeMatchers = ensureArray(exclude).map(getMatcher);
+      return (bundleId, id) => {
+          for (let i = 0; i < excludeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = excludeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return false;
+          }
+          for (let i = 0; i < includeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = includeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return true;
+          }
+          return !includeMatchers.length;
+      };
+  };
+
+  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      return (val) => {
+          if (!waiting) {
+              callback(val);
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+              }, limit);
+          }
+      };
+  };
+  const prepareFilter = (filt) => {
+      if (filt === "")
+          return [];
+      return (filt
+          .split(",")
+          // remove spaces before and after
+          .map((entry) => entry.trim())
+          // unquote "
+          .map((entry) => entry.startsWith('"') && entry.endsWith('"') ? entry.substring(1, entry.length - 1) : entry)
+          // unquote '
+          .map((entry) => entry.startsWith("'") && entry.endsWith("'") ? entry.substring(1, entry.length - 1) : entry)
+          // remove empty strings
+          .filter((entry) => entry)
+          // parse bundle:file
+          .map((entry) => entry.split(":"))
+          // normalize entry just in case
+          .flatMap((entry) => {
+          if (entry.length === 0)
+              return [];
+          let bundle = null;
+          let file = null;
+          if (entry.length === 1 && entry[0]) {
+              file = entry[0];
+              return [{ file, bundle }];
+          }
+          bundle = entry[0] || null;
+          file = entry.slice(1).join(":") || null;
+          return [{ bundle, file }];
+      }));
+  };
+  const useFilter = () => {
+      const [includeFilter, setIncludeFilter] = h("");
+      const [excludeFilter, setExcludeFilter] = h("");
+      const setIncludeFilterTrottled = F(() => throttleFilter(setIncludeFilter, 200), []);
+      const setExcludeFilterTrottled = F(() => throttleFilter(setExcludeFilter, 200), []);
+      const isIncluded = F(() => createFilter(prepareFilter(includeFilter), prepareFilter(excludeFilter)), [includeFilter, excludeFilter]);
+      const getModuleFilterMultiplier = T((bundleId, data) => {
+          return isIncluded(bundleId, data.id) ? 1 : 0;
+      }, [isIncluded]);
+      return {
+          getModuleFilterMultiplier,
+          includeFilter,
+          excludeFilter,
+          setExcludeFilter: setExcludeFilterTrottled,
+          setIncludeFilter: setIncludeFilterTrottled,
+      };
+  };
+
+  function ascending(a, b) {
+    return a == null || b == null ? NaN : a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
+  }
+
+  function descending(a, b) {
+    return a == null || b == null ? NaN
+      : b < a ? -1
+      : b > a ? 1
+      : b >= a ? 0
+      : NaN;
+  }
+
+  function bisector(f) {
+    let compare1, compare2, delta;
+
+    // If an accessor is specified, promote it to a comparator. In this case we
+    // can test whether the search value is (self-) comparable. We can’t do this
+    // for a comparator (except for specific, known comparators) because we can’t
+    // tell if the comparator is symmetric, and an asymmetric comparator can’t be
+    // used to test whether a single value is comparable.
+    if (f.length !== 2) {
+      compare1 = ascending;
+      compare2 = (d, x) => ascending(f(d), x);
+      delta = (d, x) => f(d) - x;
+    } else {
+      compare1 = f === ascending || f === descending ? f : zero$1;
+      compare2 = f;
+      delta = f;
+    }
+
+    function left(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) < 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function right(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) <= 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function center(a, x, lo = 0, hi = a.length) {
+      const i = left(a, x, lo, hi - 1);
+      return i > lo && delta(a[i - 1], x) > -delta(a[i], x) ? i - 1 : i;
+    }
+
+    return {left, center, right};
+  }
+
+  function zero$1() {
+    return 0;
+  }
+
+  function number$1(x) {
+    return x === null ? NaN : +x;
+  }
+
+  const ascendingBisect = bisector(ascending);
+  const bisectRight = ascendingBisect.right;
+  bisector(number$1).center;
+  var bisect = bisectRight;
+
+  class InternMap extends Map {
+    constructor(entries, key = keyof) {
+      super();
+      Object.defineProperties(this, {_intern: {value: new Map()}, _key: {value: key}});
+      if (entries != null) for (const [key, value] of entries) this.set(key, value);
+    }
+    get(key) {
+      return super.get(intern_get(this, key));
+    }
+    has(key) {
+      return super.has(intern_get(this, key));
+    }
+    set(key, value) {
+      return super.set(intern_set(this, key), value);
+    }
+    delete(key) {
+      return super.delete(intern_delete(this, key));
+    }
+  }
+
+  function intern_get({_intern, _key}, value) {
+    const key = _key(value);
+    return _intern.has(key) ? _intern.get(key) : value;
+  }
+
+  function intern_set({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) return _intern.get(key);
+    _intern.set(key, value);
+    return value;
+  }
+
+  function intern_delete({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) {
+      value = _intern.get(key);
+      _intern.delete(key);
+    }
+    return value;
+  }
+
+  function keyof(value) {
+    return value !== null && typeof value === "object" ? value.valueOf() : value;
+  }
+
+  function identity$2(x) {
+    return x;
+  }
+
+  function group(values, ...keys) {
+    return nest(values, identity$2, identity$2, keys);
+  }
+
+  function nest(values, map, reduce, keys) {
+    return (function regroup(values, i) {
+      if (i >= keys.length) return reduce(values);
+      const groups = new InternMap();
+      const keyof = keys[i++];
+      let index = -1;
+      for (const value of values) {
+        const key = keyof(value, ++index, values);
+        const group = groups.get(key);
+        if (group) group.push(value);
+        else groups.set(key, [value]);
+      }
+      for (const [key, values] of groups) {
+        groups.set(key, regroup(values, i));
+      }
+      return map(groups);
+    })(values, 0);
+  }
+
+  const e10 = Math.sqrt(50),
+      e5 = Math.sqrt(10),
+      e2 = Math.sqrt(2);
+
+  function tickSpec(start, stop, count) {
+    const step = (stop - start) / Math.max(0, count),
+        power = Math.floor(Math.log10(step)),
+        error = step / Math.pow(10, power),
+        factor = error >= e10 ? 10 : error >= e5 ? 5 : error >= e2 ? 2 : 1;
+    let i1, i2, inc;
+    if (power < 0) {
+      inc = Math.pow(10, -power) / factor;
+      i1 = Math.round(start * inc);
+      i2 = Math.round(stop * inc);
+      if (i1 / inc < start) ++i1;
+      if (i2 / inc > stop) --i2;
+      inc = -inc;
+    } else {
+      inc = Math.pow(10, power) * factor;
+      i1 = Math.round(start / inc);
+      i2 = Math.round(stop / inc);
+      if (i1 * inc < start) ++i1;
+      if (i2 * inc > stop) --i2;
+    }
+    if (i2 < i1 && 0.5 <= count && count < 2) return tickSpec(start, stop, count * 2);
+    return [i1, i2, inc];
+  }
+
+  function ticks(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    if (!(count > 0)) return [];
+    if (start === stop) return [start];
+    const reverse = stop < start, [i1, i2, inc] = reverse ? tickSpec(stop, start, count) : tickSpec(start, stop, count);
+    if (!(i2 >= i1)) return [];
+    const n = i2 - i1 + 1, ticks = new Array(n);
+    if (reverse) {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) * inc;
+    } else {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) * inc;
+    }
+    return ticks;
+  }
+
+  function tickIncrement(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    return tickSpec(start, stop, count)[2];
+  }
+
+  function tickStep(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    const reverse = stop < start, inc = reverse ? tickIncrement(stop, start, count) : tickIncrement(start, stop, count);
+    return (reverse ? -1 : 1) * (inc < 0 ? 1 / -inc : inc);
+  }
+
+  const TOP_PADDING = 20;
+  const PADDING = 2;
+
+  const Node = ({ node, onMouseOver, onClick, selected }) => {
+      const { getModuleColor } = q(StaticContext);
+      const { backgroundColor, fontColor } = getModuleColor(node);
+      const { x0, x1, y1, y0, data, children = null } = node;
+      const textRef = _(null);
+      const textRectRef = _();
+      const width = x1 - x0;
+      const height = y1 - y0;
+      const textProps = {
+          "font-size": "0.7em",
+          "dominant-baseline": "middle",
+          "text-anchor": "middle",
+          x: width / 2,
+      };
+      if (children != null) {
+          textProps.y = (TOP_PADDING + PADDING) / 2;
+      }
+      else {
+          textProps.y = height / 2;
+      }
+      y(() => {
+          if (width == 0 || height == 0 || !textRef.current) {
+              return;
+          }
+          if (textRectRef.current == null) {
+              textRectRef.current = textRef.current.getBoundingClientRect();
+          }
+          let scale = 1;
+          if (children != null) {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, Math.min(height, TOP_PADDING + PADDING) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(Math.min(TOP_PADDING + PADDING, height) / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          else {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, (height * 0.9) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(height / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          textRef.current.setAttribute("transform", `scale(${scale.toFixed(2)})`);
+      }, [children, height, width]);
+      if (width == 0 || height == 0) {
+          return null;
+      }
+      return (o$1("g", { className: "node", transform: `translate(${x0},${y0})`, onClick: (event) => {
+              event.stopPropagation();
+              onClick(node);
+          }, onMouseOver: (event) => {
+              event.stopPropagation();
+              onMouseOver(node);
+          }, children: [o$1("rect", { fill: backgroundColor, rx: 2, ry: 2, width: x1 - x0, height: y1 - y0, stroke: selected ? "#fff" : undefined, "stroke-width": selected ? 2 : undefined }), o$1("text", Object.assign({ ref: textRef, fill: fontColor, onClick: (event) => {
+                      var _a;
+                      if (((_a = window.getSelection()) === null || _a === void 0 ? void 0 : _a.toString()) !== "") {
+                          event.stopPropagation();
+                      }
+                  } }, textProps, { children: data.name }))] }));
+  };
+
+  const TreeMap = ({ root, onNodeHover, selectedNode, onNodeClick, }) => {
+      const { width, height, getModuleIds } = q(StaticContext);
+      console.time("layering");
+      // this will make groups by height
+      const nestedData = F(() => {
+          const nestedDataMap = group(root.descendants(), (d) => d.height);
+          const nestedData = Array.from(nestedDataMap, ([key, values]) => ({
+              key,
+              values,
+          }));
+          nestedData.sort((a, b) => b.key - a.key);
+          return nestedData;
+      }, [root]);
+      console.timeEnd("layering");
+      return (o$1("svg", { xmlns: "http://www.w3.org/2000/svg", viewBox: `0 0 ${width} ${height}`, children: nestedData.map(({ key, values }) => {
+              return (o$1("g", { className: "layer", children: values.map((node) => {
+                      return (o$1(Node, { node: node, onMouseOver: onNodeHover, selected: selectedNode === node, onClick: onNodeClick }, getModuleIds(node.data).nodeUid.id));
+                  }) }, key));
+          }) }));
+  };
+
+  var bytes$1 = {exports: {}};
+
+  /*!
+   * bytes
+   * Copyright(c) 2012-2014 TJ Holowaychuk
+   * Copyright(c) 2015 Jed Watson
+   * MIT Licensed
+   */
+
+  /**
+   * Module exports.
+   * @public
+   */
+
+  bytes$1.exports = bytes;
+  var format_1 = bytes$1.exports.format = format$1;
+  bytes$1.exports.parse = parse;
+
+  /**
+   * Module variables.
+   * @private
+   */
+
+  var formatThousandsRegExp = /\B(?=(\d{3})+(?!\d))/g;
+
+  var formatDecimalsRegExp = /(?:\.0*|(\.[^0]+)0+)$/;
+
+  var map$1 = {
+    b:  1,
+    kb: 1 << 10,
+    mb: 1 << 20,
+    gb: 1 << 30,
+    tb: Math.pow(1024, 4),
+    pb: Math.pow(1024, 5),
+  };
+
+  var parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
+
+  /**
+   * Convert the given value in bytes into a string or parse to string to an integer in bytes.
+   *
+   * @param {string|number} value
+   * @param {{
+   *  case: [string],
+   *  decimalPlaces: [number]
+   *  fixedDecimals: [boolean]
+   *  thousandsSeparator: [string]
+   *  unitSeparator: [string]
+   *  }} [options] bytes options.
+   *
+   * @returns {string|number|null}
+   */
+
+  function bytes(value, options) {
+    if (typeof value === 'string') {
+      return parse(value);
+    }
+
+    if (typeof value === 'number') {
+      return format$1(value, options);
+    }
+
+    return null;
+  }
+
+  /**
+   * Format the given value in bytes into a string.
+   *
+   * If the value is negative, it is kept as such. If it is a float,
+   * it is rounded.
+   *
+   * @param {number} value
+   * @param {object} [options]
+   * @param {number} [options.decimalPlaces=2]
+   * @param {number} [options.fixedDecimals=false]
+   * @param {string} [options.thousandsSeparator=]
+   * @param {string} [options.unit=]
+   * @param {string} [options.unitSeparator=]
+   *
+   * @returns {string|null}
+   * @public
+   */
+
+  function format$1(value, options) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    var mag = Math.abs(value);
+    var thousandsSeparator = (options && options.thousandsSeparator) || '';
+    var unitSeparator = (options && options.unitSeparator) || '';
+    var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
+    var fixedDecimals = Boolean(options && options.fixedDecimals);
+    var unit = (options && options.unit) || '';
+
+    if (!unit || !map$1[unit.toLowerCase()]) {
+      if (mag >= map$1.pb) {
+        unit = 'PB';
+      } else if (mag >= map$1.tb) {
+        unit = 'TB';
+      } else if (mag >= map$1.gb) {
+        unit = 'GB';
+      } else if (mag >= map$1.mb) {
+        unit = 'MB';
+      } else if (mag >= map$1.kb) {
+        unit = 'KB';
+      } else {
+        unit = 'B';
+      }
+    }
+
+    var val = value / map$1[unit.toLowerCase()];
+    var str = val.toFixed(decimalPlaces);
+
+    if (!fixedDecimals) {
+      str = str.replace(formatDecimalsRegExp, '$1');
+    }
+
+    if (thousandsSeparator) {
+      str = str.split('.').map(function (s, i) {
+        return i === 0
+          ? s.replace(formatThousandsRegExp, thousandsSeparator)
+          : s
+      }).join('.');
+    }
+
+    return str + unitSeparator + unit;
+  }
+
+  /**
+   * Parse the string value into an integer in bytes.
+   *
+   * If no unit is given, it is assumed the value is in bytes.
+   *
+   * @param {number|string} val
+   *
+   * @returns {number|null}
+   * @public
+   */
+
+  function parse(val) {
+    if (typeof val === 'number' && !isNaN(val)) {
+      return val;
+    }
+
+    if (typeof val !== 'string') {
+      return null;
+    }
+
+    // Test if the string passed is valid
+    var results = parseRegExp.exec(val);
+    var floatValue;
+    var unit = 'b';
+
+    if (!results) {
+      // Nothing could be extracted from the given string
+      floatValue = parseInt(val, 10);
+      unit = 'b';
+    } else {
+      // Retrieve the value and the unit
+      floatValue = parseFloat(results[1]);
+      unit = results[4].toLowerCase();
+    }
+
+    if (isNaN(floatValue)) {
+      return null;
+    }
+
+    return Math.floor(map$1[unit] * floatValue);
+  }
+
+  const Tooltip_marginX = 10;
+  const Tooltip_marginY = 30;
+  const SOURCEMAP_RENDERED = (o$1("span", { children: [" ", o$1("b", { children: LABELS.renderedLength }), " is a number of characters in the file after individual and ", o$1("br", {}), " ", "whole bundle transformations according to sourcemap."] }));
+  const RENDRED = (o$1("span", { children: [o$1("b", { children: LABELS.renderedLength }), " is a byte size of individual file after transformations and treeshake."] }));
+  const COMPRESSED = (o$1("span", { children: [o$1("b", { children: LABELS.gzipLength }), " and ", o$1("b", { children: LABELS.brotliLength }), " is a byte size of individual file after individual transformations,", o$1("br", {}), " treeshake and compression."] }));
+  const Tooltip = ({ node, visible, root, sizeProperty, }) => {
+      const { availableSizeProperties, getModuleSize, data } = q(StaticContext);
+      const ref = _(null);
+      const [style, setStyle] = h({});
+      const content = F(() => {
+          if (!node)
+              return null;
+          const mainSize = getModuleSize(node.data, sizeProperty);
+          const percentageNum = (100 * mainSize) / getModuleSize(root.data, sizeProperty);
+          const percentage = percentageNum.toFixed(2);
+          const percentageString = percentage + "%";
+          const path = node
+              .ancestors()
+              .reverse()
+              .map((d) => d.data.name)
+              .join("/");
+          let dataNode = null;
+          if (!isModuleTree(node.data)) {
+              const mainUid = data.nodeParts[node.data.uid].metaUid;
+              dataNode = data.nodeMetas[mainUid];
+          }
+          return (o$1(k$1, { children: [o$1("div", { children: path }), availableSizeProperties.map((sizeProp) => {
+                      if (sizeProp === sizeProperty) {
+                          return (o$1("div", { children: [o$1("b", { children: [LABELS[sizeProp], ": ", format_1(mainSize)] }), " ", "(", percentageString, ")"] }, sizeProp));
+                      }
+                      else {
+                          return (o$1("div", { children: [LABELS[sizeProp], ": ", format_1(getModuleSize(node.data, sizeProp))] }, sizeProp));
+                      }
+                  }), o$1("br", {}), dataNode && dataNode.importedBy.length > 0 && (o$1("div", { children: [o$1("div", { children: [o$1("b", { children: "Imported By" }), ":"] }), dataNode.importedBy.map(({ uid }) => {
+                              const id = data.nodeMetas[uid].id;
+                              return o$1("div", { children: id }, id);
+                          })] })), o$1("br", {}), o$1("small", { children: data.options.sourcemap ? SOURCEMAP_RENDERED : RENDRED }), (data.options.gzip || data.options.brotli) && (o$1(k$1, { children: [o$1("br", {}), o$1("small", { children: COMPRESSED })] }))] }));
+      }, [availableSizeProperties, data, getModuleSize, node, root.data, sizeProperty]);
+      const updatePosition = (mouseCoords) => {
+          if (!ref.current)
+              return;
+          const pos = {
+              left: mouseCoords.x + Tooltip_marginX,
+              top: mouseCoords.y + Tooltip_marginY,
+          };
+          const boundingRect = ref.current.getBoundingClientRect();
+          if (pos.left + boundingRect.width > window.innerWidth) {
+              // Shifting horizontally
+              pos.left = window.innerWidth - boundingRect.width;
+          }
+          if (pos.top + boundingRect.height > window.innerHeight) {
+              // Flipping vertically
+              pos.top = mouseCoords.y - Tooltip_marginY - boundingRect.height;
+          }
+          setStyle(pos);
+      };
+      p(() => {
+          const handleMouseMove = (event) => {
+              updatePosition({
+                  x: event.pageX,
+                  y: event.pageY,
+              });
+          };
+          document.addEventListener("mousemove", handleMouseMove, true);
+          return () => {
+              document.removeEventListener("mousemove", handleMouseMove, true);
+          };
+      }, []);
+      return (o$1("div", { className: `tooltip ${visible ? "" : "tooltip-hidden"}`, ref: ref, style: style, children: content }));
+  };
+
+  const Chart = ({ root, sizeProperty, selectedNode, setSelectedNode, }) => {
+      const [showTooltip, setShowTooltip] = h(false);
+      const [tooltipNode, setTooltipNode] = h(undefined);
+      p(() => {
+          const handleMouseOut = () => {
+              setShowTooltip(false);
+          };
+          document.addEventListener("mouseover", handleMouseOut);
+          return () => {
+              document.removeEventListener("mouseover", handleMouseOut);
+          };
+      }, []);
+      return (o$1(k$1, { children: [o$1(TreeMap, { root: root, onNodeHover: (node) => {
+                      setTooltipNode(node);
+                      setShowTooltip(true);
+                  }, selectedNode: selectedNode, onNodeClick: (node) => {
+                      setSelectedNode(selectedNode === node ? undefined : node);
+                  } }), o$1(Tooltip, { visible: showTooltip, node: tooltipNode, root: root, sizeProperty: sizeProperty })] }));
+  };
+
+  const Main = () => {
+      const { availableSizeProperties, rawHierarchy, getModuleSize, layout, data } = q(StaticContext);
+      const [sizeProperty, setSizeProperty] = h(availableSizeProperties[0]);
+      const [selectedNode, setSelectedNode] = h(undefined);
+      const { getModuleFilterMultiplier, setExcludeFilter, setIncludeFilter } = useFilter();
+      console.time("getNodeSizeMultiplier");
+      const getNodeSizeMultiplier = F(() => {
+          const selectedMultiplier = 1; // selectedSize < rootSize * increaseFactor ? (rootSize * increaseFactor) / selectedSize : rootSize / selectedSize;
+          const nonSelectedMultiplier = 0; // 1 / selectedMultiplier
+          if (selectedNode === undefined) {
+              return () => 1;
+          }
+          else if (isModuleTree(selectedNode.data)) {
+              const leaves = new Set(selectedNode.leaves().map((d) => d.data));
+              return (node) => {
+                  if (leaves.has(node)) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+          else {
+              return (node) => {
+                  if (node === selectedNode.data) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+      }, [getModuleSize, rawHierarchy.data, selectedNode, sizeProperty]);
+      console.timeEnd("getNodeSizeMultiplier");
+      console.time("root hierarchy compute");
+      // root here always be the same as rawHierarchy even after layouting
+      const root = F(() => {
+          const rootWithSizesAndSorted = rawHierarchy
+              .sum((node) => {
+              var _a;
+              if (isModuleTree(node))
+                  return 0;
+              const meta = data.nodeMetas[data.nodeParts[node.uid].metaUid];
+              const bundleId = (_a = Object.entries(meta.moduleParts).find(([bundleId, uid]) => uid == node.uid)) === null || _a === void 0 ? void 0 : _a[0];
+              const ownSize = getModuleSize(node, sizeProperty);
+              const zoomMultiplier = getNodeSizeMultiplier(node);
+              const filterMultiplier = getModuleFilterMultiplier(bundleId, meta);
+              return ownSize * zoomMultiplier * filterMultiplier;
+          })
+              .sort((a, b) => getModuleSize(a.data, sizeProperty) - getModuleSize(b.data, sizeProperty));
+          return layout(rootWithSizesAndSorted);
+      }, [
+          data,
+          getModuleFilterMultiplier,
+          getModuleSize,
+          getNodeSizeMultiplier,
+          layout,
+          rawHierarchy,
+          sizeProperty,
+      ]);
+      console.timeEnd("root hierarchy compute");
+      return (o$1(k$1, { children: [o$1(SideBar, { sizeProperty: sizeProperty, availableSizeProperties: availableSizeProperties, setSizeProperty: setSizeProperty, onExcludeChange: setExcludeFilter, onIncludeChange: setIncludeFilter }), o$1(Chart, { root: root, sizeProperty: sizeProperty, selectedNode: selectedNode, setSelectedNode: setSelectedNode })] }));
+  };
+
+  function initRange(domain, range) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: this.range(domain); break;
+      default: this.range(range).domain(domain); break;
+    }
+    return this;
+  }
+
+  function initInterpolator(domain, interpolator) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: {
+        if (typeof domain === "function") this.interpolator(domain);
+        else this.range(domain);
+        break;
+      }
+      default: {
+        this.domain(domain);
+        if (typeof interpolator === "function") this.interpolator(interpolator);
+        else this.range(interpolator);
+        break;
+      }
+    }
+    return this;
+  }
+
+  function define(constructor, factory, prototype) {
+    constructor.prototype = factory.prototype = prototype;
+    prototype.constructor = constructor;
+  }
+
+  function extend(parent, definition) {
+    var prototype = Object.create(parent.prototype);
+    for (var key in definition) prototype[key] = definition[key];
+    return prototype;
+  }
+
+  function Color() {}
+
+  var darker = 0.7;
+  var brighter = 1 / darker;
+
+  var reI = "\\s*([+-]?\\d+)\\s*",
+      reN = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*",
+      reP = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*",
+      reHex = /^#([0-9a-f]{3,8})$/,
+      reRgbInteger = new RegExp(`^rgb\\(${reI},${reI},${reI}\\)$`),
+      reRgbPercent = new RegExp(`^rgb\\(${reP},${reP},${reP}\\)$`),
+      reRgbaInteger = new RegExp(`^rgba\\(${reI},${reI},${reI},${reN}\\)$`),
+      reRgbaPercent = new RegExp(`^rgba\\(${reP},${reP},${reP},${reN}\\)$`),
+      reHslPercent = new RegExp(`^hsl\\(${reN},${reP},${reP}\\)$`),
+      reHslaPercent = new RegExp(`^hsla\\(${reN},${reP},${reP},${reN}\\)$`);
+
+  var named = {
+    aliceblue: 0xf0f8ff,
+    antiquewhite: 0xfaebd7,
+    aqua: 0x00ffff,
+    aquamarine: 0x7fffd4,
+    azure: 0xf0ffff,
+    beige: 0xf5f5dc,
+    bisque: 0xffe4c4,
+    black: 0x000000,
+    blanchedalmond: 0xffebcd,
+    blue: 0x0000ff,
+    blueviolet: 0x8a2be2,
+    brown: 0xa52a2a,
+    burlywood: 0xdeb887,
+    cadetblue: 0x5f9ea0,
+    chartreuse: 0x7fff00,
+    chocolate: 0xd2691e,
+    coral: 0xff7f50,
+    cornflowerblue: 0x6495ed,
+    cornsilk: 0xfff8dc,
+    crimson: 0xdc143c,
+    cyan: 0x00ffff,
+    darkblue: 0x00008b,
+    darkcyan: 0x008b8b,
+    darkgoldenrod: 0xb8860b,
+    darkgray: 0xa9a9a9,
+    darkgreen: 0x006400,
+    darkgrey: 0xa9a9a9,
+    darkkhaki: 0xbdb76b,
+    darkmagenta: 0x8b008b,
+    darkolivegreen: 0x556b2f,
+    darkorange: 0xff8c00,
+    darkorchid: 0x9932cc,
+    darkred: 0x8b0000,
+    darksalmon: 0xe9967a,
+    darkseagreen: 0x8fbc8f,
+    darkslateblue: 0x483d8b,
+    darkslategray: 0x2f4f4f,
+    darkslategrey: 0x2f4f4f,
+    darkturquoise: 0x00ced1,
+    darkviolet: 0x9400d3,
+    deeppink: 0xff1493,
+    deepskyblue: 0x00bfff,
+    dimgray: 0x696969,
+    dimgrey: 0x696969,
+    dodgerblue: 0x1e90ff,
+    firebrick: 0xb22222,
+    floralwhite: 0xfffaf0,
+    forestgreen: 0x228b22,
+    fuchsia: 0xff00ff,
+    gainsboro: 0xdcdcdc,
+    ghostwhite: 0xf8f8ff,
+    gold: 0xffd700,
+    goldenrod: 0xdaa520,
+    gray: 0x808080,
+    green: 0x008000,
+    greenyellow: 0xadff2f,
+    grey: 0x808080,
+    honeydew: 0xf0fff0,
+    hotpink: 0xff69b4,
+    indianred: 0xcd5c5c,
+    indigo: 0x4b0082,
+    ivory: 0xfffff0,
+    khaki: 0xf0e68c,
+    lavender: 0xe6e6fa,
+    lavenderblush: 0xfff0f5,
+    lawngreen: 0x7cfc00,
+    lemonchiffon: 0xfffacd,
+    lightblue: 0xadd8e6,
+    lightcoral: 0xf08080,
+    lightcyan: 0xe0ffff,
+    lightgoldenrodyellow: 0xfafad2,
+    lightgray: 0xd3d3d3,
+    lightgreen: 0x90ee90,
+    lightgrey: 0xd3d3d3,
+    lightpink: 0xffb6c1,
+    lightsalmon: 0xffa07a,
+    lightseagreen: 0x20b2aa,
+    lightskyblue: 0x87cefa,
+    lightslategray: 0x778899,
+    lightslategrey: 0x778899,
+    lightsteelblue: 0xb0c4de,
+    lightyellow: 0xffffe0,
+    lime: 0x00ff00,
+    limegreen: 0x32cd32,
+    linen: 0xfaf0e6,
+    magenta: 0xff00ff,
+    maroon: 0x800000,
+    mediumaquamarine: 0x66cdaa,
+    mediumblue: 0x0000cd,
+    mediumorchid: 0xba55d3,
+    mediumpurple: 0x9370db,
+    mediumseagreen: 0x3cb371,
+    mediumslateblue: 0x7b68ee,
+    mediumspringgreen: 0x00fa9a,
+    mediumturquoise: 0x48d1cc,
+    mediumvioletred: 0xc71585,
+    midnightblue: 0x191970,
+    mintcream: 0xf5fffa,
+    mistyrose: 0xffe4e1,
+    moccasin: 0xffe4b5,
+    navajowhite: 0xffdead,
+    navy: 0x000080,
+    oldlace: 0xfdf5e6,
+    olive: 0x808000,
+    olivedrab: 0x6b8e23,
+    orange: 0xffa500,
+    orangered: 0xff4500,
+    orchid: 0xda70d6,
+    palegoldenrod: 0xeee8aa,
+    palegreen: 0x98fb98,
+    paleturquoise: 0xafeeee,
+    palevioletred: 0xdb7093,
+    papayawhip: 0xffefd5,
+    peachpuff: 0xffdab9,
+    peru: 0xcd853f,
+    pink: 0xffc0cb,
+    plum: 0xdda0dd,
+    powderblue: 0xb0e0e6,
+    purple: 0x800080,
+    rebeccapurple: 0x663399,
+    red: 0xff0000,
+    rosybrown: 0xbc8f8f,
+    royalblue: 0x4169e1,
+    saddlebrown: 0x8b4513,
+    salmon: 0xfa8072,
+    sandybrown: 0xf4a460,
+    seagreen: 0x2e8b57,
+    seashell: 0xfff5ee,
+    sienna: 0xa0522d,
+    silver: 0xc0c0c0,
+    skyblue: 0x87ceeb,
+    slateblue: 0x6a5acd,
+    slategray: 0x708090,
+    slategrey: 0x708090,
+    snow: 0xfffafa,
+    springgreen: 0x00ff7f,
+    steelblue: 0x4682b4,
+    tan: 0xd2b48c,
+    teal: 0x008080,
+    thistle: 0xd8bfd8,
+    tomato: 0xff6347,
+    turquoise: 0x40e0d0,
+    violet: 0xee82ee,
+    wheat: 0xf5deb3,
+    white: 0xffffff,
+    whitesmoke: 0xf5f5f5,
+    yellow: 0xffff00,
+    yellowgreen: 0x9acd32
+  };
+
+  define(Color, color, {
+    copy(channels) {
+      return Object.assign(new this.constructor, this, channels);
+    },
+    displayable() {
+      return this.rgb().displayable();
+    },
+    hex: color_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: color_formatHex,
+    formatHex8: color_formatHex8,
+    formatHsl: color_formatHsl,
+    formatRgb: color_formatRgb,
+    toString: color_formatRgb
+  });
+
+  function color_formatHex() {
+    return this.rgb().formatHex();
+  }
+
+  function color_formatHex8() {
+    return this.rgb().formatHex8();
+  }
+
+  function color_formatHsl() {
+    return hslConvert(this).formatHsl();
+  }
+
+  function color_formatRgb() {
+    return this.rgb().formatRgb();
+  }
+
+  function color(format) {
+    var m, l;
+    format = (format + "").trim().toLowerCase();
+    return (m = reHex.exec(format)) ? (l = m[1].length, m = parseInt(m[1], 16), l === 6 ? rgbn(m) // #ff0000
+        : l === 3 ? new Rgb((m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), ((m & 0xf) << 4) | (m & 0xf), 1) // #f00
+        : l === 8 ? rgba(m >> 24 & 0xff, m >> 16 & 0xff, m >> 8 & 0xff, (m & 0xff) / 0xff) // #ff000000
+        : l === 4 ? rgba((m >> 12 & 0xf) | (m >> 8 & 0xf0), (m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), (((m & 0xf) << 4) | (m & 0xf)) / 0xff) // #f000
+        : null) // invalid hex
+        : (m = reRgbInteger.exec(format)) ? new Rgb(m[1], m[2], m[3], 1) // rgb(255, 0, 0)
+        : (m = reRgbPercent.exec(format)) ? new Rgb(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, 1) // rgb(100%, 0%, 0%)
+        : (m = reRgbaInteger.exec(format)) ? rgba(m[1], m[2], m[3], m[4]) // rgba(255, 0, 0, 1)
+        : (m = reRgbaPercent.exec(format)) ? rgba(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, m[4]) // rgb(100%, 0%, 0%, 1)
+        : (m = reHslPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, 1) // hsl(120, 50%, 50%)
+        : (m = reHslaPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, m[4]) // hsla(120, 50%, 50%, 1)
+        : named.hasOwnProperty(format) ? rgbn(named[format]) // eslint-disable-line no-prototype-builtins
+        : format === "transparent" ? new Rgb(NaN, NaN, NaN, 0)
+        : null;
+  }
+
+  function rgbn(n) {
+    return new Rgb(n >> 16 & 0xff, n >> 8 & 0xff, n & 0xff, 1);
+  }
+
+  function rgba(r, g, b, a) {
+    if (a <= 0) r = g = b = NaN;
+    return new Rgb(r, g, b, a);
+  }
+
+  function rgbConvert(o) {
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Rgb;
+    o = o.rgb();
+    return new Rgb(o.r, o.g, o.b, o.opacity);
+  }
+
+  function rgb$1(r, g, b, opacity) {
+    return arguments.length === 1 ? rgbConvert(r) : new Rgb(r, g, b, opacity == null ? 1 : opacity);
+  }
+
+  function Rgb(r, g, b, opacity) {
+    this.r = +r;
+    this.g = +g;
+    this.b = +b;
+    this.opacity = +opacity;
+  }
+
+  define(Rgb, rgb$1, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    rgb() {
+      return this;
+    },
+    clamp() {
+      return new Rgb(clampi(this.r), clampi(this.g), clampi(this.b), clampa(this.opacity));
+    },
+    displayable() {
+      return (-0.5 <= this.r && this.r < 255.5)
+          && (-0.5 <= this.g && this.g < 255.5)
+          && (-0.5 <= this.b && this.b < 255.5)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    hex: rgb_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: rgb_formatHex,
+    formatHex8: rgb_formatHex8,
+    formatRgb: rgb_formatRgb,
+    toString: rgb_formatRgb
+  }));
+
+  function rgb_formatHex() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}`;
+  }
+
+  function rgb_formatHex8() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}${hex((isNaN(this.opacity) ? 1 : this.opacity) * 255)}`;
+  }
+
+  function rgb_formatRgb() {
+    const a = clampa(this.opacity);
+    return `${a === 1 ? "rgb(" : "rgba("}${clampi(this.r)}, ${clampi(this.g)}, ${clampi(this.b)}${a === 1 ? ")" : `, ${a})`}`;
+  }
+
+  function clampa(opacity) {
+    return isNaN(opacity) ? 1 : Math.max(0, Math.min(1, opacity));
+  }
+
+  function clampi(value) {
+    return Math.max(0, Math.min(255, Math.round(value) || 0));
+  }
+
+  function hex(value) {
+    value = clampi(value);
+    return (value < 16 ? "0" : "") + value.toString(16);
+  }
+
+  function hsla(h, s, l, a) {
+    if (a <= 0) h = s = l = NaN;
+    else if (l <= 0 || l >= 1) h = s = NaN;
+    else if (s <= 0) h = NaN;
+    return new Hsl(h, s, l, a);
+  }
+
+  function hslConvert(o) {
+    if (o instanceof Hsl) return new Hsl(o.h, o.s, o.l, o.opacity);
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Hsl;
+    if (o instanceof Hsl) return o;
+    o = o.rgb();
+    var r = o.r / 255,
+        g = o.g / 255,
+        b = o.b / 255,
+        min = Math.min(r, g, b),
+        max = Math.max(r, g, b),
+        h = NaN,
+        s = max - min,
+        l = (max + min) / 2;
+    if (s) {
+      if (r === max) h = (g - b) / s + (g < b) * 6;
+      else if (g === max) h = (b - r) / s + 2;
+      else h = (r - g) / s + 4;
+      s /= l < 0.5 ? max + min : 2 - max - min;
+      h *= 60;
+    } else {
+      s = l > 0 && l < 1 ? 0 : h;
+    }
+    return new Hsl(h, s, l, o.opacity);
+  }
+
+  function hsl(h, s, l, opacity) {
+    return arguments.length === 1 ? hslConvert(h) : new Hsl(h, s, l, opacity == null ? 1 : opacity);
+  }
+
+  function Hsl(h, s, l, opacity) {
+    this.h = +h;
+    this.s = +s;
+    this.l = +l;
+    this.opacity = +opacity;
+  }
+
+  define(Hsl, hsl, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    rgb() {
+      var h = this.h % 360 + (this.h < 0) * 360,
+          s = isNaN(h) || isNaN(this.s) ? 0 : this.s,
+          l = this.l,
+          m2 = l + (l < 0.5 ? l : 1 - l) * s,
+          m1 = 2 * l - m2;
+      return new Rgb(
+        hsl2rgb(h >= 240 ? h - 240 : h + 120, m1, m2),
+        hsl2rgb(h, m1, m2),
+        hsl2rgb(h < 120 ? h + 240 : h - 120, m1, m2),
+        this.opacity
+      );
+    },
+    clamp() {
+      return new Hsl(clamph(this.h), clampt(this.s), clampt(this.l), clampa(this.opacity));
+    },
+    displayable() {
+      return (0 <= this.s && this.s <= 1 || isNaN(this.s))
+          && (0 <= this.l && this.l <= 1)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    formatHsl() {
+      const a = clampa(this.opacity);
+      return `${a === 1 ? "hsl(" : "hsla("}${clamph(this.h)}, ${clampt(this.s) * 100}%, ${clampt(this.l) * 100}%${a === 1 ? ")" : `, ${a})`}`;
+    }
+  }));
+
+  function clamph(value) {
+    value = (value || 0) % 360;
+    return value < 0 ? value + 360 : value;
+  }
+
+  function clampt(value) {
+    return Math.max(0, Math.min(1, value || 0));
+  }
+
+  /* From FvD 13.37, CSS Color Module Level 3 */
+  function hsl2rgb(h, m1, m2) {
+    return (h < 60 ? m1 + (m2 - m1) * h / 60
+        : h < 180 ? m2
+        : h < 240 ? m1 + (m2 - m1) * (240 - h) / 60
+        : m1) * 255;
+  }
+
+  var constant = x => () => x;
+
+  function linear$1(a, d) {
+    return function(t) {
+      return a + t * d;
+    };
+  }
+
+  function exponential(a, b, y) {
+    return a = Math.pow(a, y), b = Math.pow(b, y) - a, y = 1 / y, function(t) {
+      return Math.pow(a + t * b, y);
+    };
+  }
+
+  function gamma(y) {
+    return (y = +y) === 1 ? nogamma : function(a, b) {
+      return b - a ? exponential(a, b, y) : constant(isNaN(a) ? b : a);
+    };
+  }
+
+  function nogamma(a, b) {
+    var d = b - a;
+    return d ? linear$1(a, d) : constant(isNaN(a) ? b : a);
+  }
+
+  var rgb = (function rgbGamma(y) {
+    var color = gamma(y);
+
+    function rgb(start, end) {
+      var r = color((start = rgb$1(start)).r, (end = rgb$1(end)).r),
+          g = color(start.g, end.g),
+          b = color(start.b, end.b),
+          opacity = nogamma(start.opacity, end.opacity);
+      return function(t) {
+        start.r = r(t);
+        start.g = g(t);
+        start.b = b(t);
+        start.opacity = opacity(t);
+        return start + "";
+      };
+    }
+
+    rgb.gamma = rgbGamma;
+
+    return rgb;
+  })(1);
+
+  function numberArray(a, b) {
+    if (!b) b = [];
+    var n = a ? Math.min(b.length, a.length) : 0,
+        c = b.slice(),
+        i;
+    return function(t) {
+      for (i = 0; i < n; ++i) c[i] = a[i] * (1 - t) + b[i] * t;
+      return c;
+    };
+  }
+
+  function isNumberArray(x) {
+    return ArrayBuffer.isView(x) && !(x instanceof DataView);
+  }
+
+  function genericArray(a, b) {
+    var nb = b ? b.length : 0,
+        na = a ? Math.min(nb, a.length) : 0,
+        x = new Array(na),
+        c = new Array(nb),
+        i;
+
+    for (i = 0; i < na; ++i) x[i] = interpolate(a[i], b[i]);
+    for (; i < nb; ++i) c[i] = b[i];
+
+    return function(t) {
+      for (i = 0; i < na; ++i) c[i] = x[i](t);
+      return c;
+    };
+  }
+
+  function date(a, b) {
+    var d = new Date;
+    return a = +a, b = +b, function(t) {
+      return d.setTime(a * (1 - t) + b * t), d;
+    };
+  }
+
+  function interpolateNumber(a, b) {
+    return a = +a, b = +b, function(t) {
+      return a * (1 - t) + b * t;
+    };
+  }
+
+  function object(a, b) {
+    var i = {},
+        c = {},
+        k;
+
+    if (a === null || typeof a !== "object") a = {};
+    if (b === null || typeof b !== "object") b = {};
+
+    for (k in b) {
+      if (k in a) {
+        i[k] = interpolate(a[k], b[k]);
+      } else {
+        c[k] = b[k];
+      }
+    }
+
+    return function(t) {
+      for (k in i) c[k] = i[k](t);
+      return c;
+    };
+  }
+
+  var reA = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g,
+      reB = new RegExp(reA.source, "g");
+
+  function zero(b) {
+    return function() {
+      return b;
+    };
+  }
+
+  function one(b) {
+    return function(t) {
+      return b(t) + "";
+    };
+  }
+
+  function string(a, b) {
+    var bi = reA.lastIndex = reB.lastIndex = 0, // scan index for next number in b
+        am, // current match in a
+        bm, // current match in b
+        bs, // string preceding current number in b, if any
+        i = -1, // index in s
+        s = [], // string constants and placeholders
+        q = []; // number interpolators
+
+    // Coerce inputs to strings.
+    a = a + "", b = b + "";
+
+    // Interpolate pairs of numbers in a & b.
+    while ((am = reA.exec(a))
+        && (bm = reB.exec(b))) {
+      if ((bs = bm.index) > bi) { // a string precedes the next number in b
+        bs = b.slice(bi, bs);
+        if (s[i]) s[i] += bs; // coalesce with previous string
+        else s[++i] = bs;
+      }
+      if ((am = am[0]) === (bm = bm[0])) { // numbers in a & b match
+        if (s[i]) s[i] += bm; // coalesce with previous string
+        else s[++i] = bm;
+      } else { // interpolate non-matching numbers
+        s[++i] = null;
+        q.push({i: i, x: interpolateNumber(am, bm)});
+      }
+      bi = reB.lastIndex;
+    }
+
+    // Add remains of b.
+    if (bi < b.length) {
+      bs = b.slice(bi);
+      if (s[i]) s[i] += bs; // coalesce with previous string
+      else s[++i] = bs;
+    }
+
+    // Special optimization for only a single match.
+    // Otherwise, interpolate each of the numbers and rejoin the string.
+    return s.length < 2 ? (q[0]
+        ? one(q[0].x)
+        : zero(b))
+        : (b = q.length, function(t) {
+            for (var i = 0, o; i < b; ++i) s[(o = q[i]).i] = o.x(t);
+            return s.join("");
+          });
+  }
+
+  function interpolate(a, b) {
+    var t = typeof b, c;
+    return b == null || t === "boolean" ? constant(b)
+        : (t === "number" ? interpolateNumber
+        : t === "string" ? ((c = color(b)) ? (b = c, rgb) : string)
+        : b instanceof color ? rgb
+        : b instanceof Date ? date
+        : isNumberArray(b) ? numberArray
+        : Array.isArray(b) ? genericArray
+        : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
+        : interpolateNumber)(a, b);
+  }
+
+  function interpolateRound(a, b) {
+    return a = +a, b = +b, function(t) {
+      return Math.round(a * (1 - t) + b * t);
+    };
+  }
+
+  function constants(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function number(x) {
+    return +x;
+  }
+
+  var unit = [0, 1];
+
+  function identity$1(x) {
+    return x;
+  }
+
+  function normalize(a, b) {
+    return (b -= (a = +a))
+        ? function(x) { return (x - a) / b; }
+        : constants(isNaN(b) ? NaN : 0.5);
+  }
+
+  function clamper(a, b) {
+    var t;
+    if (a > b) t = a, a = b, b = t;
+    return function(x) { return Math.max(a, Math.min(b, x)); };
+  }
+
+  // normalize(a, b)(x) takes a domain value x in [a,b] and returns the corresponding parameter t in [0,1].
+  // interpolate(a, b)(t) takes a parameter t in [0,1] and returns the corresponding range value x in [a,b].
+  function bimap(domain, range, interpolate) {
+    var d0 = domain[0], d1 = domain[1], r0 = range[0], r1 = range[1];
+    if (d1 < d0) d0 = normalize(d1, d0), r0 = interpolate(r1, r0);
+    else d0 = normalize(d0, d1), r0 = interpolate(r0, r1);
+    return function(x) { return r0(d0(x)); };
+  }
+
+  function polymap(domain, range, interpolate) {
+    var j = Math.min(domain.length, range.length) - 1,
+        d = new Array(j),
+        r = new Array(j),
+        i = -1;
+
+    // Reverse descending domains.
+    if (domain[j] < domain[0]) {
+      domain = domain.slice().reverse();
+      range = range.slice().reverse();
+    }
+
+    while (++i < j) {
+      d[i] = normalize(domain[i], domain[i + 1]);
+      r[i] = interpolate(range[i], range[i + 1]);
+    }
+
+    return function(x) {
+      var i = bisect(domain, x, 1, j) - 1;
+      return r[i](d[i](x));
+    };
+  }
+
+  function copy$1(source, target) {
+    return target
+        .domain(source.domain())
+        .range(source.range())
+        .interpolate(source.interpolate())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function transformer$1() {
+    var domain = unit,
+        range = unit,
+        interpolate$1 = interpolate,
+        transform,
+        untransform,
+        unknown,
+        clamp = identity$1,
+        piecewise,
+        output,
+        input;
+
+    function rescale() {
+      var n = Math.min(domain.length, range.length);
+      if (clamp !== identity$1) clamp = clamper(domain[0], domain[n - 1]);
+      piecewise = n > 2 ? polymap : bimap;
+      output = input = null;
+      return scale;
+    }
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : (output || (output = piecewise(domain.map(transform), range, interpolate$1)))(transform(clamp(x)));
+    }
+
+    scale.invert = function(y) {
+      return clamp(untransform((input || (input = piecewise(range, domain.map(transform), interpolateNumber)))(y)));
+    };
+
+    scale.domain = function(_) {
+      return arguments.length ? (domain = Array.from(_, number), rescale()) : domain.slice();
+    };
+
+    scale.range = function(_) {
+      return arguments.length ? (range = Array.from(_), rescale()) : range.slice();
+    };
+
+    scale.rangeRound = function(_) {
+      return range = Array.from(_), interpolate$1 = interpolateRound, rescale();
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = _ ? true : identity$1, rescale()) : clamp !== identity$1;
+    };
+
+    scale.interpolate = function(_) {
+      return arguments.length ? (interpolate$1 = _, rescale()) : interpolate$1;
+    };
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t, u) {
+      transform = t, untransform = u;
+      return rescale();
+    };
+  }
+
+  function continuous() {
+    return transformer$1()(identity$1, identity$1);
+  }
+
+  function formatDecimal(x) {
+    return Math.abs(x = Math.round(x)) >= 1e21
+        ? x.toLocaleString("en").replace(/,/g, "")
+        : x.toString(10);
+  }
+
+  // Computes the decimal coefficient and exponent of the specified number x with
+  // significant digits p, where x is positive and p is in [1, 21] or undefined.
+  // For example, formatDecimalParts(1.23) returns ["123", 0].
+  function formatDecimalParts(x, p) {
+    if ((i = (x = p ? x.toExponential(p - 1) : x.toExponential()).indexOf("e")) < 0) return null; // NaN, ±Infinity
+    var i, coefficient = x.slice(0, i);
+
+    // The string returned by toExponential either has the form \d\.\d+e[-+]\d+
+    // (e.g., 1.2e+3) or the form \de[-+]\d+ (e.g., 1e+3).
+    return [
+      coefficient.length > 1 ? coefficient[0] + coefficient.slice(2) : coefficient,
+      +x.slice(i + 1)
+    ];
+  }
+
+  function exponent(x) {
+    return x = formatDecimalParts(Math.abs(x)), x ? x[1] : NaN;
+  }
+
+  function formatGroup(grouping, thousands) {
+    return function(value, width) {
+      var i = value.length,
+          t = [],
+          j = 0,
+          g = grouping[0],
+          length = 0;
+
+      while (i > 0 && g > 0) {
+        if (length + g + 1 > width) g = Math.max(1, width - length);
+        t.push(value.substring(i -= g, i + g));
+        if ((length += g + 1) > width) break;
+        g = grouping[j = (j + 1) % grouping.length];
+      }
+
+      return t.reverse().join(thousands);
+    };
+  }
+
+  function formatNumerals(numerals) {
+    return function(value) {
+      return value.replace(/[0-9]/g, function(i) {
+        return numerals[+i];
+      });
+    };
+  }
+
+  // [[fill]align][sign][symbol][0][width][,][.precision][~][type]
+  var re = /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
+
+  function formatSpecifier(specifier) {
+    if (!(match = re.exec(specifier))) throw new Error("invalid format: " + specifier);
+    var match;
+    return new FormatSpecifier({
+      fill: match[1],
+      align: match[2],
+      sign: match[3],
+      symbol: match[4],
+      zero: match[5],
+      width: match[6],
+      comma: match[7],
+      precision: match[8] && match[8].slice(1),
+      trim: match[9],
+      type: match[10]
+    });
+  }
+
+  formatSpecifier.prototype = FormatSpecifier.prototype; // instanceof
+
+  function FormatSpecifier(specifier) {
+    this.fill = specifier.fill === undefined ? " " : specifier.fill + "";
+    this.align = specifier.align === undefined ? ">" : specifier.align + "";
+    this.sign = specifier.sign === undefined ? "-" : specifier.sign + "";
+    this.symbol = specifier.symbol === undefined ? "" : specifier.symbol + "";
+    this.zero = !!specifier.zero;
+    this.width = specifier.width === undefined ? undefined : +specifier.width;
+    this.comma = !!specifier.comma;
+    this.precision = specifier.precision === undefined ? undefined : +specifier.precision;
+    this.trim = !!specifier.trim;
+    this.type = specifier.type === undefined ? "" : specifier.type + "";
+  }
+
+  FormatSpecifier.prototype.toString = function() {
+    return this.fill
+        + this.align
+        + this.sign
+        + this.symbol
+        + (this.zero ? "0" : "")
+        + (this.width === undefined ? "" : Math.max(1, this.width | 0))
+        + (this.comma ? "," : "")
+        + (this.precision === undefined ? "" : "." + Math.max(0, this.precision | 0))
+        + (this.trim ? "~" : "")
+        + this.type;
+  };
+
+  // Trims insignificant zeros, e.g., replaces 1.2000k with 1.2k.
+  function formatTrim(s) {
+    out: for (var n = s.length, i = 1, i0 = -1, i1; i < n; ++i) {
+      switch (s[i]) {
+        case ".": i0 = i1 = i; break;
+        case "0": if (i0 === 0) i0 = i; i1 = i; break;
+        default: if (!+s[i]) break out; if (i0 > 0) i0 = 0; break;
+      }
+    }
+    return i0 > 0 ? s.slice(0, i0) + s.slice(i1 + 1) : s;
+  }
+
+  var prefixExponent;
+
+  function formatPrefixAuto(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1],
+        i = exponent - (prefixExponent = Math.max(-8, Math.min(8, Math.floor(exponent / 3))) * 3) + 1,
+        n = coefficient.length;
+    return i === n ? coefficient
+        : i > n ? coefficient + new Array(i - n + 1).join("0")
+        : i > 0 ? coefficient.slice(0, i) + "." + coefficient.slice(i)
+        : "0." + new Array(1 - i).join("0") + formatDecimalParts(x, Math.max(0, p + i - 1))[0]; // less than 1y!
+  }
+
+  function formatRounded(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1];
+    return exponent < 0 ? "0." + new Array(-exponent).join("0") + coefficient
+        : coefficient.length > exponent + 1 ? coefficient.slice(0, exponent + 1) + "." + coefficient.slice(exponent + 1)
+        : coefficient + new Array(exponent - coefficient.length + 2).join("0");
+  }
+
+  var formatTypes = {
+    "%": (x, p) => (x * 100).toFixed(p),
+    "b": (x) => Math.round(x).toString(2),
+    "c": (x) => x + "",
+    "d": formatDecimal,
+    "e": (x, p) => x.toExponential(p),
+    "f": (x, p) => x.toFixed(p),
+    "g": (x, p) => x.toPrecision(p),
+    "o": (x) => Math.round(x).toString(8),
+    "p": (x, p) => formatRounded(x * 100, p),
+    "r": formatRounded,
+    "s": formatPrefixAuto,
+    "X": (x) => Math.round(x).toString(16).toUpperCase(),
+    "x": (x) => Math.round(x).toString(16)
+  };
+
+  function identity(x) {
+    return x;
+  }
+
+  var map = Array.prototype.map,
+      prefixes = ["y","z","a","f","p","n","µ","m","","k","M","G","T","P","E","Z","Y"];
+
+  function formatLocale(locale) {
+    var group = locale.grouping === undefined || locale.thousands === undefined ? identity : formatGroup(map.call(locale.grouping, Number), locale.thousands + ""),
+        currencyPrefix = locale.currency === undefined ? "" : locale.currency[0] + "",
+        currencySuffix = locale.currency === undefined ? "" : locale.currency[1] + "",
+        decimal = locale.decimal === undefined ? "." : locale.decimal + "",
+        numerals = locale.numerals === undefined ? identity : formatNumerals(map.call(locale.numerals, String)),
+        percent = locale.percent === undefined ? "%" : locale.percent + "",
+        minus = locale.minus === undefined ? "−" : locale.minus + "",
+        nan = locale.nan === undefined ? "NaN" : locale.nan + "";
+
+    function newFormat(specifier) {
+      specifier = formatSpecifier(specifier);
+
+      var fill = specifier.fill,
+          align = specifier.align,
+          sign = specifier.sign,
+          symbol = specifier.symbol,
+          zero = specifier.zero,
+          width = specifier.width,
+          comma = specifier.comma,
+          precision = specifier.precision,
+          trim = specifier.trim,
+          type = specifier.type;
+
+      // The "n" type is an alias for ",g".
+      if (type === "n") comma = true, type = "g";
+
+      // The "" type, and any invalid type, is an alias for ".12~g".
+      else if (!formatTypes[type]) precision === undefined && (precision = 12), trim = true, type = "g";
+
+      // If zero fill is specified, padding goes after sign and before digits.
+      if (zero || (fill === "0" && align === "=")) zero = true, fill = "0", align = "=";
+
+      // Compute the prefix and suffix.
+      // For SI-prefix, the suffix is lazily computed.
+      var prefix = symbol === "$" ? currencyPrefix : symbol === "#" && /[boxX]/.test(type) ? "0" + type.toLowerCase() : "",
+          suffix = symbol === "$" ? currencySuffix : /[%p]/.test(type) ? percent : "";
+
+      // What format function should we use?
+      // Is this an integer type?
+      // Can this type generate exponential notation?
+      var formatType = formatTypes[type],
+          maybeSuffix = /[defgprs%]/.test(type);
+
+      // Set the default precision if not specified,
+      // or clamp the specified precision to the supported range.
+      // For significant precision, it must be in [1, 21].
+      // For fixed precision, it must be in [0, 20].
+      precision = precision === undefined ? 6
+          : /[gprs]/.test(type) ? Math.max(1, Math.min(21, precision))
+          : Math.max(0, Math.min(20, precision));
+
+      function format(value) {
+        var valuePrefix = prefix,
+            valueSuffix = suffix,
+            i, n, c;
+
+        if (type === "c") {
+          valueSuffix = formatType(value) + valueSuffix;
+          value = "";
+        } else {
+          value = +value;
+
+          // Determine the sign. -0 is not less than 0, but 1 / -0 is!
+          var valueNegative = value < 0 || 1 / value < 0;
+
+          // Perform the initial formatting.
+          value = isNaN(value) ? nan : formatType(Math.abs(value), precision);
+
+          // Trim insignificant zeros.
+          if (trim) value = formatTrim(value);
+
+          // If a negative value rounds to zero after formatting, and no explicit positive sign is requested, hide the sign.
+          if (valueNegative && +value === 0 && sign !== "+") valueNegative = false;
+
+          // Compute the prefix and suffix.
+          valuePrefix = (valueNegative ? (sign === "(" ? sign : minus) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
+          valueSuffix = (type === "s" ? prefixes[8 + prefixExponent / 3] : "") + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
+
+          // Break the formatted value into the integer “value” part that can be
+          // grouped, and fractional or exponential “suffix” part that is not.
+          if (maybeSuffix) {
+            i = -1, n = value.length;
+            while (++i < n) {
+              if (c = value.charCodeAt(i), 48 > c || c > 57) {
+                valueSuffix = (c === 46 ? decimal + value.slice(i + 1) : value.slice(i)) + valueSuffix;
+                value = value.slice(0, i);
+                break;
+              }
+            }
+          }
+        }
+
+        // If the fill character is not "0", grouping is applied before padding.
+        if (comma && !zero) value = group(value, Infinity);
+
+        // Compute the padding.
+        var length = valuePrefix.length + value.length + valueSuffix.length,
+            padding = length < width ? new Array(width - length + 1).join(fill) : "";
+
+        // If the fill character is "0", grouping is applied after padding.
+        if (comma && zero) value = group(padding + value, padding.length ? width - valueSuffix.length : Infinity), padding = "";
+
+        // Reconstruct the final output based on the desired alignment.
+        switch (align) {
+          case "<": value = valuePrefix + value + valueSuffix + padding; break;
+          case "=": value = valuePrefix + padding + value + valueSuffix; break;
+          case "^": value = padding.slice(0, length = padding.length >> 1) + valuePrefix + value + valueSuffix + padding.slice(length); break;
+          default: value = padding + valuePrefix + value + valueSuffix; break;
+        }
+
+        return numerals(value);
+      }
+
+      format.toString = function() {
+        return specifier + "";
+      };
+
+      return format;
+    }
+
+    function formatPrefix(specifier, value) {
+      var f = newFormat((specifier = formatSpecifier(specifier), specifier.type = "f", specifier)),
+          e = Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3,
+          k = Math.pow(10, -e),
+          prefix = prefixes[8 + e / 3];
+      return function(value) {
+        return f(k * value) + prefix;
+      };
+    }
+
+    return {
+      format: newFormat,
+      formatPrefix: formatPrefix
+    };
+  }
+
+  var locale;
+  var format;
+  var formatPrefix;
+
+  defaultLocale({
+    thousands: ",",
+    grouping: [3],
+    currency: ["$", ""]
+  });
+
+  function defaultLocale(definition) {
+    locale = formatLocale(definition);
+    format = locale.format;
+    formatPrefix = locale.formatPrefix;
+    return locale;
+  }
+
+  function precisionFixed(step) {
+    return Math.max(0, -exponent(Math.abs(step)));
+  }
+
+  function precisionPrefix(step, value) {
+    return Math.max(0, Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3 - exponent(Math.abs(step)));
+  }
+
+  function precisionRound(step, max) {
+    step = Math.abs(step), max = Math.abs(max) - step;
+    return Math.max(0, exponent(max) - exponent(step)) + 1;
+  }
+
+  function tickFormat(start, stop, count, specifier) {
+    var step = tickStep(start, stop, count),
+        precision;
+    specifier = formatSpecifier(specifier == null ? ",f" : specifier);
+    switch (specifier.type) {
+      case "s": {
+        var value = Math.max(Math.abs(start), Math.abs(stop));
+        if (specifier.precision == null && !isNaN(precision = precisionPrefix(step, value))) specifier.precision = precision;
+        return formatPrefix(specifier, value);
+      }
+      case "":
+      case "e":
+      case "g":
+      case "p":
+      case "r": {
+        if (specifier.precision == null && !isNaN(precision = precisionRound(step, Math.max(Math.abs(start), Math.abs(stop))))) specifier.precision = precision - (specifier.type === "e");
+        break;
+      }
+      case "f":
+      case "%": {
+        if (specifier.precision == null && !isNaN(precision = precisionFixed(step))) specifier.precision = precision - (specifier.type === "%") * 2;
+        break;
+      }
+    }
+    return format(specifier);
+  }
+
+  function linearish(scale) {
+    var domain = scale.domain;
+
+    scale.ticks = function(count) {
+      var d = domain();
+      return ticks(d[0], d[d.length - 1], count == null ? 10 : count);
+    };
+
+    scale.tickFormat = function(count, specifier) {
+      var d = domain();
+      return tickFormat(d[0], d[d.length - 1], count == null ? 10 : count, specifier);
+    };
+
+    scale.nice = function(count) {
+      if (count == null) count = 10;
+
+      var d = domain();
+      var i0 = 0;
+      var i1 = d.length - 1;
+      var start = d[i0];
+      var stop = d[i1];
+      var prestep;
+      var step;
+      var maxIter = 10;
+
+      if (stop < start) {
+        step = start, start = stop, stop = step;
+        step = i0, i0 = i1, i1 = step;
+      }
+      
+      while (maxIter-- > 0) {
+        step = tickIncrement(start, stop, count);
+        if (step === prestep) {
+          d[i0] = start;
+          d[i1] = stop;
+          return domain(d);
+        } else if (step > 0) {
+          start = Math.floor(start / step) * step;
+          stop = Math.ceil(stop / step) * step;
+        } else if (step < 0) {
+          start = Math.ceil(start * step) / step;
+          stop = Math.floor(stop * step) / step;
+        } else {
+          break;
+        }
+        prestep = step;
+      }
+
+      return scale;
+    };
+
+    return scale;
+  }
+
+  function linear() {
+    var scale = continuous();
+
+    scale.copy = function() {
+      return copy$1(scale, linear());
+    };
+
+    initRange.apply(scale, arguments);
+
+    return linearish(scale);
+  }
+
+  function transformer() {
+    var x0 = 0,
+        x1 = 1,
+        t0,
+        t1,
+        k10,
+        transform,
+        interpolator = identity$1,
+        clamp = false,
+        unknown;
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : interpolator(k10 === 0 ? 0.5 : (x = (transform(x) - t0) * k10, clamp ? Math.max(0, Math.min(1, x)) : x));
+    }
+
+    scale.domain = function(_) {
+      return arguments.length ? ([x0, x1] = _, t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0), scale) : [x0, x1];
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = !!_, scale) : clamp;
+    };
+
+    scale.interpolator = function(_) {
+      return arguments.length ? (interpolator = _, scale) : interpolator;
+    };
+
+    function range(interpolate) {
+      return function(_) {
+        var r0, r1;
+        return arguments.length ? ([r0, r1] = _, interpolator = interpolate(r0, r1), scale) : [interpolator(0), interpolator(1)];
+      };
+    }
+
+    scale.range = range(interpolate);
+
+    scale.rangeRound = range(interpolateRound);
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t) {
+      transform = t, t0 = t(x0), t1 = t(x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0);
+      return scale;
+    };
+  }
+
+  function copy(source, target) {
+    return target
+        .domain(source.domain())
+        .interpolator(source.interpolator())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function sequential() {
+    var scale = linearish(transformer()(identity$1));
+
+    scale.copy = function() {
+      return copy(scale, sequential());
+    };
+
+    return initInterpolator.apply(scale, arguments);
+  }
+
+  const COLOR_BASE = "#cecece";
+
+  // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+  const rc = 0.2126;
+  const gc = 0.7152;
+  const bc = 0.0722;
+  // low-gamma adjust coefficient
+  const lowc = 1 / 12.92;
+  function adjustGamma(p) {
+      return Math.pow((p + 0.055) / 1.055, 2.4);
+  }
+  function relativeLuminance(o) {
+      const rsrgb = o.r / 255;
+      const gsrgb = o.g / 255;
+      const bsrgb = o.b / 255;
+      const r = rsrgb <= 0.03928 ? rsrgb * lowc : adjustGamma(rsrgb);
+      const g = gsrgb <= 0.03928 ? gsrgb * lowc : adjustGamma(gsrgb);
+      const b = bsrgb <= 0.03928 ? bsrgb * lowc : adjustGamma(bsrgb);
+      return r * rc + g * gc + b * bc;
+  }
+  const createRainbowColor = (root) => {
+      const colorParentMap = new Map();
+      colorParentMap.set(root, COLOR_BASE);
+      if (root.children != null) {
+          const colorScale = sequential([0, root.children.length], (n) => hsl(360 * n, 0.3, 0.85));
+          root.children.forEach((c, id) => {
+              colorParentMap.set(c, colorScale(id).toString());
+          });
+      }
+      const colorMap = new Map();
+      const lightScale = linear().domain([0, root.height]).range([0.9, 0.3]);
+      const getBackgroundColor = (node) => {
+          const parents = node.ancestors();
+          const colorStr = parents.length === 1
+              ? colorParentMap.get(parents[0])
+              : colorParentMap.get(parents[parents.length - 2]);
+          const hslColor = hsl(colorStr);
+          hslColor.l = lightScale(node.depth);
+          return hslColor;
+      };
+      return (node) => {
+          if (!colorMap.has(node)) {
+              const backgroundColor = getBackgroundColor(node);
+              const l = relativeLuminance(backgroundColor.rgb());
+              const fontColor = l > 0.19 ? "#000" : "#fff";
+              colorMap.set(node, {
+                  backgroundColor: backgroundColor.toString(),
+                  fontColor,
+              });
+          }
+          return colorMap.get(node);
+      };
+  };
+
+  const StaticContext = G({});
+  const drawChart = (parentNode, data, width, height) => {
+      const availableSizeProperties = getAvailableSizeOptions(data.options);
+      console.time("layout create");
+      const layout = treemap()
+          .size([width, height])
+          .paddingOuter(PADDING)
+          .paddingTop(TOP_PADDING)
+          .paddingInner(PADDING)
+          .round(true)
+          .tile(treemapResquarify);
+      console.timeEnd("layout create");
+      console.time("rawHierarchy create");
+      const rawHierarchy = hierarchy(data.tree);
+      console.timeEnd("rawHierarchy create");
+      const nodeSizesCache = new Map();
+      const nodeIdsCache = new Map();
+      const getModuleSize = (node, sizeKey) => { var _a, _b; return (_b = (_a = nodeSizesCache.get(node)) === null || _a === void 0 ? void 0 : _a[sizeKey]) !== null && _b !== void 0 ? _b : 0; };
+      console.time("rawHierarchy eachAfter cache");
+      rawHierarchy.eachAfter((node) => {
+          var _a;
+          const nodeData = node.data;
+          nodeIdsCache.set(nodeData, {
+              nodeUid: generateUniqueId("node"),
+              clipUid: generateUniqueId("clip"),
+          });
+          const sizes = { renderedLength: 0, gzipLength: 0, brotliLength: 0 };
+          if (isModuleTree(nodeData)) {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = nodeData.children.reduce((acc, child) => getModuleSize(child, sizeKey) + acc, 0);
+              }
+          }
+          else {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = (_a = data.nodeParts[nodeData.uid][sizeKey]) !== null && _a !== void 0 ? _a : 0;
+              }
+          }
+          nodeSizesCache.set(nodeData, sizes);
+      });
+      console.timeEnd("rawHierarchy eachAfter cache");
+      const getModuleIds = (node) => nodeIdsCache.get(node);
+      console.time("color");
+      const getModuleColor = createRainbowColor(rawHierarchy);
+      console.timeEnd("color");
+      D(o$1(StaticContext.Provider, { value: {
+              data,
+              availableSizeProperties,
+              width,
+              height,
+              getModuleSize,
+              getModuleIds,
+              getModuleColor,
+              rawHierarchy,
+              layout,
+          }, children: o$1(Main, {}) }), parentNode);
+  };
+
+  exports.StaticContext = StaticContext;
+  exports.default = drawChart;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+  return exports;
+
+})({});
+
+  /*-->*/
+  </script>
+  <script>
+    /*<!--*/
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"metamask-sdk.js","children":[{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"rollup-plugin-node-globals/src","children":[{"uid":"5277-1293","name":"global.js"},{"uid":"5277-1793","name":"browser.js"}]},{"name":"buffer-es6","children":[{"uid":"5277-1295","name":"base64.js"},{"uid":"5277-1297","name":"ieee754.js"},{"uid":"5277-1299","name":"isArray.js"},{"uid":"5277-1301","name":"index.js"}]},{"name":"process-es6/browser.js","uid":"5277-1315"},{"name":"safe-buffer/index.js","uid":"5277-1321"},{"name":"randombytes/browser.js","uid":"5277-1323"},{"name":"inherits/inherits_browser.js","uid":"5277-1327"},{"name":"rollup-plugin-node-builtins/src/es6","children":[{"uid":"5277-1331","name":"events.js"},{"uid":"5277-1337","name":"inherits.js"},{"uid":"5277-1339","name":"util.js"},{"name":"readable-stream","children":[{"uid":"5277-1403","name":"buffer-list.js"},{"uid":"5277-1407","name":"readable.js"},{"uid":"5277-1409","name":"writable.js"},{"uid":"5277-1411","name":"duplex.js"},{"uid":"5277-1413","name":"transform.js"},{"uid":"5277-1415","name":"passthrough.js"}]},{"uid":"5277-1405","name":"string-decoder.js"},{"uid":"5277-1417","name":"stream.js"},{"uid":"5277-2075","name":"empty.js"}]},{"name":"hash-base","children":[{"name":"node_modules","children":[{"name":"readable-stream","children":[{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-1335","name":"stream-browser.js"},{"uid":"5277-1343","name":"buffer_list.js"},{"uid":"5277-1345","name":"destroy.js"},{"uid":"5277-1351","name":"state.js"},{"uid":"5277-1363","name":"end-of-stream.js"},{"uid":"5277-1365","name":"async_iterator.js"},{"uid":"5277-1367","name":"from-browser.js"},{"uid":"5277-1375","name":"pipeline.js"}]},{"uid":"5277-1355","name":"_stream_writable.js"},{"uid":"5277-1357","name":"_stream_duplex.js"},{"uid":"5277-1369","name":"_stream_readable.js"},{"uid":"5277-1371","name":"_stream_transform.js"},{"uid":"5277-1373","name":"_stream_passthrough.js"}]},{"uid":"5277-1349","name":"errors-browser.js"},{"uid":"5277-1377","name":"readable-browser.js"}]},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-1361"}]},{"uid":"5277-1379","name":"index.js"}]},{"name":"util-deprecate/browser.js","uid":"5277-1353"},{"name":"md5.js/index.js","uid":"5277-1381"},{"name":"ripemd160/index.js","uid":"5277-1383"},{"name":"sha.js","children":[{"uid":"5277-1387","name":"hash.js"},{"uid":"5277-1389","name":"sha.js"},{"uid":"5277-1391","name":"sha1.js"},{"uid":"5277-1393","name":"sha256.js"},{"uid":"5277-1395","name":"sha224.js"},{"uid":"5277-1397","name":"sha512.js"},{"uid":"5277-1399","name":"sha384.js"},{"uid":"5277-1401","name":"index.js"}]},{"name":"cipher-base/index.js","uid":"5277-1423"},{"name":"create-hash","children":[{"uid":"5277-1425","name":"browser.js"},{"uid":"5277-1429","name":"md5.js"}]},{"name":"create-hmac","children":[{"uid":"5277-1427","name":"legacy.js"},{"uid":"5277-1431","name":"browser.js"}]},{"name":"browserify-sign","children":[{"name":"browser","children":[{"uid":"5277-1433","name":"algorithms.json"},{"uid":"5277-1761","name":"curves.json"},{"uid":"5277-1763","name":"sign.js"},{"uid":"5277-1765","name":"verify.js"},{"uid":"5277-1767","name":"index.js"}]},{"uid":"5277-1435","name":"algos.js"},{"name":"node_modules","children":[{"name":"readable-stream","children":[{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-1567","name":"stream-browser.js"},{"uid":"5277-1569","name":"buffer_list.js"},{"uid":"5277-1571","name":"destroy.js"},{"uid":"5277-1577","name":"state.js"},{"uid":"5277-1587","name":"end-of-stream.js"},{"uid":"5277-1589","name":"async_iterator.js"},{"uid":"5277-1591","name":"from-browser.js"},{"uid":"5277-1599","name":"pipeline.js"}]},{"uid":"5277-1579","name":"_stream_writable.js"},{"uid":"5277-1581","name":"_stream_duplex.js"},{"uid":"5277-1593","name":"_stream_readable.js"},{"uid":"5277-1595","name":"_stream_transform.js"},{"uid":"5277-1597","name":"_stream_passthrough.js"}]},{"uid":"5277-1575","name":"errors-browser.js"},{"uid":"5277-1601","name":"readable-browser.js"}]},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-1585"}]}]},{"name":"pbkdf2","children":[{"name":"lib","children":[{"uid":"5277-1439","name":"precondition.js"},{"uid":"5277-1441","name":"default-encoding.js"},{"uid":"5277-1443","name":"to-buffer.js"},{"uid":"5277-1445","name":"sync-browser.js"},{"uid":"5277-1447","name":"async.js"}]},{"uid":"5277-1449","name":"browser.js"}]},{"name":"des.js/lib","children":[{"name":"des","children":[{"uid":"5277-1457","name":"utils.js"},{"uid":"5277-1461","name":"cipher.js"},{"uid":"5277-1463","name":"des.js"},{"uid":"5277-1467","name":"cbc.js"},{"uid":"5277-1469","name":"ede.js"}]},{"uid":"5277-1471","name":"des.js"}]},{"name":"minimalistic-assert/index.js","uid":"5277-1459"},{"name":"browserify-des","children":[{"uid":"5277-1473","name":"index.js"},{"uid":"5277-1537","name":"modes.js"}]},{"name":"browserify-aes","children":[{"name":"modes","children":[{"uid":"5277-1481","name":"ecb.js"},{"uid":"5277-1487","name":"cbc.js"},{"uid":"5277-1491","name":"cfb.js"},{"uid":"5277-1495","name":"cfb8.js"},{"uid":"5277-1499","name":"cfb1.js"},{"uid":"5277-1503","name":"ofb.js"},{"uid":"5277-1509","name":"ctr.js"},{"uid":"5277-1511","name":"list.json"},{"uid":"5277-1513","name":"index.js"}]},{"uid":"5277-1507","name":"incr32.js"},{"uid":"5277-1517","name":"aes.js"},{"uid":"5277-1519","name":"ghash.js"},{"uid":"5277-1521","name":"authCipher.js"},{"uid":"5277-1523","name":"streamCipher.js"},{"uid":"5277-1527","name":"encrypter.js"},{"uid":"5277-1531","name":"decrypter.js"},{"uid":"5277-1533","name":"browser.js"}]},{"name":"buffer-xor/index.js","uid":"5277-1485"},{"name":"evp_bytestokey/index.js","uid":"5277-1525"},{"name":"browserify-cipher/browser.js","uid":"5277-1539"},{"name":"diffie-hellman","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-1545"},{"name":"lib","children":[{"uid":"5277-1557","name":"generatePrime.js"},{"uid":"5277-1559","name":"primes.json"},{"uid":"5277-1561","name":"dh.js"}]},{"uid":"5277-1563","name":"browser.js"}]},{"name":"miller-rabin","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-1549"},{"name":"lib/mr.js","uid":"5277-1555"}]},{"name":"brorand/index.js","uid":"5277-1553"},{"name":"bn.js/lib/bn.js","uid":"5277-1607"},{"name":"browserify-rsa/index.js","uid":"5277-1609"},{"name":"elliptic","children":[{"uid":"5277-1613","name":"package.json"},{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-1619"},{"name":"lib","children":[{"name":"elliptic","children":[{"uid":"5277-1625","name":"utils.js"},{"name":"curve","children":[{"uid":"5277-1629","name":"base.js"},{"uid":"5277-1631","name":"short.js"},{"uid":"5277-1633","name":"mont.js"},{"uid":"5277-1635","name":"edwards.js"},{"uid":"5277-1637","name":"index.js"}]},{"name":"precomputed/secp256k1.js","uid":"5277-1677"},{"uid":"5277-1679","name":"curves.js"},{"name":"ec","children":[{"uid":"5277-1683","name":"key.js"},{"uid":"5277-1685","name":"signature.js"},{"uid":"5277-1687","name":"index.js"}]},{"name":"eddsa","children":[{"uid":"5277-1689","name":"key.js"},{"uid":"5277-1691","name":"signature.js"},{"uid":"5277-1693","name":"index.js"}]}]},{"uid":"5277-1695","name":"elliptic.js"}]}]},{"name":"minimalistic-crypto-utils/lib/utils.js","uid":"5277-1623"},{"name":"hash.js/lib","children":[{"name":"hash","children":[{"uid":"5277-1645","name":"utils.js"},{"uid":"5277-1649","name":"common.js"},{"name":"sha","children":[{"uid":"5277-1655","name":"common.js"},{"uid":"5277-1657","name":"1.js"},{"uid":"5277-1659","name":"256.js"},{"uid":"5277-1661","name":"224.js"},{"uid":"5277-1663","name":"512.js"},{"uid":"5277-1665","name":"384.js"}]},{"uid":"5277-1667","name":"sha.js"},{"uid":"5277-1671","name":"ripemd.js"},{"uid":"5277-1673","name":"hmac.js"}]},{"uid":"5277-1675","name":"hash.js"}]},{"name":"hmac-drbg/lib/hmac-drbg.js","uid":"5277-1681"},{"name":"asn1.js","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-1703"},{"name":"lib","children":[{"name":"asn1","children":[{"name":"base","children":[{"uid":"5277-1713","name":"reporter.js"},{"uid":"5277-1717","name":"buffer.js"},{"uid":"5277-1719","name":"node.js"},{"uid":"5277-1743","name":"index.js"}]},{"name":"constants","children":[{"uid":"5277-1723","name":"der.js"},{"uid":"5277-1747","name":"index.js"}]},{"name":"encoders","children":[{"uid":"5277-1725","name":"der.js"},{"uid":"5277-1727","name":"pem.js"},{"uid":"5277-1729","name":"index.js"}]},{"name":"decoders","children":[{"uid":"5277-1733","name":"der.js"},{"uid":"5277-1735","name":"pem.js"},{"uid":"5277-1737","name":"index.js"}]},{"uid":"5277-1739","name":"api.js"}]},{"uid":"5277-1749","name":"asn1.js"}]}]},{"name":"safer-buffer/safer.js","uid":"5277-1709"},{"name":"parse-asn1","children":[{"uid":"5277-1751","name":"certificate.js"},{"uid":"5277-1753","name":"asn1.js"},{"uid":"5277-1755","name":"aesid.json"},{"uid":"5277-1757","name":"fixProc.js"},{"uid":"5277-1759","name":"index.js"}]},{"name":"create-ecdh","children":[{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-1771"},{"uid":"5277-1773","name":"browser.js"}]},{"name":"public-encrypt","children":[{"uid":"5277-1777","name":"mgf.js"},{"uid":"5277-1779","name":"xor.js"},{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-1783"},{"uid":"5277-1785","name":"withPublic.js"},{"uid":"5277-1787","name":"publicEncrypt.js"},{"uid":"5277-1789","name":"privateDecrypt.js"},{"uid":"5277-1791","name":"browser.js"}]},{"name":"randomfill/browser.js","uid":"5277-1797"},{"name":"crypto-browserify/index.js","uid":"5277-1799"},{"name":"futoin-hkdf/hkdf.js","uid":"5277-1801"},{"name":"eciesjs","children":[{"name":"node_modules/secp256k1","children":[{"name":"lib","children":[{"uid":"5277-1803","name":"index.js"},{"uid":"5277-1805","name":"elliptic.js"}]},{"uid":"5277-1807","name":"elliptic.js"}]},{"name":"dist","children":[{"uid":"5277-1813","name":"consts.js"},{"uid":"5277-1815","name":"utils.js"},{"name":"keys","children":[{"uid":"5277-1819","name":"PublicKey.js"},{"uid":"5277-1821","name":"PrivateKey.js"},{"uid":"5277-1823","name":"index.js"}]},{"uid":"5277-1825","name":"index.js"}]}]},{"name":"eventemitter2/lib/eventemitter2.js","uid":"5277-1829"},{"name":"uuid/dist/esm-browser","children":[{"uid":"5277-1831","name":"rng.js"},{"uid":"5277-1833","name":"regex.js"},{"uid":"5277-1835","name":"validate.js"},{"uid":"5277-1837","name":"stringify.js"},{"uid":"5277-1839","name":"v4.js"}]},{"name":"engine.io-parser/build/esm","children":[{"uid":"5277-1841","name":"commons.js"},{"uid":"5277-1843","name":"encodePacket.browser.js"},{"name":"contrib/base64-arraybuffer.js","uid":"5277-1845"},{"uid":"5277-1847","name":"decodePacket.browser.js"},{"uid":"5277-1849","name":"index.js"}]},{"name":"@socket.io/component-emitter/index.mjs","uid":"5277-1851"},{"name":"engine.io-client/build/esm","children":[{"uid":"5277-1853","name":"globalThis.browser.js"},{"uid":"5277-1855","name":"util.js"},{"name":"contrib","children":[{"uid":"5277-1857","name":"parseqs.js"},{"uid":"5277-1861","name":"yeast.js"},{"uid":"5277-1863","name":"has-cors.js"},{"uid":"5277-1877","name":"parseuri.js"}]},{"uid":"5277-1859","name":"transport.js"},{"name":"transports","children":[{"uid":"5277-1865","name":"xmlhttprequest.browser.js"},{"uid":"5277-1867","name":"polling.js"},{"uid":"5277-1869","name":"websocket-constructor.browser.js"},{"uid":"5277-1871","name":"websocket.js"},{"uid":"5277-1873","name":"webtransport.js"},{"uid":"5277-1875","name":"index.js"}]},{"uid":"5277-1879","name":"socket.js"}]},{"name":"socket.io-client/build/esm","children":[{"uid":"5277-1881","name":"url.js"},{"uid":"5277-1889","name":"on.js"},{"uid":"5277-1891","name":"socket.js"},{"name":"contrib/backo2.js","uid":"5277-1893"},{"uid":"5277-1895","name":"manager.js"},{"uid":"5277-1897","name":"index.js"}]},{"name":"socket.io-parser/build/esm","children":[{"uid":"5277-1883","name":"is-binary.js"},{"uid":"5277-1885","name":"binary.js"},{"uid":"5277-1887","name":"index.js"}]},{"name":"cross-fetch/dist/browser-ponyfill.js","uid":"5277-1901"},{"name":"@metamask","children":[{"name":"safe-event-emitter/index.js","uid":"5277-1913"},{"name":"providers","children":[{"name":"node_modules/fast-deep-equal/index.js","uid":"5277-1937"},{"name":"dist","children":[{"uid":"5277-1969","name":"messages.js"},{"name":"middleware/createRpcWarningMiddleware.js","uid":"5277-1975"},{"uid":"5277-1977","name":"utils.js"},{"uid":"5277-1979","name":"BaseProvider.js"},{"uid":"5277-1995","name":"siteMetadata.js"},{"uid":"5277-2081","name":"StreamProvider.js"},{"uid":"5277-2083","name":"MetaMaskInpageProvider.js"},{"name":"extension-provider","children":[{"uid":"5277-2085","name":"external-extension-config.json"},{"uid":"5277-2087","name":"createExternalExtensionProvider.js"}]},{"uid":"5277-2093","name":"shimWeb3.js"},{"uid":"5277-2095","name":"initializeInpageProvider.js"},{"uid":"5277-2097","name":"index.js"}]}]},{"name":"object-multiplex/dist","children":[{"uid":"5277-2051","name":"Substream.js"},{"uid":"5277-2053","name":"ObjectMultiplex.js"},{"uid":"5277-2055","name":"index.js"}]},{"name":"onboarding/dist/metamask-onboarding.es.js","uid":"5277-2239"}]},{"name":"fast-safe-stringify/index.js","uid":"5277-1919"},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-1921","name":"classes.js"},{"uid":"5277-1927","name":"error-constants.js"},{"uid":"5277-1929","name":"utils.js"},{"uid":"5277-1933","name":"errors.js"},{"uid":"5277-1935","name":"index.js"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-1945","name":"getUniqueId.js"},{"uid":"5277-1947","name":"idRemapMiddleware.js"},{"uid":"5277-1951","name":"createAsyncMiddleware.js"},{"uid":"5277-1955","name":"createScaffoldMiddleware.js"},{"uid":"5277-1959","name":"JsonRpcEngine.js"},{"uid":"5277-1963","name":"mergeMiddleware.js"},{"uid":"5277-1965","name":"index.js"}]},{"name":"extension-port-stream/dist/index.js","uid":"5277-1985"},{"name":"detect-browser/es/index.js","uid":"5277-1987"},{"name":"process-nextick-args/index.js","uid":"5277-2005"},{"name":"readable-stream","children":[{"name":"node_modules","children":[{"name":"isarray/index.js","uid":"5277-2007"},{"name":"safe-buffer/index.js","uid":"5277-2013"},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-2031"}]},{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-2009","name":"stream-browser.js"},{"uid":"5277-2021","name":"BufferList.js"},{"uid":"5277-2023","name":"destroy.js"}]},{"uid":"5277-2025","name":"_stream_writable.js"},{"uid":"5277-2027","name":"_stream_duplex.js"},{"uid":"5277-2033","name":"_stream_readable.js"},{"uid":"5277-2035","name":"_stream_transform.js"},{"uid":"5277-2037","name":"_stream_passthrough.js"}]},{"uid":"5277-2039","name":"readable-browser.js"}]},{"name":"core-util-is/lib/util.js","uid":"5277-2017"},{"name":"wrappy/wrappy.js","uid":"5277-2043"},{"name":"once/once.js","uid":"5277-2045"},{"name":"end-of-stream/index.js","uid":"5277-2047"},{"name":"is-stream/index.js","uid":"5277-2057"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-2063","name":"createEngineStream.js"},{"uid":"5277-2071","name":"createStreamMiddleware.js"},{"uid":"5277-2073","name":"index.js"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js","uid":"5277-2069"}]},{"name":"pump/index.js","uid":"5277-2079"},{"name":"i18next","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-2109","name":"typeof.js"},{"uid":"5277-2111","name":"classCallCheck.js"},{"uid":"5277-2113","name":"toPrimitive.js"},{"uid":"5277-2115","name":"toPropertyKey.js"},{"uid":"5277-2117","name":"createClass.js"},{"uid":"5277-2119","name":"assertThisInitialized.js"},{"uid":"5277-2121","name":"setPrototypeOf.js"},{"uid":"5277-2123","name":"inherits.js"},{"uid":"5277-2125","name":"possibleConstructorReturn.js"},{"uid":"5277-2127","name":"getPrototypeOf.js"},{"uid":"5277-2129","name":"defineProperty.js"},{"uid":"5277-2131","name":"arrayWithHoles.js"},{"uid":"5277-2133","name":"iterableToArray.js"},{"uid":"5277-2135","name":"arrayLikeToArray.js"},{"uid":"5277-2137","name":"unsupportedIterableToArray.js"},{"uid":"5277-2139","name":"nonIterableRest.js"},{"uid":"5277-2141","name":"toArray.js"}]},{"name":"dist/esm/i18next.js","uid":"5277-2143"}]},{"name":"bowser/es5.js","uid":"5277-2209"},{"name":"qr-code-styling/lib/qr-code-styling.js","uid":"5277-2251"},{"name":"i18next-browser-languagedetector","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-2297","name":"classCallCheck.js"},{"uid":"5277-2299","name":"typeof.js"},{"uid":"5277-2301","name":"toPrimitive.js"},{"uid":"5277-2303","name":"toPropertyKey.js"},{"uid":"5277-2305","name":"createClass.js"}]},{"name":"dist/esm/i18nextBrowserLanguageDetector.js","uid":"5277-2307"}]},{"name":"react","children":[{"name":"cjs","children":[{"uid":"5277-2313","name":"react.production.min.js"},{"uid":"5277-2317","name":"react.development.js"}]},{"uid":"5277-2319","name":"index.js"}]},{"name":"react-i18next/dist/es","children":[{"uid":"5277-2321","name":"unescape.js"},{"uid":"5277-2323","name":"defaults.js"},{"uid":"5277-2325","name":"initReactI18next.js"},{"uid":"5277-2327","name":"context.js"}]}]},{"uid":"5277-1303","name":"\u0000commonjsHelpers.js"},{"name":"\u0000","children":[{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"eciesjs/dist","children":[{"uid":"5277-1305","name":"index.js?commonjs-exports"},{"name":"keys","children":[{"uid":"5277-1307","name":"index.js?commonjs-exports"},{"uid":"5277-1309","name":"PrivateKey.js?commonjs-exports"},{"uid":"5277-1817","name":"PublicKey.js?commonjs-exports"}]},{"uid":"5277-1809","name":"utils.js?commonjs-exports"},{"uid":"5277-1811","name":"consts.js?commonjs-exports"}]},{"name":"buffer-es6/index.js?commonjs-proxy","uid":"5277-1311"},{"name":"crypto-browserify/index.js?commonjs-exports","uid":"5277-1313"},{"name":"randombytes/browser.js?commonjs-module","uid":"5277-1317"},{"name":"safe-buffer/index.js?commonjs-module","uid":"5277-1319"},{"name":"inherits/inherits_browser.js?commonjs-module","uid":"5277-1325"},{"name":"hash-base/node_modules","children":[{"name":"readable-stream","children":[{"uid":"5277-1329","name":"readable-browser.js?commonjs-module"},{"uid":"5277-1347","name":"errors-browser.js?commonjs-exports"}]},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-1359"}]},{"name":"rollup-plugin-node-builtins/src/es6","children":[{"uid":"5277-1333","name":"events.js?commonjs-proxy"},{"uid":"5277-1341","name":"util.js?commonjs-proxy"},{"uid":"5277-1419","name":"stream.js?commonjs-proxy"},{"uid":"5277-1421","name":"string-decoder.js?commonjs-proxy"},{"uid":"5277-2077","name":"empty.js?commonjs-proxy"}]},{"name":"sha.js/index.js?commonjs-module","uid":"5277-1385"},{"name":"pbkdf2/browser.js?commonjs-exports","uid":"5277-1437"},{"name":"browserify-cipher/browser.js?commonjs-exports","uid":"5277-1451"},{"name":"des.js/lib","children":[{"uid":"5277-1453","name":"des.js?commonjs-exports"},{"name":"des","children":[{"uid":"5277-1455","name":"utils.js?commonjs-exports"},{"uid":"5277-1465","name":"cbc.js?commonjs-exports"}]}]},{"name":"browserify-aes","children":[{"uid":"5277-1475","name":"browser.js?commonjs-exports"},{"uid":"5277-1477","name":"encrypter.js?commonjs-exports"},{"name":"modes","children":[{"uid":"5277-1479","name":"ecb.js?commonjs-exports"},{"uid":"5277-1483","name":"cbc.js?commonjs-exports"},{"uid":"5277-1489","name":"cfb.js?commonjs-exports"},{"uid":"5277-1493","name":"cfb8.js?commonjs-exports"},{"uid":"5277-1497","name":"cfb1.js?commonjs-exports"},{"uid":"5277-1501","name":"ofb.js?commonjs-exports"},{"uid":"5277-1505","name":"ctr.js?commonjs-exports"}]},{"uid":"5277-1515","name":"aes.js?commonjs-exports"},{"uid":"5277-1529","name":"decrypter.js?commonjs-exports"}]},{"name":"browserify-des/modes.js?commonjs-exports","uid":"5277-1535"},{"name":"diffie-hellman","children":[{"uid":"5277-1541","name":"browser.js?commonjs-exports"},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-1543"}]},{"name":"miller-rabin/node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-1547"},{"name":"brorand/index.js?commonjs-module","uid":"5277-1551"},{"name":"browserify-sign","children":[{"name":"node_modules","children":[{"name":"readable-stream","children":[{"uid":"5277-1565","name":"readable-browser.js?commonjs-module"},{"uid":"5277-1573","name":"errors-browser.js?commonjs-exports"}]},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-1583"}]},{"name":"browser/sign.js?commonjs-module","uid":"5277-1603"}]},{"name":"bn.js/lib/bn.js?commonjs-module","uid":"5277-1605"},{"name":"elliptic","children":[{"name":"lib","children":[{"uid":"5277-1611","name":"elliptic.js?commonjs-exports"},{"name":"elliptic","children":[{"uid":"5277-1615","name":"utils.js?commonjs-exports"},{"name":"curve/index.js?commonjs-exports","uid":"5277-1627"},{"uid":"5277-1639","name":"curves.js?commonjs-exports"}]}]},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-1617"}]},{"name":"minimalistic-crypto-utils/lib/utils.js?commonjs-exports","uid":"5277-1621"},{"name":"hash.js/lib","children":[{"uid":"5277-1641","name":"hash.js?commonjs-exports"},{"name":"hash","children":[{"uid":"5277-1643","name":"utils.js?commonjs-exports"},{"uid":"5277-1647","name":"common.js?commonjs-exports"},{"uid":"5277-1651","name":"sha.js?commonjs-exports"},{"name":"sha/common.js?commonjs-exports","uid":"5277-1653"},{"uid":"5277-1669","name":"ripemd.js?commonjs-exports"}]}]},{"name":"parse-asn1/asn1.js?commonjs-exports","uid":"5277-1697"},{"name":"asn1.js","children":[{"name":"lib","children":[{"uid":"5277-1699","name":"asn1.js?commonjs-exports"},{"name":"asn1","children":[{"uid":"5277-1705","name":"api.js?commonjs-exports"},{"name":"encoders/index.js?commonjs-exports","uid":"5277-1707"},{"name":"base","children":[{"uid":"5277-1711","name":"reporter.js?commonjs-exports"},{"uid":"5277-1715","name":"buffer.js?commonjs-exports"},{"uid":"5277-1741","name":"index.js?commonjs-exports"}]},{"name":"constants","children":[{"uid":"5277-1721","name":"der.js?commonjs-exports"},{"uid":"5277-1745","name":"index.js?commonjs-exports"}]},{"name":"decoders/index.js?commonjs-exports","uid":"5277-1731"}]}]},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-1701"}]},{"name":"create-ecdh/node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-1769"},{"name":"public-encrypt","children":[{"uid":"5277-1775","name":"browser.js?commonjs-exports"},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-1781"}]},{"name":"randomfill/browser.js?commonjs-exports","uid":"5277-1795"},{"name":"eventemitter2/lib/eventemitter2.js?commonjs-module","uid":"5277-1827"},{"name":"cross-fetch/dist/browser-ponyfill.js?commonjs-module","uid":"5277-1899"},{"name":"@metamask","children":[{"name":"providers/dist","children":[{"uid":"5277-1907","name":"index.js?commonjs-exports"},{"uid":"5277-1909","name":"BaseProvider.js?commonjs-exports"},{"uid":"5277-1967","name":"messages.js?commonjs-exports"},{"uid":"5277-1971","name":"utils.js?commonjs-exports"},{"name":"middleware/createRpcWarningMiddleware.js?commonjs-exports","uid":"5277-1973"},{"name":"extension-provider/createExternalExtensionProvider.js?commonjs-exports","uid":"5277-1981"},{"uid":"5277-1991","name":"MetaMaskInpageProvider.js?commonjs-exports"},{"uid":"5277-1993","name":"siteMetadata.js?commonjs-exports"},{"uid":"5277-1997","name":"StreamProvider.js?commonjs-exports"},{"uid":"5277-2089","name":"initializeInpageProvider.js?commonjs-exports"},{"uid":"5277-2091","name":"shimWeb3.js?commonjs-exports"}]},{"name":"safe-event-emitter/index.js?commonjs-exports","uid":"5277-1911"},{"name":"object-multiplex/dist","children":[{"uid":"5277-1999","name":"ObjectMultiplex.js?commonjs-exports"},{"uid":"5277-2049","name":"Substream.js?commonjs-exports"}]}]},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-1915","name":"index.js?commonjs-exports"},{"uid":"5277-1917","name":"classes.js?commonjs-exports"},{"uid":"5277-1923","name":"utils.js?commonjs-exports"},{"uid":"5277-1925","name":"error-constants.js?commonjs-exports"},{"uid":"5277-1931","name":"errors.js?commonjs-exports"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-1939","name":"index.js?commonjs-exports"},{"uid":"5277-1941","name":"idRemapMiddleware.js?commonjs-exports"},{"uid":"5277-1943","name":"getUniqueId.js?commonjs-exports"},{"uid":"5277-1949","name":"createAsyncMiddleware.js?commonjs-exports"},{"uid":"5277-1953","name":"createScaffoldMiddleware.js?commonjs-exports"},{"uid":"5277-1957","name":"JsonRpcEngine.js?commonjs-exports"},{"uid":"5277-1961","name":"mergeMiddleware.js?commonjs-exports"}]},{"name":"extension-port-stream/dist/index.js?commonjs-exports","uid":"5277-1983"},{"name":"detect-browser/es/index.js?commonjs-proxy","uid":"5277-1989"},{"name":"readable-stream","children":[{"uid":"5277-2001","name":"readable-browser.js?commonjs-module"},{"name":"node_modules","children":[{"name":"safe-buffer/index.js?commonjs-module","uid":"5277-2011"},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-2029"}]},{"name":"lib/internal/streams/BufferList.js?commonjs-module","uid":"5277-2019"}]},{"name":"process-nextick-args/index.js?commonjs-module","uid":"5277-2003"},{"name":"core-util-is/lib/util.js?commonjs-exports","uid":"5277-2015"},{"name":"once/once.js?commonjs-module","uid":"5277-2041"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-2059","name":"index.js?commonjs-exports"},{"uid":"5277-2061","name":"createEngineStream.js?commonjs-exports"},{"uid":"5277-2065","name":"createStreamMiddleware.js?commonjs-exports"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","uid":"5277-2067"}]},{"name":"bowser/es5.js?commonjs-module","uid":"5277-2207"},{"name":"qr-code-styling/lib/qr-code-styling.js?commonjs-module","uid":"5277-2249"},{"name":"react","children":[{"uid":"5277-2309","name":"index.js?commonjs-module"},{"name":"cjs","children":[{"uid":"5277-2311","name":"react.production.min.js?commonjs-exports"},{"uid":"5277-2315","name":"react.development.js?commonjs-module"}]}]}]},{"name":"node_modules/cross-fetch/dist/browser-ponyfill.js?commonjs-module","uid":"5277-2179"}]},{"name":"-communication-layer/dist/browser/es/metamask-sdk-communication-layer.js","uid":"5277-1903"},{"uid":"5277-1905","name":"\u0000tslib.js"},{"name":"src","children":[{"name":"services","children":[{"name":"SDKProvider","children":[{"name":"ChainManager/handleChainChanged.ts","uid":"5277-2099"},{"name":"ConnectionManager/handleDisconnect.ts","uid":"5277-2101"},{"name":"InitializationManager","children":[{"uid":"5277-2103","name":"initializeState.ts"},{"uid":"5277-2105","name":"initializeStateAsync.ts"}]}]},{"name":"MetaMaskSDK","children":[{"name":"ConnectionManager","children":[{"uid":"5277-2145","name":"connect.ts"},{"uid":"5277-2147","name":"resume.ts"},{"uid":"5277-2153","name":"terminate.ts"},{"uid":"5277-2349","name":"connectAndSign.ts"}]},{"name":"ProviderManager/connectWithExtensionProvider.ts","uid":"5277-2155"},{"name":"InitializerManager","children":[{"uid":"5277-2159","name":"handleAutoAndExtensionConnections.ts"},{"uid":"5277-2161","name":"initEventListeners.ts"},{"uid":"5277-2189","name":"initializeProviderAndEventListeners.ts"},{"uid":"5277-2191","name":"setupAnalytics.ts"},{"uid":"5277-2197","name":"setupDappMetadata.ts"},{"uid":"5277-2205","name":"setupExtensionPreferences.ts"},{"uid":"5277-2233","name":"setupPlatformManager.ts"},{"uid":"5277-2285","name":"setupRemoteConnectionAndInstaller.ts"},{"uid":"5277-2291","name":"setupStorage.ts"},{"uid":"5277-2293","name":"setupInfuraProvider.ts"},{"uid":"5277-2295","name":"setupReadOnlyRPCProviders.ts"},{"uid":"5277-2343","name":"initializeI18next.ts"},{"uid":"5277-2345","name":"performSDKInitialization.ts"},{"uid":"5277-2347","name":"initializeMetaMaskSDK.ts"}]}]},{"uid":"5277-2157","name":"Analytics.ts"},{"name":"RemoteCommunicationPostMessageStream","children":[{"uid":"5277-2165","name":"onMessage.ts"},{"uid":"5277-2169","name":"extractMethod.ts"},{"uid":"5277-2171","name":"write.ts"}]},{"uid":"5277-2167","name":"Ethereum.ts"},{"name":"rpc-requests/RPCRequestHandler.ts","uid":"5277-2183"},{"name":"PlatfformManager","children":[{"uid":"5277-2213","name":"disableWakeLock.ts"},{"uid":"5277-2215","name":"enableWakeLock.ts"},{"uid":"5277-2217","name":"getPlatformType.ts"},{"uid":"5277-2219","name":"isMetaMaskInstalled.ts"},{"uid":"5277-2221","name":"openDeeplink.ts"}]},{"name":"MetaMaskInstaller","children":[{"uid":"5277-2235","name":"checkInstallation.ts"},{"uid":"5277-2237","name":"redirectToProperInstall.ts"},{"uid":"5277-2241","name":"startDesktopOnboarding.ts"},{"uid":"5277-2243","name":"startInstaller.ts"}]},{"name":"RemoteConnection","children":[{"name":"ConnectionInitializer/initializeConnector.ts","uid":"5277-2263"},{"name":"ConnectionManager","children":[{"uid":"5277-2265","name":"connectWithDeeplink.ts"},{"uid":"5277-2269","name":"connectWithModalInstaller.ts"},{"uid":"5277-2277","name":"startConnection.ts"}]},{"name":"ModalManager","children":[{"uid":"5277-2267","name":"showInstallModal.ts"},{"uid":"5277-2271","name":"onOTPModalDisconnect.ts"},{"uid":"5277-2273","name":"waitForOTPAnswer.ts"},{"uid":"5277-2275","name":"reconnectWithModalOTP.ts"},{"uid":"5277-2281","name":"showActiveModal.ts"}]},{"name":"EventListeners/setupListeners.ts","uid":"5277-2279"},{"uid":"5277-2283","name":"RemoteConnection.ts"}]}]},{"name":"provider","children":[{"uid":"5277-2107","name":"SDKProvider.ts"},{"uid":"5277-2187","name":"initializeMobileProvider.ts"},{"uid":"5277-2199","name":"wrapExtensionProvider.ts"}]},{"uid":"5277-2149","name":"config.ts"},{"name":"types","children":[{"uid":"5277-2151","name":"ProviderUpdateType.ts"},{"uid":"5277-2211","name":"WakeLockStatus.ts"}]},{"uid":"5277-2163","name":"constants.ts"},{"name":"PostMessageStream","children":[{"uid":"5277-2173","name":"RemoteCommunicationPostMessageStream.ts"},{"uid":"5277-2175","name":"getPostMessageStream.ts"}]},{"name":"utils","children":[{"uid":"5277-2177","name":"wait.ts"},{"uid":"5277-2193","name":"extractFavicon.ts"},{"uid":"5277-2195","name":"getBase64FromUrl.ts"},{"uid":"5277-2201","name":"eip6963RequestProvider.ts"},{"uid":"5277-2203","name":"get-browser-extension.ts"},{"uid":"5277-2223","name":"hasNativeWakeLockSupport.ts"},{"uid":"5277-2225","name":"isOldIOS.ts"}]},{"name":"Platform","children":[{"uid":"5277-2227","name":"Media.ts"},{"uid":"5277-2229","name":"WakeLockManager.ts"},{"uid":"5277-2231","name":"PlatfformManager.ts"},{"uid":"5277-2245","name":"MetaMaskInstaller.ts"}]},{"name":"ui/InstallModal","children":[{"uid":"5277-2255","name":"InstallModal-web.ts"},{"uid":"5277-2257","name":"installModal.ts"},{"uid":"5277-2259","name":"pendingModal-web.ts"},{"uid":"5277-2261","name":"pendingModal.ts"}]},{"name":"storage-manager","children":[{"uid":"5277-2287","name":"StorageManagerWeb.ts"},{"uid":"5277-2289","name":"getStorageManager.ts"}]},{"name":"locales","children":[{"uid":"5277-2329","name":"en.json"},{"uid":"5277-2331","name":"es.json"},{"uid":"5277-2333","name":"fr.json"},{"uid":"5277-2335","name":"he.json"},{"uid":"5277-2337","name":"it.json"},{"uid":"5277-2339","name":"pt.json"},{"uid":"5277-2341","name":"tr.json"}]},{"uid":"5277-2351","name":"sdk.ts"},{"uid":"5277-2353","name":"index.ts"}]},{"name":"node_modules/cross-fetch/dist/browser-ponyfill.js","uid":"5277-2181"},{"uid":"5277-2185","name":"package.json"},{"name":"\u0000-install-modal-web/dist/umd/index.js?commonjs-module","uid":"5277-2247"},{"name":"-install-modal-web/dist/umd/index.js","uid":"5277-2253"}]}],"isRoot":true},"nodeParts":{"5277-1293":{"renderedLength":199,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1292"},"5277-1295":{"renderedLength":4494,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1294"},"5277-1297":{"renderedLength":2956,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1296"},"5277-1299":{"renderedLength":182,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1298"},"5277-1301":{"renderedLength":67087,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1300"},"5277-1303":{"renderedLength":1279,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1302"},"5277-1305":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1304"},"5277-1307":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1306"},"5277-1309":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1308"},"5277-1311":{"renderedLength":77,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1310"},"5277-1313":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1312"},"5277-1315":{"renderedLength":8630,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1314"},"5277-1317":{"renderedLength":42,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1316"},"5277-1319":{"renderedLength":45,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1318"},"5277-1321":{"renderedLength":2578,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1320"},"5277-1323":{"renderedLength":2128,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1322"},"5277-1325":{"renderedLength":49,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1324"},"5277-1327":{"renderedLength":1173,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1326"},"5277-1329":{"renderedLength":50,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1328"},"5277-1331":{"renderedLength":17792,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1330"},"5277-1333":{"renderedLength":74,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1332"},"5277-1335":{"renderedLength":60,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1334"},"5277-1337":{"renderedLength":966,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1336"},"5277-1339":{"renderedLength":19532,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1338"},"5277-1341":{"renderedLength":72,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1340"},"5277-1343":{"renderedLength":9459,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1342"},"5277-1345":{"renderedLength":4169,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1344"},"5277-1347":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1346"},"5277-1349":{"renderedLength":5460,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1348"},"5277-1351":{"renderedLength":956,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1350"},"5277-1353":{"renderedLength":2335,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1352"},"5277-1355":{"renderedLength":27942,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1354"},"5277-1357":{"renderedLength":4527,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1356"},"5277-1359":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1358"},"5277-1361":{"renderedLength":11859,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1360"},"5277-1363":{"renderedLength":3935,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1362"},"5277-1365":{"renderedLength":9031,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1364"},"5277-1367":{"renderedLength":416,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1366"},"5277-1369":{"renderedLength":47172,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1368"},"5277-1371":{"renderedLength":5942,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1370"},"5277-1373":{"renderedLength":492,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1372"},"5277-1375":{"renderedLength":3284,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1374"},"5277-1377":{"renderedLength":648,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1376"},"5277-1379":{"renderedLength":3274,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1378"},"5277-1381":{"renderedLength":6215,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1380"},"5277-1383":{"renderedLength":6276,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1382"},"5277-1385":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1384"},"5277-1387":{"renderedLength":2664,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1386"},"5277-1389":{"renderedLength":2851,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1388"},"5277-1391":{"renderedLength":3003,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1390"},"5277-1393":{"renderedLength":4687,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1392"},"5277-1395":{"renderedLength":1603,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1394"},"5277-1397":{"renderedLength":9952,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1396"},"5277-1399":{"renderedLength":1740,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1398"},"5277-1401":{"renderedLength":617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1400"},"5277-1403":{"renderedLength":1892,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1402"},"5277-1405":{"renderedLength":10004,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1404"},"5277-1407":{"renderedLength":36074,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1406"},"5277-1409":{"renderedLength":18671,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1408"},"5277-1411":{"renderedLength":1369,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1410"},"5277-1413":{"renderedLength":7864,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1412"},"5277-1415":{"renderedLength":375,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1414"},"5277-1417":{"renderedLength":3168,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1416"},"5277-1419":{"renderedLength":74,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1418"},"5277-1421":{"renderedLength":81,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1420"},"5277-1423":{"renderedLength":3298,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1422"},"5277-1425":{"renderedLength":875,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1424"},"5277-1427":{"renderedLength":1410,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1426"},"5277-1429":{"renderedLength":148,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1428"},"5277-1431":{"renderedLength":2197,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1430"},"5277-1433":{"renderedLength":4683,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1432"},"5277-1435":{"renderedLength":35,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1434"},"5277-1437":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1436"},"5277-1439":{"renderedLength":690,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1438"},"5277-1441":{"renderedLength":572,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1440"},"5277-1443":{"renderedLength":564,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1442"},"5277-1445":{"renderedLength":3553,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1444"},"5277-1447":{"renderedLength":4447,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1446"},"5277-1449":{"renderedLength":85,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1448"},"5277-1451":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1450"},"5277-1453":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1452"},"5277-1455":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1454"},"5277-1457":{"renderedLength":9206,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1456"},"5277-1459":{"renderedLength":373,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1458"},"5277-1461":{"renderedLength":4664,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1460"},"5277-1463":{"renderedLength":4651,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1462"},"5277-1465":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1464"},"5277-1467":{"renderedLength":2002,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1466"},"5277-1469":{"renderedLength":1799,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1468"},"5277-1471":{"renderedLength":160,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1470"},"5277-1473":{"renderedLength":1835,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1472"},"5277-1475":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1474"},"5277-1477":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1476"},"5277-1479":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1478"},"5277-1481":{"renderedLength":240,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1480"},"5277-1483":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1482"},"5277-1485":{"renderedLength":306,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1484"},"5277-1487":{"renderedLength":479,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1486"},"5277-1489":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1488"},"5277-1491":{"renderedLength":1216,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1490"},"5277-1493":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1492"},"5277-1495":{"renderedLength":760,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1494"},"5277-1497":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1496"},"5277-1499":{"renderedLength":1361,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1498"},"5277-1501":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1500"},"5277-1503":{"renderedLength":570,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1502"},"5277-1505":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1504"},"5277-1507":{"renderedLength":448,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1506"},"5277-1509":{"renderedLength":1244,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1508"},"5277-1511":{"renderedLength":4735,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1510"},"5277-1513":{"renderedLength":446,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1512"},"5277-1515":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1514"},"5277-1517":{"renderedLength":8700,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1516"},"5277-1519":{"renderedLength":2942,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1518"},"5277-1521":{"renderedLength":4238,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1520"},"5277-1523":{"renderedLength":938,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1522"},"5277-1525":{"renderedLength":1665,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1524"},"5277-1527":{"renderedLength":3997,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1526"},"5277-1529":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1528"},"5277-1531":{"renderedLength":4475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1530"},"5277-1533":{"renderedLength":631,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1532"},"5277-1535":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1534"},"5277-1537":{"renderedLength":677,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1536"},"5277-1539":{"renderedLength":2629,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1538"},"5277-1541":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1540"},"5277-1543":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1542"},"5277-1545":{"renderedLength":126108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1544"},"5277-1547":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1546"},"5277-1549":{"renderedLength":126108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1548"},"5277-1551":{"renderedLength":40,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1550"},"5277-1553":{"renderedLength":2474,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1552"},"5277-1555":{"renderedLength":3815,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1554"},"5277-1557":{"renderedLength":3646,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1556"},"5277-1559":{"renderedLength":7701,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1558"},"5277-1561":{"renderedLength":6006,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1560"},"5277-1563":{"renderedLength":1744,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1562"},"5277-1565":{"renderedLength":50,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1564"},"5277-1567":{"renderedLength":60,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1566"},"5277-1569":{"renderedLength":9443,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1568"},"5277-1571":{"renderedLength":4149,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1570"},"5277-1573":{"renderedLength":35,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1572"},"5277-1575":{"renderedLength":5404,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1574"},"5277-1577":{"renderedLength":940,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1576"},"5277-1579":{"renderedLength":27938,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1578"},"5277-1581":{"renderedLength":4527,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1580"},"5277-1583":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1582"},"5277-1585":{"renderedLength":11859,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1584"},"5277-1587":{"renderedLength":3927,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1586"},"5277-1589":{"renderedLength":9015,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1588"},"5277-1591":{"renderedLength":400,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1590"},"5277-1593":{"renderedLength":47162,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1592"},"5277-1595":{"renderedLength":5924,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1594"},"5277-1597":{"renderedLength":492,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1596"},"5277-1599":{"renderedLength":3258,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1598"},"5277-1601":{"renderedLength":646,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1600"},"5277-1603":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1602"},"5277-1605":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1604"},"5277-1607":{"renderedLength":123486,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1606"},"5277-1609":{"renderedLength":1490,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1608"},"5277-1611":{"renderedLength":32,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1610"},"5277-1613":{"renderedLength":2454,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1612"},"5277-1615":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1614"},"5277-1617":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1616"},"5277-1619":{"renderedLength":126108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1618"},"5277-1621":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1620"},"5277-1623":{"renderedLength":1862,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1622"},"5277-1625":{"renderedLength":3686,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1624"},"5277-1627":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1626"},"5277-1629":{"renderedLength":13058,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1628"},"5277-1631":{"renderedLength":32650,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1630"},"5277-1633":{"renderedLength":6383,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1632"},"5277-1635":{"renderedLength":15423,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1634"},"5277-1637":{"renderedLength":232,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1636"},"5277-1639":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1638"},"5277-1641":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1640"},"5277-1643":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1642"},"5277-1645":{"renderedLength":9523,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1644"},"5277-1647":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1646"},"5277-1649":{"renderedLength":3206,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1648"},"5277-1651":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1650"},"5277-1653":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1652"},"5277-1655":{"renderedLength":1391,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1654"},"5277-1657":{"renderedLength":2268,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1656"},"5277-1659":{"renderedLength":3979,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1658"},"5277-1661":{"renderedLength":907,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1660"},"5277-1663":{"renderedLength":11728,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1662"},"5277-1665":{"renderedLength":1066,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1664"},"5277-1667":{"renderedLength":150,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1666"},"5277-1669":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1668"},"5277-1671":{"renderedLength":5098,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1670"},"5277-1673":{"renderedLength":1546,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1672"},"5277-1675":{"renderedLength":586,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1674"},"5277-1677":{"renderedLength":42919,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1676"},"5277-1679":{"renderedLength":8887,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1678"},"5277-1681":{"renderedLength":4047,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1680"},"5277-1683":{"renderedLength":4305,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1682"},"5277-1685":{"renderedLength":5001,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1684"},"5277-1687":{"renderedLength":8898,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1686"},"5277-1689":{"renderedLength":3451,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1688"},"5277-1691":{"renderedLength":2307,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1690"},"5277-1693":{"renderedLength":4610,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1692"},"5277-1695":{"renderedLength":654,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1694"},"5277-1697":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1696"},"5277-1699":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1698"},"5277-1701":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1700"},"5277-1703":{"renderedLength":126108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1702"},"5277-1705":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1704"},"5277-1707":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1706"},"5277-1709":{"renderedLength":2840,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1708"},"5277-1711":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1710"},"5277-1713":{"renderedLength":3841,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1712"},"5277-1715":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1714"},"5277-1717":{"renderedLength":5684,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1716"},"5277-1719":{"renderedLength":22894,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1718"},"5277-1721":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1720"},"5277-1723":{"renderedLength":1719,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1722"},"5277-1725":{"renderedLength":10814,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1724"},"5277-1727":{"renderedLength":796,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1726"},"5277-1729":{"renderedLength":174,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1728"},"5277-1731":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1730"},"5277-1733":{"renderedLength":11350,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1732"},"5277-1735":{"renderedLength":1657,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1734"},"5277-1737":{"renderedLength":170,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1736"},"5277-1739":{"renderedLength":2031,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1738"},"5277-1741":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1740"},"5277-1743":{"renderedLength":285,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1742"},"5277-1745":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1744"},"5277-1747":{"renderedLength":587,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1746"},"5277-1749":{"renderedLength":326,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1748"},"5277-1751":{"renderedLength":3164,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1750"},"5277-1753":{"renderedLength":4398,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1752"},"5277-1755":{"renderedLength":702,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1754"},"5277-1757":{"renderedLength":1607,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1756"},"5277-1759":{"renderedLength":4951,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1758"},"5277-1761":{"renderedLength":285,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1760"},"5277-1763":{"renderedLength":5743,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1762"},"5277-1765":{"renderedLength":3638,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1764"},"5277-1767":{"renderedLength":3414,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1766"},"5277-1769":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1768"},"5277-1771":{"renderedLength":126108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1770"},"5277-1773":{"renderedLength":4419,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1772"},"5277-1775":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1774"},"5277-1777":{"renderedLength":627,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1776"},"5277-1779":{"renderedLength":223,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1778"},"5277-1781":{"renderedLength":35,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1780"},"5277-1783":{"renderedLength":126100,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1782"},"5277-1785":{"renderedLength":403,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1784"},"5277-1787":{"renderedLength":3383,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1786"},"5277-1789":{"renderedLength":3617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1788"},"5277-1791":{"renderedLength":471,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1790"},"5277-1793":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1792"},"5277-1795":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1794"},"5277-1797":{"renderedLength":3715,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1796"},"5277-1799":{"renderedLength":4481,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1798"},"5277-1801":{"renderedLength":7125,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1800"},"5277-1803":{"renderedLength":14075,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1802"},"5277-1805":{"renderedLength":14531,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1804"},"5277-1807":{"renderedLength":43,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1806"},"5277-1809":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1808"},"5277-1811":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1810"},"5277-1813":{"renderedLength":583,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1812"},"5277-1815":{"renderedLength":2361,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1814"},"5277-1817":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1816"},"5277-1819":{"renderedLength":2294,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1818"},"5277-1821":{"renderedLength":2115,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1820"},"5277-1823":{"renderedLength":781,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1822"},"5277-1825":{"renderedLength":2158,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1824"},"5277-1827":{"renderedLength":46,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1826"},"5277-1829":{"renderedLength":62446,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1828"},"5277-1831":{"renderedLength":1229,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1830"},"5277-1833":{"renderedLength":142,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1832"},"5277-1835":{"renderedLength":118,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1834"},"5277-1837":{"renderedLength":1672,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1836"},"5277-1839":{"renderedLength":625,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1838"},"5277-1841":{"renderedLength":634,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1840"},"5277-1843":{"renderedLength":3065,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1842"},"5277-1845":{"renderedLength":1543,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1844"},"5277-1847":{"renderedLength":2517,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1846"},"5277-1849":{"renderedLength":2074,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1848"},"5277-1851":{"renderedLength":5007,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1850"},"5277-1853":{"renderedLength":369,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1852"},"5277-1855":{"renderedLength":2211,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1854"},"5277-1857":{"renderedLength":1206,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1856"},"5277-1859":{"renderedLength":4787,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1858"},"5277-1861":{"renderedLength":1342,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1860"},"5277-1863":{"renderedLength":448,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1862"},"5277-1865":{"renderedLength":723,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1864"},"5277-1867":{"renderedLength":15502,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1866"},"5277-1869":{"renderedLength":594,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1868"},"5277-1871":{"renderedLength":5958,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1870"},"5277-1873":{"renderedLength":4166,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1872"},"5277-1875":{"renderedLength":146,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1874"},"5277-1877":{"renderedLength":3174,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1876"},"5277-1879":{"renderedLength":26394,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1878"},"5277-1881":{"renderedLength":2368,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1880"},"5277-1883":{"renderedLength":2167,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1882"},"5277-1885":{"renderedLength":3669,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1884"},"5277-1887":{"renderedLength":13477,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1886"},"5277-1889":{"renderedLength":187,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1888"},"5277-1891":{"renderedLength":33657,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1890"},"5277-1893":{"renderedLength":2168,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1892"},"5277-1895":{"renderedLength":14208,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1894"},"5277-1897":{"renderedLength":1610,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1896"},"5277-1899":{"renderedLength":50,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1898"},"5277-1901":{"renderedLength":21916,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1900"},"5277-1903":{"renderedLength":67819,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1902"},"5277-1905":{"renderedLength":3199,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1904"},"5277-1907":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1906"},"5277-1909":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1908"},"5277-1911":{"renderedLength":40,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1910"},"5277-1913":{"renderedLength":2904,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1912"},"5277-1915":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1914"},"5277-1917":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1916"},"5277-1919":{"renderedLength":8414,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1918"},"5277-1921":{"renderedLength":3182,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1920"},"5277-1923":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1922"},"5277-1925":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1924"},"5277-1927":{"renderedLength":3644,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1926"},"5277-1929":{"renderedLength":5484,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1928"},"5277-1931":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1930"},"5277-1933":{"renderedLength":7372,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1932"},"5277-1935":{"renderedLength":1345,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1934"},"5277-1937":{"renderedLength":1776,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1936"},"5277-1939":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1938"},"5277-1941":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1940"},"5277-1943":{"renderedLength":35,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1942"},"5277-1945":{"renderedLength":521,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1944"},"5277-1947":{"renderedLength":776,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1946"},"5277-1949":{"renderedLength":45,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1948"},"5277-1951":{"renderedLength":3397,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1950"},"5277-1953":{"renderedLength":48,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1952"},"5277-1955":{"renderedLength":958,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1954"},"5277-1957":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1956"},"5277-1959":{"renderedLength":12520,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1958"},"5277-1961":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1960"},"5277-1963":{"renderedLength":524,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1962"},"5277-1965":{"renderedLength":1169,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1964"},"5277-1967":{"renderedLength":32,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1966"},"5277-1969":{"renderedLength":3937,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1968"},"5277-1971":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1970"},"5277-1973":{"renderedLength":50,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1972"},"5277-1975":{"renderedLength":1785,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1974"},"5277-1977":{"renderedLength":4098,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1976"},"5277-1979":{"renderedLength":16103,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1978"},"5277-1981":{"renderedLength":55,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1980"},"5277-1983":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1982"},"5277-1985":{"renderedLength":3310,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1984"},"5277-1987":{"renderedLength":10180,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1986"},"5277-1989":{"renderedLength":70,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1988"},"5277-1991":{"renderedLength":44,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1990"},"5277-1993":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1992"},"5277-1995":{"renderedLength":3767,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1994"},"5277-1997":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1996"},"5277-1999":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-1998"},"5277-2001":{"renderedLength":48,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2000"},"5277-2003":{"renderedLength":51,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2002"},"5277-2005":{"renderedLength":1626,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2004"},"5277-2007":{"renderedLength":176,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2006"},"5277-2009":{"renderedLength":58,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2008"},"5277-2011":{"renderedLength":43,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2010"},"5277-2013":{"renderedLength":2402,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2012"},"5277-2015":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2014"},"5277-2017":{"renderedLength":4098,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2016"},"5277-2019":{"renderedLength":43,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2018"},"5277-2021":{"renderedLength":3191,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2020"},"5277-2023":{"renderedLength":2969,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2022"},"5277-2025":{"renderedLength":25949,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2024"},"5277-2027":{"renderedLength":3968,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2026"},"5277-2029":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2028"},"5277-2031":{"renderedLength":11843,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2030"},"5277-2033":{"renderedLength":41505,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2032"},"5277-2035":{"renderedLength":5664,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2034"},"5277-2037":{"renderedLength":626,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2036"},"5277-2039":{"renderedLength":537,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2038"},"5277-2041":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2040"},"5277-2043":{"renderedLength":1265,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2042"},"5277-2045":{"renderedLength":1452,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2044"},"5277-2047":{"renderedLength":3586,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2046"},"5277-2049":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2048"},"5277-2051":{"renderedLength":1300,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2050"},"5277-2053":{"renderedLength":4098,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2052"},"5277-2055":{"renderedLength":116,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2054"},"5277-2057":{"renderedLength":913,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2056"},"5277-2059":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2058"},"5277-2061":{"renderedLength":42,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2060"},"5277-2063":{"renderedLength":1631,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2062"},"5277-2065":{"renderedLength":46,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2064"},"5277-2067":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2066"},"5277-2069":{"renderedLength":2858,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2068"},"5277-2071":{"renderedLength":5265,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2070"},"5277-2073":{"renderedLength":660,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2072"},"5277-2075":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2074"},"5277-2077":{"renderedLength":73,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2076"},"5277-2079":{"renderedLength":3016,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2078"},"5277-2081":{"renderedLength":8831,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2080"},"5277-2083":{"renderedLength":15451,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2082"},"5277-2085":{"renderedLength":237,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2084"},"5277-2087":{"renderedLength":2590,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2086"},"5277-2089":{"renderedLength":46,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2088"},"5277-2091":{"renderedLength":32,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2090"},"5277-2093":{"renderedLength":3215,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2092"},"5277-2095":{"renderedLength":2705,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2094"},"5277-2097":{"renderedLength":2102,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2096"},"5277-2099":{"renderedLength":2296,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2098"},"5277-2101":{"renderedLength":2984,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2100"},"5277-2103":{"renderedLength":1356,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2102"},"5277-2105":{"renderedLength":5152,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2104"},"5277-2107":{"renderedLength":2946,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2106"},"5277-2109":{"renderedLength":437,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2108"},"5277-2111":{"renderedLength":223,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2110"},"5277-2113":{"renderedLength":529,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2112"},"5277-2115":{"renderedLength":183,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2114"},"5277-2117":{"renderedLength":871,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2116"},"5277-2119":{"renderedLength":248,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2118"},"5277-2121":{"renderedLength":298,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2120"},"5277-2123":{"renderedLength":692,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2122"},"5277-2125":{"renderedLength":402,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2124"},"5277-2127":{"renderedLength":294,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2126"},"5277-2129":{"renderedLength":452,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2128"},"5277-2131":{"renderedLength":107,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2130"},"5277-2133":{"renderedLength":196,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2132"},"5277-2135":{"renderedLength":245,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2134"},"5277-2137":{"renderedLength":524,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2136"},"5277-2139":{"renderedLength":231,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2138"},"5277-2141":{"renderedLength":176,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2140"},"5277-2143":{"renderedLength":134855,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2142"},"5277-2145":{"renderedLength":1590,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2144"},"5277-2147":{"renderedLength":1342,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2146"},"5277-2149":{"renderedLength":1200,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2148"},"5277-2151":{"renderedLength":386,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2150"},"5277-2153":{"renderedLength":2585,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2152"},"5277-2155":{"renderedLength":2997,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2154"},"5277-2157":{"renderedLength":1949,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2156"},"5277-2159":{"renderedLength":3794,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2158"},"5277-2161":{"renderedLength":1323,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2160"},"5277-2163":{"renderedLength":906,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2162"},"5277-2165":{"renderedLength":1716,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2164"},"5277-2167":{"renderedLength":3306,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2166"},"5277-2169":{"renderedLength":610,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2168"},"5277-2171":{"renderedLength":6521,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2170"},"5277-2173":{"renderedLength":1572,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2172"},"5277-2175":{"renderedLength":760,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2174"},"5277-2177":{"renderedLength":235,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2176"},"5277-2179":{"renderedLength":48,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2178"},"5277-2181":{"renderedLength":26945,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2180"},"5277-2183":{"renderedLength":1730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2182"},"5277-2185":{"renderedLength":6586,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2184"},"5277-2187":{"renderedLength":14900,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2186"},"5277-2189":{"renderedLength":1803,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2188"},"5277-2191":{"renderedLength":1626,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2190"},"5277-2193":{"renderedLength":709,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2192"},"5277-2195":{"renderedLength":562,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2194"},"5277-2197":{"renderedLength":1736,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2196"},"5277-2199":{"renderedLength":1830,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2198"},"5277-2201":{"renderedLength":1459,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2200"},"5277-2203":{"renderedLength":2214,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2202"},"5277-2205":{"renderedLength":4067,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2204"},"5277-2207":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2206"},"5277-2209":{"renderedLength":26025,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2208"},"5277-2211":{"renderedLength":317,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2210"},"5277-2213":{"renderedLength":408,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2212"},"5277-2215":{"renderedLength":1106,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2214"},"5277-2217":{"renderedLength":806,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2216"},"5277-2219":{"renderedLength":653,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2218"},"5277-2221":{"renderedLength":1503,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2220"},"5277-2223":{"renderedLength":120,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2222"},"5277-2225":{"renderedLength":569,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2224"},"5277-2227":{"renderedLength":12542,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2226"},"5277-2229":{"renderedLength":7999,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2228"},"5277-2231":{"renderedLength":4354,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2230"},"5277-2233":{"renderedLength":1376,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2232"},"5277-2235":{"renderedLength":1498,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2234"},"5277-2237":{"renderedLength":3262,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2236"},"5277-2239":{"renderedLength":14042,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2238"},"5277-2241":{"renderedLength":1224,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2240"},"5277-2243":{"renderedLength":1566,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2242"},"5277-2245":{"renderedLength":1635,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2244"},"5277-2247":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2246"},"5277-2249":{"renderedLength":46,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2248"},"5277-2251":{"renderedLength":52621,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2250"},"5277-2253":{"renderedLength":554383,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2252"},"5277-2255":{"renderedLength":3219,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2254"},"5277-2257":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2256"},"5277-2259":{"renderedLength":2078,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2258"},"5277-2261":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2260"},"5277-2263":{"renderedLength":2171,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2262"},"5277-2265":{"renderedLength":1030,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2264"},"5277-2267":{"renderedLength":1357,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2266"},"5277-2269":{"renderedLength":2587,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2268"},"5277-2271":{"renderedLength":380,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2270"},"5277-2273":{"renderedLength":368,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2272"},"5277-2275":{"renderedLength":3498,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2274"},"5277-2277":{"renderedLength":3083,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2276"},"5277-2279":{"renderedLength":7996,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2278"},"5277-2281":{"renderedLength":1067,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2280"},"5277-2283":{"renderedLength":5009,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2282"},"5277-2285":{"renderedLength":3681,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2284"},"5277-2287":{"renderedLength":2762,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2286"},"5277-2289":{"renderedLength":709,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2288"},"5277-2291":{"renderedLength":1340,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2290"},"5277-2293":{"renderedLength":4939,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2292"},"5277-2295":{"renderedLength":716,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2294"},"5277-2297":{"renderedLength":221,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2296"},"5277-2299":{"renderedLength":431,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2298"},"5277-2301":{"renderedLength":523,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2300"},"5277-2303":{"renderedLength":177,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2302"},"5277-2305":{"renderedLength":861,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2304"},"5277-2307":{"renderedLength":16339,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2306"},"5277-2309":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2308"},"5277-2311":{"renderedLength":42,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2310"},"5277-2313":{"renderedLength":8001,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2312"},"5277-2315":{"renderedLength":50,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2314"},"5277-2317":{"renderedLength":119668,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2316"},"5277-2319":{"renderedLength":257,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2318"},"5277-2321":{"renderedLength":913,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2320"},"5277-2323":{"renderedLength":639,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2322"},"5277-2325":{"renderedLength":185,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2324"},"5277-2327":{"renderedLength":41,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2326"},"5277-2329":{"renderedLength":2138,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2328"},"5277-2331":{"renderedLength":2335,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2330"},"5277-2333":{"renderedLength":2368,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2332"},"5277-2335":{"renderedLength":2651,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2334"},"5277-2337":{"renderedLength":2313,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2336"},"5277-2339":{"renderedLength":2257,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2338"},"5277-2341":{"renderedLength":2246,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2340"},"5277-2343":{"renderedLength":3397,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2342"},"5277-2345":{"renderedLength":4160,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2344"},"5277-2347":{"renderedLength":1931,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2346"},"5277-2349":{"renderedLength":1628,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2348"},"5277-2351":{"renderedLength":7767,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2350"},"5277-2353":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-2352"}},"nodeMetas":{"5277-1292":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-globals/src/global.js","moduleParts":{"metamask-sdk.js":"5277-1293"},"imported":[],"importedBy":[{"uid":"5277-1902"},{"uid":"5277-1300"},{"uid":"5277-1314"},{"uid":"5277-1338"}]},"5277-1294":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/base64.js","moduleParts":{"metamask-sdk.js":"5277-1295"},"imported":[],"importedBy":[{"uid":"5277-1300"}]},"5277-1296":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/ieee754.js","moduleParts":{"metamask-sdk.js":"5277-1297"},"imported":[],"importedBy":[{"uid":"5277-1300"}]},"5277-1298":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/isArray.js","moduleParts":{"metamask-sdk.js":"5277-1299"},"imported":[],"importedBy":[{"uid":"5277-1300"}]},"5277-1300":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/index.js","moduleParts":{"metamask-sdk.js":"5277-1301"},"imported":[{"uid":"5277-1292"},{"uid":"5277-1294"},{"uid":"5277-1296"},{"uid":"5277-1298"}],"importedBy":[{"uid":"5277-1824"},{"uid":"5277-1814"},{"uid":"5277-1820"},{"uid":"5277-1818"},{"uid":"5277-1562"},{"uid":"5277-1772"},{"uid":"5277-1870"},{"uid":"5277-1984"},{"uid":"5277-1560"},{"uid":"5277-2164"},{"uid":"5277-1338"},{"uid":"5277-1406"},{"uid":"5277-1408"},{"uid":"5277-2168"},{"uid":"5277-1310"},{"uid":"5277-1608"},{"uid":"5277-1402"},{"uid":"5277-1404"},{"uid":"5277-1502"},{"uid":"5277-1484"}]},"5277-1302":{"id":"\u0000commonjsHelpers.js","moduleParts":{"metamask-sdk.js":"5277-1303"},"imported":[],"importedBy":[{"uid":"5277-1824"},{"uid":"5277-1828"},{"uid":"5277-1900"},{"uid":"5277-2096"},{"uid":"5277-1934"},{"uid":"5277-1822"},{"uid":"5277-1814"},{"uid":"5277-1812"},{"uid":"5277-1978"},{"uid":"5277-2086"},{"uid":"5277-2094"},{"uid":"5277-2082"},{"uid":"5277-2092"},{"uid":"5277-2080"},{"uid":"5277-1798"},{"uid":"5277-1988"},{"uid":"5277-1920"},{"uid":"5277-1928"},{"uid":"5277-1932"},{"uid":"5277-1926"},{"uid":"5277-2208"},{"uid":"5277-1820"},{"uid":"5277-1818"},{"uid":"5277-1562"},{"uid":"5277-1766"},{"uid":"5277-1772"},{"uid":"5277-1806"},{"uid":"5277-1912"},{"uid":"5277-1936"},{"uid":"5277-1964"},{"uid":"5277-1968"},{"uid":"5277-1976"},{"uid":"5277-1984"},{"uid":"5277-1986"},{"uid":"5277-1994"},{"uid":"5277-2054"},{"uid":"5277-2056"},{"uid":"5277-2072"},{"uid":"5277-2078"},{"uid":"5277-2180"},{"uid":"5277-1322"},{"uid":"5277-1424"},{"uid":"5277-1430"},{"uid":"5277-1434"},{"uid":"5277-1448"},{"uid":"5277-1538"},{"uid":"5277-1556"},{"uid":"5277-1560"},{"uid":"5277-1762"},{"uid":"5277-1764"},{"uid":"5277-1694"},{"uid":"5277-1790"},{"uid":"5277-1796"},{"uid":"5277-1332"},{"uid":"5277-1418"},{"uid":"5277-2076"},{"uid":"5277-1918"},{"uid":"5277-2318"},{"uid":"5277-1800"},{"uid":"5277-1554"},{"uid":"5277-1320"},{"uid":"5277-1600"},{"uid":"5277-1326"},{"uid":"5277-1552"},{"uid":"5277-1686"},{"uid":"5277-1770"},{"uid":"5277-1802"},{"uid":"5277-1804"},{"uid":"5277-1946"},{"uid":"5277-1950"},{"uid":"5277-1954"},{"uid":"5277-1944"},{"uid":"5277-1958"},{"uid":"5277-1962"},{"uid":"5277-1974"},{"uid":"5277-2052"},{"uid":"5277-2062"},{"uid":"5277-2070"},{"uid":"5277-2044"},{"uid":"5277-2046"},{"uid":"5277-2074"},{"uid":"5277-2312"},{"uid":"5277-2316"},{"uid":"5277-2471"},{"uid":"5277-2252"},{"uid":"5277-1310"},{"uid":"5277-1380"},{"uid":"5277-1382"},{"uid":"5277-1400"},{"uid":"5277-1422"},{"uid":"5277-1426"},{"uid":"5277-1428"},{"uid":"5277-1446"},{"uid":"5277-1444"},{"uid":"5277-1472"},{"uid":"5277-1532"},{"uid":"5277-1512"},{"uid":"5277-1536"},{"uid":"5277-1524"},{"uid":"5277-1544"},{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-1580"},{"uid":"5277-1608"},{"uid":"5277-1606"},{"uid":"5277-1758"},{"uid":"5277-1624"},{"uid":"5277-1636"},{"uid":"5277-1678"},{"uid":"5277-1692"},{"uid":"5277-1786"},{"uid":"5277-1788"},{"uid":"5277-2250"},{"uid":"5277-1420"},{"uid":"5277-1548"},{"uid":"5277-1340"},{"uid":"5277-1568"},{"uid":"5277-1584"},{"uid":"5277-1588"},{"uid":"5277-1590"},{"uid":"5277-1594"},{"uid":"5277-1596"},{"uid":"5277-1586"},{"uid":"5277-1598"},{"uid":"5277-1676"},{"uid":"5277-1618"},{"uid":"5277-1680"},{"uid":"5277-1682"},{"uid":"5277-1684"},{"uid":"5277-2038"},{"uid":"5277-2050"},{"uid":"5277-2068"},{"uid":"5277-2042"},{"uid":"5277-1378"},{"uid":"5277-1388"},{"uid":"5277-1390"},{"uid":"5277-1394"},{"uid":"5277-1392"},{"uid":"5277-1398"},{"uid":"5277-1396"},{"uid":"5277-1438"},{"uid":"5277-1440"},{"uid":"5277-1442"},{"uid":"5277-1470"},{"uid":"5277-1526"},{"uid":"5277-1530"},{"uid":"5277-1480"},{"uid":"5277-1486"},{"uid":"5277-1490"},{"uid":"5277-1494"},{"uid":"5277-1498"},{"uid":"5277-1502"},{"uid":"5277-1508"},{"uid":"5277-1566"},{"uid":"5277-1570"},{"uid":"5277-1576"},{"uid":"5277-1574"},{"uid":"5277-1352"},{"uid":"5277-1752"},{"uid":"5277-1756"},{"uid":"5277-1458"},{"uid":"5277-1622"},{"uid":"5277-1628"},{"uid":"5277-1630"},{"uid":"5277-1632"},{"uid":"5277-1634"},{"uid":"5277-1674"},{"uid":"5277-1688"},{"uid":"5277-1690"},{"uid":"5277-1776"},{"uid":"5277-1778"},{"uid":"5277-1782"},{"uid":"5277-1784"},{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2026"},{"uid":"5277-2020"},{"uid":"5277-2030"},{"uid":"5277-2034"},{"uid":"5277-2036"},{"uid":"5277-1376"},{"uid":"5277-1386"},{"uid":"5277-1456"},{"uid":"5277-1460"},{"uid":"5277-1462"},{"uid":"5277-1466"},{"uid":"5277-1468"},{"uid":"5277-1520"},{"uid":"5277-1522"},{"uid":"5277-1516"},{"uid":"5277-1484"},{"uid":"5277-1506"},{"uid":"5277-1748"},{"uid":"5277-1750"},{"uid":"5277-1644"},{"uid":"5277-1648"},{"uid":"5277-1666"},{"uid":"5277-1670"},{"uid":"5277-1672"},{"uid":"5277-2004"},{"uid":"5277-2006"},{"uid":"5277-2008"},{"uid":"5277-2012"},{"uid":"5277-2016"},{"uid":"5277-2022"},{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-1356"},{"uid":"5277-1342"},{"uid":"5277-1360"},{"uid":"5277-1364"},{"uid":"5277-1366"},{"uid":"5277-1370"},{"uid":"5277-1372"},{"uid":"5277-1362"},{"uid":"5277-1374"},{"uid":"5277-1518"},{"uid":"5277-1702"},{"uid":"5277-1738"},{"uid":"5277-1742"},{"uid":"5277-1746"},{"uid":"5277-1736"},{"uid":"5277-1728"},{"uid":"5277-1656"},{"uid":"5277-1660"},{"uid":"5277-1658"},{"uid":"5277-1664"},{"uid":"5277-1662"},{"uid":"5277-1334"},{"uid":"5277-1344"},{"uid":"5277-1350"},{"uid":"5277-1348"},{"uid":"5277-1712"},{"uid":"5277-1716"},{"uid":"5277-1718"},{"uid":"5277-1722"},{"uid":"5277-1732"},{"uid":"5277-1734"},{"uid":"5277-1724"},{"uid":"5277-1726"},{"uid":"5277-1654"},{"uid":"5277-1708"}]},"5277-1304":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1305"},"imported":[],"importedBy":[{"uid":"5277-1824"}]},"5277-1306":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1307"},"imported":[],"importedBy":[{"uid":"5277-1822"}]},"5277-1308":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1309"},"imported":[],"importedBy":[{"uid":"5277-1820"}]},"5277-1310":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-es6/index.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-1311"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1300"}],"importedBy":[{"uid":"5277-1800"},{"uid":"5277-1320"},{"uid":"5277-1770"},{"uid":"5277-1382"},{"uid":"5277-1544"},{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-1606"},{"uid":"5277-1548"},{"uid":"5277-1568"},{"uid":"5277-1618"},{"uid":"5277-1782"},{"uid":"5277-2012"},{"uid":"5277-2016"},{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-1342"},{"uid":"5277-1702"},{"uid":"5277-1708"}]},"5277-1312":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/crypto-browserify/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1313"},"imported":[],"importedBy":[{"uid":"5277-1798"}]},"5277-1314":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-es6/browser.js","moduleParts":{"metamask-sdk.js":"5277-1315"},"imported":[{"uid":"5277-1292"}],"importedBy":[{"uid":"5277-1828"},{"uid":"5277-1986"},{"uid":"5277-2078"},{"uid":"5277-1322"},{"uid":"5277-1796"},{"uid":"5277-2318"},{"uid":"5277-2046"},{"uid":"5277-1338"},{"uid":"5277-1410"},{"uid":"5277-1406"},{"uid":"5277-1408"},{"uid":"5277-2316"},{"uid":"5277-2252"},{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-1580"},{"uid":"5277-1588"},{"uid":"5277-1440"},{"uid":"5277-1570"},{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2004"},{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-1356"},{"uid":"5277-1364"},{"uid":"5277-1344"},{"uid":"5277-1708"}]},"5277-1316":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randombytes/browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1317"},"imported":[],"importedBy":[{"uid":"5277-1322"}]},"5277-1318":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safe-buffer/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1319"},"imported":[],"importedBy":[{"uid":"5277-1320"}]},"5277-1320":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safe-buffer/index.js","moduleParts":{"metamask-sdk.js":"5277-1321"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1318"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2423"}]},"5277-1322":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randombytes/browser.js","moduleParts":{"metamask-sdk.js":"5277-1323"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1316"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2399"}]},"5277-1324":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1325"},"imported":[],"importedBy":[{"uid":"5277-1326"}]},"5277-1326":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js","moduleParts":{"metamask-sdk.js":"5277-1327"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1324"}],"importedBy":[{"uid":"5277-2425"}]},"5277-1328":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/readable-browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1329"},"imported":[],"importedBy":[{"uid":"5277-1376"}]},"5277-1330":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/events.js","moduleParts":{"metamask-sdk.js":"5277-1331"},"imported":[],"importedBy":[{"uid":"5277-1332"},{"uid":"5277-1416"},{"uid":"5277-1406"},{"uid":"5277-1408"}]},"5277-1332":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/events.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-1333"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1330"}],"importedBy":[{"uid":"5277-1912"},{"uid":"5277-1592"},{"uid":"5277-2068"},{"uid":"5277-1566"},{"uid":"5277-2032"},{"uid":"5277-2008"},{"uid":"5277-1368"},{"uid":"5277-1334"}]},"5277-1334":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/stream-browser.js","moduleParts":{"metamask-sdk.js":"5277-1335"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1332"}],"importedBy":[{"uid":"5277-2570"}]},"5277-1336":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/inherits.js","moduleParts":{"metamask-sdk.js":"5277-1337"},"imported":[],"importedBy":[{"uid":"5277-1338"}]},"5277-1338":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/util.js","moduleParts":{"metamask-sdk.js":"5277-1339"},"imported":[{"uid":"5277-1292"},{"uid":"5277-1300"},{"uid":"5277-1314"},{"uid":"5277-1336"}],"importedBy":[{"uid":"5277-1416"},{"uid":"5277-1410"},{"uid":"5277-1406"},{"uid":"5277-1408"},{"uid":"5277-1412"},{"uid":"5277-1414"},{"uid":"5277-1340"}]},"5277-1340":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/util.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-1341"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1338"}],"importedBy":[{"uid":"5277-1592"},{"uid":"5277-1568"},{"uid":"5277-2032"},{"uid":"5277-2020"},{"uid":"5277-1368"},{"uid":"5277-1342"}]},"5277-1342":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/buffer_list.js","moduleParts":{"metamask-sdk.js":"5277-1343"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1310"},{"uid":"5277-1340"}],"importedBy":[{"uid":"5277-1368"}]},"5277-1344":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-1345"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2571"}]},"5277-1346":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/errors-browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1347"},"imported":[],"importedBy":[{"uid":"5277-1348"}]},"5277-1348":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/errors-browser.js","moduleParts":{"metamask-sdk.js":"5277-1349"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1346"}],"importedBy":[{"uid":"5277-2573"}]},"5277-1350":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/state.js","moduleParts":{"metamask-sdk.js":"5277-1351"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2573"}],"importedBy":[{"uid":"5277-2572"}]},"5277-1352":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/util-deprecate/browser.js","moduleParts":{"metamask-sdk.js":"5277-1353"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2510"}]},"5277-1354":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-1355"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2510"},{"uid":"5277-2570"},{"uid":"5277-1310"},{"uid":"5277-2571"},{"uid":"5277-2572"},{"uid":"5277-2573"},{"uid":"5277-2425"},{"uid":"5277-1356"}],"importedBy":[{"uid":"5277-1376"},{"uid":"5277-1356"}]},"5277-1356":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-1357"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-1376"},{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-1370"}]},"5277-1358":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1359"},"imported":[],"importedBy":[{"uid":"5277-1360"}]},"5277-1360":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-1361"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1358"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-1368"}]},"5277-1362":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/end-of-stream.js","moduleParts":{"metamask-sdk.js":"5277-1363"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2573"}],"importedBy":[{"uid":"5277-2556"}]},"5277-1364":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/async_iterator.js","moduleParts":{"metamask-sdk.js":"5277-1365"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2556"}],"importedBy":[{"uid":"5277-1368"}]},"5277-1366":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/from-browser.js","moduleParts":{"metamask-sdk.js":"5277-1367"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-1368"}]},"5277-1368":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-1369"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1332"},{"uid":"5277-2570"},{"uid":"5277-1310"},{"uid":"5277-1340"},{"uid":"5277-1342"},{"uid":"5277-2571"},{"uid":"5277-2572"},{"uid":"5277-2573"},{"uid":"5277-2425"},{"uid":"5277-1356"},{"uid":"5277-1360"},{"uid":"5277-1364"},{"uid":"5277-1366"}],"importedBy":[{"uid":"5277-1376"},{"uid":"5277-1356"}]},"5277-1370":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-1371"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2573"},{"uid":"5277-1356"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2554"}]},"5277-1372":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-1373"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2554"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2555"}]},"5277-1374":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/pipeline.js","moduleParts":{"metamask-sdk.js":"5277-1375"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2573"},{"uid":"5277-2556"}],"importedBy":[{"uid":"5277-2557"}]},"5277-1376":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/readable-browser.js","moduleParts":{"metamask-sdk.js":"5277-1377"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1328"},{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-1356"},{"uid":"5277-2554"},{"uid":"5277-2555"},{"uid":"5277-2556"},{"uid":"5277-2557"}],"importedBy":[{"uid":"5277-2529"}]},"5277-1378":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/index.js","moduleParts":{"metamask-sdk.js":"5277-1379"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"},{"uid":"5277-2529"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2485"}]},"5277-1380":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/md5.js/index.js","moduleParts":{"metamask-sdk.js":"5277-1381"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2485"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2446"}]},"5277-1382":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/ripemd160/index.js","moduleParts":{"metamask-sdk.js":"5277-1383"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1310"},{"uid":"5277-2425"},{"uid":"5277-2485"}],"importedBy":[{"uid":"5277-2447"}]},"5277-1384":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1385"},"imported":[],"importedBy":[{"uid":"5277-1400"}]},"5277-1386":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/hash.js","moduleParts":{"metamask-sdk.js":"5277-1387"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2530"}]},"5277-1388":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha.js","moduleParts":{"metamask-sdk.js":"5277-1389"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2530"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2486"}]},"5277-1390":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha1.js","moduleParts":{"metamask-sdk.js":"5277-1391"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2530"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2487"}]},"5277-1392":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha256.js","moduleParts":{"metamask-sdk.js":"5277-1393"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2530"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2489"}]},"5277-1394":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha224.js","moduleParts":{"metamask-sdk.js":"5277-1395"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2489"},{"uid":"5277-2530"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2488"}]},"5277-1396":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha512.js","moduleParts":{"metamask-sdk.js":"5277-1397"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2530"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2491"}]},"5277-1398":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha384.js","moduleParts":{"metamask-sdk.js":"5277-1399"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2491"},{"uid":"5277-2530"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2490"}]},"5277-1400":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/index.js","moduleParts":{"metamask-sdk.js":"5277-1401"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1384"},{"uid":"5277-2486"},{"uid":"5277-2487"},{"uid":"5277-2488"},{"uid":"5277-2489"},{"uid":"5277-2490"},{"uid":"5277-2491"}],"importedBy":[{"uid":"5277-2448"}]},"5277-1402":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/buffer-list.js","moduleParts":{"metamask-sdk.js":"5277-1403"},"imported":[{"uid":"5277-1300"}],"importedBy":[{"uid":"5277-1406"}]},"5277-1404":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/string-decoder.js","moduleParts":{"metamask-sdk.js":"5277-1405"},"imported":[{"uid":"5277-1300"}],"importedBy":[{"uid":"5277-1406"},{"uid":"5277-1420"}]},"5277-1406":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/readable.js","moduleParts":{"metamask-sdk.js":"5277-1407"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1330"},{"uid":"5277-1338"},{"uid":"5277-1402"},{"uid":"5277-1404"},{"uid":"5277-1410"},{"uid":"5277-1314"}],"importedBy":[{"uid":"5277-1416"},{"uid":"5277-1410"}]},"5277-1408":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/writable.js","moduleParts":{"metamask-sdk.js":"5277-1409"},"imported":[{"uid":"5277-1338"},{"uid":"5277-1300"},{"uid":"5277-1330"},{"uid":"5277-1410"},{"uid":"5277-1314"}],"importedBy":[{"uid":"5277-1416"},{"uid":"5277-1410"}]},"5277-1410":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/duplex.js","moduleParts":{"metamask-sdk.js":"5277-1411"},"imported":[{"uid":"5277-1338"},{"uid":"5277-1314"},{"uid":"5277-1406"},{"uid":"5277-1408"}],"importedBy":[{"uid":"5277-1416"},{"uid":"5277-1406"},{"uid":"5277-1408"},{"uid":"5277-1412"}]},"5277-1412":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/transform.js","moduleParts":{"metamask-sdk.js":"5277-1413"},"imported":[{"uid":"5277-1410"},{"uid":"5277-1338"}],"importedBy":[{"uid":"5277-1416"},{"uid":"5277-1414"}]},"5277-1414":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/readable-stream/passthrough.js","moduleParts":{"metamask-sdk.js":"5277-1415"},"imported":[{"uid":"5277-1412"},{"uid":"5277-1338"}],"importedBy":[{"uid":"5277-1416"}]},"5277-1416":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/stream.js","moduleParts":{"metamask-sdk.js":"5277-1417"},"imported":[{"uid":"5277-1330"},{"uid":"5277-1338"},{"uid":"5277-1410"},{"uid":"5277-1406"},{"uid":"5277-1408"},{"uid":"5277-1412"},{"uid":"5277-1414"}],"importedBy":[{"uid":"5277-2172"},{"uid":"5277-1418"}]},"5277-1418":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/stream.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-1419"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1416"}],"importedBy":[{"uid":"5277-1984"},{"uid":"5277-1422"}]},"5277-1420":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/string-decoder.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-1421"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1404"}],"importedBy":[{"uid":"5277-1422"}]},"5277-1422":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cipher-base/index.js","moduleParts":{"metamask-sdk.js":"5277-1423"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"},{"uid":"5277-1418"},{"uid":"5277-1420"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2449"}]},"5277-1424":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/browser.js","moduleParts":{"metamask-sdk.js":"5277-1425"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2446"},{"uid":"5277-2447"},{"uid":"5277-2448"},{"uid":"5277-2449"}],"importedBy":[{"uid":"5277-2400"}]},"5277-1426":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/legacy.js","moduleParts":{"metamask-sdk.js":"5277-1427"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2423"},{"uid":"5277-2449"}],"importedBy":[{"uid":"5277-2450"}]},"5277-1428":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/md5.js","moduleParts":{"metamask-sdk.js":"5277-1429"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2446"}],"importedBy":[{"uid":"5277-2451"}]},"5277-1430":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/browser.js","moduleParts":{"metamask-sdk.js":"5277-1431"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2450"},{"uid":"5277-2449"},{"uid":"5277-2423"},{"uid":"5277-2451"},{"uid":"5277-2447"},{"uid":"5277-2448"}],"importedBy":[{"uid":"5277-2401"}]},"5277-1432":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/algorithms.json","moduleParts":{"metamask-sdk.js":"5277-1433"},"imported":[],"importedBy":[{"uid":"5277-2426"}]},"5277-1434":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/algos.js","moduleParts":{"metamask-sdk.js":"5277-1435"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2426"}],"importedBy":[{"uid":"5277-2402"}]},"5277-1436":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1437"},"imported":[],"importedBy":[{"uid":"5277-1448"}]},"5277-1438":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/precondition.js","moduleParts":{"metamask-sdk.js":"5277-1439"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2492"}]},"5277-1440":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/default-encoding.js","moduleParts":{"metamask-sdk.js":"5277-1441"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2493"}]},"5277-1442":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/to-buffer.js","moduleParts":{"metamask-sdk.js":"5277-1443"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2494"}]},"5277-1444":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/sync-browser.js","moduleParts":{"metamask-sdk.js":"5277-1445"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2451"},{"uid":"5277-2447"},{"uid":"5277-2448"},{"uid":"5277-2423"},{"uid":"5277-2492"},{"uid":"5277-2493"},{"uid":"5277-2494"}],"importedBy":[{"uid":"5277-2453"}]},"5277-1446":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/async.js","moduleParts":{"metamask-sdk.js":"5277-1447"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"},{"uid":"5277-2492"},{"uid":"5277-2493"},{"uid":"5277-2453"},{"uid":"5277-2494"}],"importedBy":[{"uid":"5277-2452"}]},"5277-1448":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/browser.js","moduleParts":{"metamask-sdk.js":"5277-1449"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1436"},{"uid":"5277-2452"},{"uid":"5277-2453"}],"importedBy":[{"uid":"5277-2403"}]},"5277-1450":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-cipher/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1451"},"imported":[],"importedBy":[{"uid":"5277-1538"}]},"5277-1452":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1453"},"imported":[],"importedBy":[{"uid":"5277-1470"}]},"5277-1454":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1455"},"imported":[],"importedBy":[{"uid":"5277-1456"}]},"5277-1456":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/utils.js","moduleParts":{"metamask-sdk.js":"5277-1457"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1454"}],"importedBy":[{"uid":"5277-2531"}]},"5277-1458":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-assert/index.js","moduleParts":{"metamask-sdk.js":"5277-1459"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2514"}]},"5277-1460":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cipher.js","moduleParts":{"metamask-sdk.js":"5277-1461"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2514"}],"importedBy":[{"uid":"5277-2532"}]},"5277-1462":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/des.js","moduleParts":{"metamask-sdk.js":"5277-1463"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2514"},{"uid":"5277-2425"},{"uid":"5277-2531"},{"uid":"5277-2532"}],"importedBy":[{"uid":"5277-2533"}]},"5277-1464":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cbc.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1465"},"imported":[],"importedBy":[{"uid":"5277-1466"}]},"5277-1466":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cbc.js","moduleParts":{"metamask-sdk.js":"5277-1467"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1464"},{"uid":"5277-2514"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2534"}]},"5277-1468":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/ede.js","moduleParts":{"metamask-sdk.js":"5277-1469"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2514"},{"uid":"5277-2425"},{"uid":"5277-2532"},{"uid":"5277-2533"}],"importedBy":[{"uid":"5277-2535"}]},"5277-1470":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des.js","moduleParts":{"metamask-sdk.js":"5277-1471"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1452"},{"uid":"5277-2531"},{"uid":"5277-2532"},{"uid":"5277-2533"},{"uid":"5277-2534"},{"uid":"5277-2535"}],"importedBy":[{"uid":"5277-2495"}]},"5277-1472":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/index.js","moduleParts":{"metamask-sdk.js":"5277-1473"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2449"},{"uid":"5277-2495"},{"uid":"5277-2425"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2454"}]},"5277-1474":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1475"},"imported":[],"importedBy":[{"uid":"5277-1532"}]},"5277-1476":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/encrypter.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1477"},"imported":[],"importedBy":[{"uid":"5277-1526"}]},"5277-1478":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ecb.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1479"},"imported":[],"importedBy":[{"uid":"5277-1480"}]},"5277-1480":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ecb.js","moduleParts":{"metamask-sdk.js":"5277-1481"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1478"}],"importedBy":[{"uid":"5277-2499"}]},"5277-1482":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cbc.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1483"},"imported":[],"importedBy":[{"uid":"5277-1486"}]},"5277-1484":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-xor/index.js","moduleParts":{"metamask-sdk.js":"5277-1485"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2539"}]},"5277-1486":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cbc.js","moduleParts":{"metamask-sdk.js":"5277-1487"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1482"},{"uid":"5277-2539"}],"importedBy":[{"uid":"5277-2500"}]},"5277-1488":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1489"},"imported":[],"importedBy":[{"uid":"5277-1490"}]},"5277-1490":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb.js","moduleParts":{"metamask-sdk.js":"5277-1491"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1488"},{"uid":"5277-2423"},{"uid":"5277-2539"}],"importedBy":[{"uid":"5277-2501"}]},"5277-1492":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb8.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1493"},"imported":[],"importedBy":[{"uid":"5277-1494"}]},"5277-1494":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb8.js","moduleParts":{"metamask-sdk.js":"5277-1495"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1492"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2502"}]},"5277-1496":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb1.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1497"},"imported":[],"importedBy":[{"uid":"5277-1498"}]},"5277-1498":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb1.js","moduleParts":{"metamask-sdk.js":"5277-1499"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1496"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2503"}]},"5277-1500":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ofb.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1501"},"imported":[],"importedBy":[{"uid":"5277-1502"}]},"5277-1502":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ofb.js","moduleParts":{"metamask-sdk.js":"5277-1503"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1500"},{"uid":"5277-2539"}],"importedBy":[{"uid":"5277-2504"}]},"5277-1504":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ctr.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1505"},"imported":[],"importedBy":[{"uid":"5277-1508"}]},"5277-1506":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/incr32.js","moduleParts":{"metamask-sdk.js":"5277-1507"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2540"}]},"5277-1508":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ctr.js","moduleParts":{"metamask-sdk.js":"5277-1509"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1504"},{"uid":"5277-2539"},{"uid":"5277-2423"},{"uid":"5277-2540"}],"importedBy":[{"uid":"5277-2505"}]},"5277-1510":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/list.json","moduleParts":{"metamask-sdk.js":"5277-1511"},"imported":[],"importedBy":[{"uid":"5277-2498"}]},"5277-1512":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/index.js","moduleParts":{"metamask-sdk.js":"5277-1513"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2499"},{"uid":"5277-2500"},{"uid":"5277-2501"},{"uid":"5277-2502"},{"uid":"5277-2503"},{"uid":"5277-2504"},{"uid":"5277-2505"},{"uid":"5277-2498"}],"importedBy":[{"uid":"5277-2456"}]},"5277-1514":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/aes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1515"},"imported":[],"importedBy":[{"uid":"5277-1516"}]},"5277-1516":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/aes.js","moduleParts":{"metamask-sdk.js":"5277-1517"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1514"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2538"}]},"5277-1518":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/ghash.js","moduleParts":{"metamask-sdk.js":"5277-1519"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2558"}]},"5277-1520":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/authCipher.js","moduleParts":{"metamask-sdk.js":"5277-1521"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2538"},{"uid":"5277-2423"},{"uid":"5277-2449"},{"uid":"5277-2425"},{"uid":"5277-2558"},{"uid":"5277-2539"},{"uid":"5277-2540"}],"importedBy":[{"uid":"5277-2536"}]},"5277-1522":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/streamCipher.js","moduleParts":{"metamask-sdk.js":"5277-1523"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2538"},{"uid":"5277-2423"},{"uid":"5277-2449"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2537"}]},"5277-1524":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/evp_bytestokey/index.js","moduleParts":{"metamask-sdk.js":"5277-1525"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"},{"uid":"5277-2446"}],"importedBy":[{"uid":"5277-2458"}]},"5277-1526":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/encrypter.js","moduleParts":{"metamask-sdk.js":"5277-1527"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1476"},{"uid":"5277-2456"},{"uid":"5277-2536"},{"uid":"5277-2423"},{"uid":"5277-2537"},{"uid":"5277-2449"},{"uid":"5277-2538"},{"uid":"5277-2458"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2496"}]},"5277-1528":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/decrypter.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1529"},"imported":[],"importedBy":[{"uid":"5277-1530"}]},"5277-1530":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/decrypter.js","moduleParts":{"metamask-sdk.js":"5277-1531"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1528"},{"uid":"5277-2536"},{"uid":"5277-2423"},{"uid":"5277-2456"},{"uid":"5277-2537"},{"uid":"5277-2449"},{"uid":"5277-2538"},{"uid":"5277-2458"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2497"}]},"5277-1532":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/browser.js","moduleParts":{"metamask-sdk.js":"5277-1533"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1474"},{"uid":"5277-2496"},{"uid":"5277-2497"},{"uid":"5277-2498"}],"importedBy":[{"uid":"5277-2455"}]},"5277-1534":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/modes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1535"},"imported":[],"importedBy":[{"uid":"5277-1536"}]},"5277-1536":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/modes.js","moduleParts":{"metamask-sdk.js":"5277-1537"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1534"}],"importedBy":[{"uid":"5277-2457"}]},"5277-1538":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-cipher/browser.js","moduleParts":{"metamask-sdk.js":"5277-1539"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1450"},{"uid":"5277-2454"},{"uid":"5277-2455"},{"uid":"5277-2456"},{"uid":"5277-2457"},{"uid":"5277-2458"}],"importedBy":[{"uid":"5277-2404"}]},"5277-1540":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1541"},"imported":[],"importedBy":[{"uid":"5277-1562"}]},"5277-1542":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1543"},"imported":[],"importedBy":[{"uid":"5277-1544"}]},"5277-1544":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-1545"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1542"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2459"}]},"5277-1546":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1547"},"imported":[],"importedBy":[{"uid":"5277-1548"}]},"5277-1548":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-1549"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1546"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2472"}]},"5277-1550":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1551"},"imported":[],"importedBy":[{"uid":"5277-1552"}]},"5277-1552":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js","moduleParts":{"metamask-sdk.js":"5277-1553"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1550"},{"uid":"5277-1798"}],"importedBy":[{"uid":"5277-1694"},{"uid":"5277-1554"},{"uid":"5277-1686"}]},"5277-1554":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/lib/mr.js","moduleParts":{"metamask-sdk.js":"5277-1555"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2472"},{"uid":"5277-1552"}],"importedBy":[{"uid":"5277-1556"},{"uid":"5277-1560"}]},"5277-1556":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/generatePrime.js","moduleParts":{"metamask-sdk.js":"5277-1557"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2399"},{"uid":"5277-2459"},{"uid":"5277-1554"}],"importedBy":[{"uid":"5277-1562"},{"uid":"5277-1560"}]},"5277-1558":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/primes.json","moduleParts":{"metamask-sdk.js":"5277-1559"},"imported":[],"importedBy":[{"uid":"5277-2422"}]},"5277-1560":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/dh.js","moduleParts":{"metamask-sdk.js":"5277-1561"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-2459"},{"uid":"5277-1554"},{"uid":"5277-1556"},{"uid":"5277-2399"}],"importedBy":[{"uid":"5277-1562"}]},"5277-1562":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/browser.js","moduleParts":{"metamask-sdk.js":"5277-1563"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1540"},{"uid":"5277-1556"},{"uid":"5277-2422"},{"uid":"5277-1560"}],"importedBy":[{"uid":"5277-1798"}]},"5277-1564":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/readable-browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1565"},"imported":[],"importedBy":[{"uid":"5277-1600"}]},"5277-1566":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/stream-browser.js","moduleParts":{"metamask-sdk.js":"5277-1567"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1332"}],"importedBy":[{"uid":"5277-2506"}]},"5277-1568":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/buffer_list.js","moduleParts":{"metamask-sdk.js":"5277-1569"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1310"},{"uid":"5277-1340"}],"importedBy":[{"uid":"5277-1592"}]},"5277-1570":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-1571"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2507"}]},"5277-1572":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/errors-browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1573"},"imported":[],"importedBy":[{"uid":"5277-1574"}]},"5277-1574":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/errors-browser.js","moduleParts":{"metamask-sdk.js":"5277-1575"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1572"}],"importedBy":[{"uid":"5277-2509"}]},"5277-1576":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/state.js","moduleParts":{"metamask-sdk.js":"5277-1577"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2509"}],"importedBy":[{"uid":"5277-2508"}]},"5277-1578":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-1579"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2510"},{"uid":"5277-2506"},{"uid":"5277-1310"},{"uid":"5277-2507"},{"uid":"5277-2508"},{"uid":"5277-2509"},{"uid":"5277-2425"},{"uid":"5277-1580"}],"importedBy":[{"uid":"5277-1600"},{"uid":"5277-1580"}]},"5277-1580":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-1581"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-1600"},{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-1594"}]},"5277-1582":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1583"},"imported":[],"importedBy":[{"uid":"5277-1584"}]},"5277-1584":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-1585"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1582"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-1592"}]},"5277-1586":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/end-of-stream.js","moduleParts":{"metamask-sdk.js":"5277-1587"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2509"}],"importedBy":[{"uid":"5277-2475"}]},"5277-1588":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/async_iterator.js","moduleParts":{"metamask-sdk.js":"5277-1589"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2475"}],"importedBy":[{"uid":"5277-1592"}]},"5277-1590":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/from-browser.js","moduleParts":{"metamask-sdk.js":"5277-1591"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-1592"}]},"5277-1592":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-1593"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1332"},{"uid":"5277-2506"},{"uid":"5277-1310"},{"uid":"5277-1340"},{"uid":"5277-1568"},{"uid":"5277-2507"},{"uid":"5277-2508"},{"uid":"5277-2509"},{"uid":"5277-2425"},{"uid":"5277-1580"},{"uid":"5277-1584"},{"uid":"5277-1588"},{"uid":"5277-1590"}],"importedBy":[{"uid":"5277-1600"},{"uid":"5277-1580"}]},"5277-1594":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-1595"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2509"},{"uid":"5277-1580"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2473"}]},"5277-1596":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-1597"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2473"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2474"}]},"5277-1598":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/pipeline.js","moduleParts":{"metamask-sdk.js":"5277-1599"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2509"},{"uid":"5277-2475"}],"importedBy":[{"uid":"5277-2476"}]},"5277-1600":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/readable-browser.js","moduleParts":{"metamask-sdk.js":"5277-1601"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1564"},{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-1580"},{"uid":"5277-2473"},{"uid":"5277-2474"},{"uid":"5277-2475"},{"uid":"5277-2476"}],"importedBy":[{"uid":"5277-2424"}]},"5277-1602":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/sign.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1603"},"imported":[],"importedBy":[{"uid":"5277-1762"}]},"5277-1604":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1605"},"imported":[],"importedBy":[{"uid":"5277-1606"}]},"5277-1606":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-1607"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1604"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2461"}]},"5277-1608":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-rsa/index.js","moduleParts":{"metamask-sdk.js":"5277-1609"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-2461"},{"uid":"5277-2399"}],"importedBy":[{"uid":"5277-2460"}]},"5277-1610":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1611"},"imported":[],"importedBy":[{"uid":"5277-1694"}]},"5277-1612":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json","moduleParts":{"metamask-sdk.js":"5277-1613"},"imported":[],"importedBy":[{"uid":"5277-2464"}]},"5277-1614":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1615"},"imported":[],"importedBy":[{"uid":"5277-1624"}]},"5277-1616":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1617"},"imported":[],"importedBy":[{"uid":"5277-1618"}]},"5277-1618":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-1619"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1616"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2477"}]},"5277-1620":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1621"},"imported":[],"importedBy":[{"uid":"5277-1622"}]},"5277-1622":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js","moduleParts":{"metamask-sdk.js":"5277-1623"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1620"}],"importedBy":[{"uid":"5277-2515"}]},"5277-1624":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js","moduleParts":{"metamask-sdk.js":"5277-1625"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1614"},{"uid":"5277-2477"},{"uid":"5277-2514"},{"uid":"5277-2515"}],"importedBy":[{"uid":"5277-2465"}]},"5277-1626":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1627"},"imported":[],"importedBy":[{"uid":"5277-1636"}]},"5277-1628":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/base.js","moduleParts":{"metamask-sdk.js":"5277-1629"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2477"},{"uid":"5277-2465"}],"importedBy":[{"uid":"5277-2516"}]},"5277-1630":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/short.js","moduleParts":{"metamask-sdk.js":"5277-1631"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2465"},{"uid":"5277-2477"},{"uid":"5277-2425"},{"uid":"5277-2516"}],"importedBy":[{"uid":"5277-2517"}]},"5277-1632":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/mont.js","moduleParts":{"metamask-sdk.js":"5277-1633"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2477"},{"uid":"5277-2425"},{"uid":"5277-2516"},{"uid":"5277-2465"}],"importedBy":[{"uid":"5277-2518"}]},"5277-1634":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/edwards.js","moduleParts":{"metamask-sdk.js":"5277-1635"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2465"},{"uid":"5277-2477"},{"uid":"5277-2425"},{"uid":"5277-2516"}],"importedBy":[{"uid":"5277-2519"}]},"5277-1636":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js","moduleParts":{"metamask-sdk.js":"5277-1637"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1626"},{"uid":"5277-2516"},{"uid":"5277-2517"},{"uid":"5277-2518"},{"uid":"5277-2519"}],"importedBy":[{"uid":"5277-2466"}]},"5277-1638":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1639"},"imported":[],"importedBy":[{"uid":"5277-1678"}]},"5277-1640":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1641"},"imported":[],"importedBy":[{"uid":"5277-1674"}]},"5277-1642":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1643"},"imported":[],"importedBy":[{"uid":"5277-1644"}]},"5277-1644":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js","moduleParts":{"metamask-sdk.js":"5277-1645"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1642"},{"uid":"5277-2514"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2543"}]},"5277-1646":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1647"},"imported":[],"importedBy":[{"uid":"5277-1648"}]},"5277-1648":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js","moduleParts":{"metamask-sdk.js":"5277-1649"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1646"},{"uid":"5277-2543"},{"uid":"5277-2514"}],"importedBy":[{"uid":"5277-2544"}]},"5277-1650":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1651"},"imported":[],"importedBy":[{"uid":"5277-1666"}]},"5277-1652":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1653"},"imported":[],"importedBy":[{"uid":"5277-1654"}]},"5277-1654":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js","moduleParts":{"metamask-sdk.js":"5277-1655"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1652"},{"uid":"5277-2543"}],"importedBy":[{"uid":"5277-2582"}]},"5277-1656":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/1.js","moduleParts":{"metamask-sdk.js":"5277-1657"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2543"},{"uid":"5277-2544"},{"uid":"5277-2582"}],"importedBy":[{"uid":"5277-2565"}]},"5277-1658":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/256.js","moduleParts":{"metamask-sdk.js":"5277-1659"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2543"},{"uid":"5277-2544"},{"uid":"5277-2582"},{"uid":"5277-2514"}],"importedBy":[{"uid":"5277-2567"}]},"5277-1660":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/224.js","moduleParts":{"metamask-sdk.js":"5277-1661"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2543"},{"uid":"5277-2567"}],"importedBy":[{"uid":"5277-2566"}]},"5277-1662":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/512.js","moduleParts":{"metamask-sdk.js":"5277-1663"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2543"},{"uid":"5277-2544"},{"uid":"5277-2514"}],"importedBy":[{"uid":"5277-2569"}]},"5277-1664":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/384.js","moduleParts":{"metamask-sdk.js":"5277-1665"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2543"},{"uid":"5277-2569"}],"importedBy":[{"uid":"5277-2568"}]},"5277-1666":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js","moduleParts":{"metamask-sdk.js":"5277-1667"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1650"},{"uid":"5277-2565"},{"uid":"5277-2566"},{"uid":"5277-2567"},{"uid":"5277-2568"},{"uid":"5277-2569"}],"importedBy":[{"uid":"5277-2545"}]},"5277-1668":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1669"},"imported":[],"importedBy":[{"uid":"5277-1670"}]},"5277-1670":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js","moduleParts":{"metamask-sdk.js":"5277-1671"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1668"},{"uid":"5277-2543"},{"uid":"5277-2544"}],"importedBy":[{"uid":"5277-2546"}]},"5277-1672":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/hmac.js","moduleParts":{"metamask-sdk.js":"5277-1673"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2543"},{"uid":"5277-2514"}],"importedBy":[{"uid":"5277-2547"}]},"5277-1674":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js","moduleParts":{"metamask-sdk.js":"5277-1675"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1640"},{"uid":"5277-2543"},{"uid":"5277-2544"},{"uid":"5277-2545"},{"uid":"5277-2546"},{"uid":"5277-2547"}],"importedBy":[{"uid":"5277-2520"}]},"5277-1676":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/precomputed/secp256k1.js","moduleParts":{"metamask-sdk.js":"5277-1677"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-1678"}]},"5277-1678":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js","moduleParts":{"metamask-sdk.js":"5277-1679"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1638"},{"uid":"5277-2520"},{"uid":"5277-2466"},{"uid":"5277-2465"},{"uid":"5277-1676"}],"importedBy":[{"uid":"5277-2467"}]},"5277-1680":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hmac-drbg/lib/hmac-drbg.js","moduleParts":{"metamask-sdk.js":"5277-1681"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2520"},{"uid":"5277-2515"},{"uid":"5277-2514"}],"importedBy":[{"uid":"5277-2478"}]},"5277-1682":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/key.js","moduleParts":{"metamask-sdk.js":"5277-1683"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2477"},{"uid":"5277-2465"}],"importedBy":[{"uid":"5277-2479"}]},"5277-1684":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/signature.js","moduleParts":{"metamask-sdk.js":"5277-1685"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2477"},{"uid":"5277-2465"}],"importedBy":[{"uid":"5277-2480"}]},"5277-1686":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/index.js","moduleParts":{"metamask-sdk.js":"5277-1687"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2477"},{"uid":"5277-2478"},{"uid":"5277-2465"},{"uid":"5277-2467"},{"uid":"5277-1552"},{"uid":"5277-2479"},{"uid":"5277-2480"}],"importedBy":[{"uid":"5277-1694"}]},"5277-1688":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/key.js","moduleParts":{"metamask-sdk.js":"5277-1689"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2465"}],"importedBy":[{"uid":"5277-2521"}]},"5277-1690":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/signature.js","moduleParts":{"metamask-sdk.js":"5277-1691"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2477"},{"uid":"5277-2465"}],"importedBy":[{"uid":"5277-2522"}]},"5277-1692":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/index.js","moduleParts":{"metamask-sdk.js":"5277-1693"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2520"},{"uid":"5277-2467"},{"uid":"5277-2465"},{"uid":"5277-2521"},{"uid":"5277-2522"}],"importedBy":[{"uid":"5277-2468"}]},"5277-1694":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-1695"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1610"},{"uid":"5277-2464"},{"uid":"5277-2465"},{"uid":"5277-1552"},{"uid":"5277-2466"},{"uid":"5277-2467"},{"uid":"5277-1686"},{"uid":"5277-2468"}],"importedBy":[{"uid":"5277-1772"},{"uid":"5277-1762"},{"uid":"5277-1764"},{"uid":"5277-1804"}]},"5277-1696":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/asn1.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1697"},"imported":[],"importedBy":[{"uid":"5277-1752"}]},"5277-1698":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1699"},"imported":[],"importedBy":[{"uid":"5277-1748"}]},"5277-1700":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1701"},"imported":[],"importedBy":[{"uid":"5277-1702"}]},"5277-1702":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-1703"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1700"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2559"}]},"5277-1704":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/api.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1705"},"imported":[],"importedBy":[{"uid":"5277-1738"}]},"5277-1706":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1707"},"imported":[],"importedBy":[{"uid":"5277-1728"}]},"5277-1708":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safer-buffer/safer.js","moduleParts":{"metamask-sdk.js":"5277-1709"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2583"}]},"5277-1710":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/reporter.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1711"},"imported":[],"importedBy":[{"uid":"5277-1712"}]},"5277-1712":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/reporter.js","moduleParts":{"metamask-sdk.js":"5277-1713"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1710"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2574"}]},"5277-1714":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/buffer.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1715"},"imported":[],"importedBy":[{"uid":"5277-1716"}]},"5277-1716":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/buffer.js","moduleParts":{"metamask-sdk.js":"5277-1717"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1714"},{"uid":"5277-2425"},{"uid":"5277-2574"},{"uid":"5277-2583"}],"importedBy":[{"uid":"5277-2575"}]},"5277-1718":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/node.js","moduleParts":{"metamask-sdk.js":"5277-1719"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2574"},{"uid":"5277-2575"},{"uid":"5277-2514"}],"importedBy":[{"uid":"5277-2576"}]},"5277-1720":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/der.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1721"},"imported":[],"importedBy":[{"uid":"5277-1722"}]},"5277-1722":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/der.js","moduleParts":{"metamask-sdk.js":"5277-1723"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1720"}],"importedBy":[{"uid":"5277-2577"}]},"5277-1724":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/der.js","moduleParts":{"metamask-sdk.js":"5277-1725"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2583"},{"uid":"5277-2576"},{"uid":"5277-2577"}],"importedBy":[{"uid":"5277-2580"}]},"5277-1726":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/pem.js","moduleParts":{"metamask-sdk.js":"5277-1727"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2580"}],"importedBy":[{"uid":"5277-2581"}]},"5277-1728":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/index.js","moduleParts":{"metamask-sdk.js":"5277-1729"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1706"},{"uid":"5277-2580"},{"uid":"5277-2581"}],"importedBy":[{"uid":"5277-2564"}]},"5277-1730":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1731"},"imported":[],"importedBy":[{"uid":"5277-1736"}]},"5277-1732":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/der.js","moduleParts":{"metamask-sdk.js":"5277-1733"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2559"},{"uid":"5277-2575"},{"uid":"5277-2576"},{"uid":"5277-2577"}],"importedBy":[{"uid":"5277-2578"}]},"5277-1734":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/pem.js","moduleParts":{"metamask-sdk.js":"5277-1735"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2425"},{"uid":"5277-2583"},{"uid":"5277-2578"}],"importedBy":[{"uid":"5277-2579"}]},"5277-1736":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/index.js","moduleParts":{"metamask-sdk.js":"5277-1737"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1730"},{"uid":"5277-2578"},{"uid":"5277-2579"}],"importedBy":[{"uid":"5277-2563"}]},"5277-1738":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/api.js","moduleParts":{"metamask-sdk.js":"5277-1739"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1704"},{"uid":"5277-2564"},{"uid":"5277-2563"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2560"}]},"5277-1740":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1741"},"imported":[],"importedBy":[{"uid":"5277-1742"}]},"5277-1742":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/index.js","moduleParts":{"metamask-sdk.js":"5277-1743"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1740"},{"uid":"5277-2574"},{"uid":"5277-2575"},{"uid":"5277-2576"}],"importedBy":[{"uid":"5277-2561"}]},"5277-1744":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1745"},"imported":[],"importedBy":[{"uid":"5277-1746"}]},"5277-1746":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/index.js","moduleParts":{"metamask-sdk.js":"5277-1747"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1744"},{"uid":"5277-2577"}],"importedBy":[{"uid":"5277-2562"}]},"5277-1748":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1.js","moduleParts":{"metamask-sdk.js":"5277-1749"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1698"},{"uid":"5277-2559"},{"uid":"5277-2560"},{"uid":"5277-2561"},{"uid":"5277-2562"},{"uid":"5277-2563"},{"uid":"5277-2564"}],"importedBy":[{"uid":"5277-2541"}]},"5277-1750":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/certificate.js","moduleParts":{"metamask-sdk.js":"5277-1751"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2541"}],"importedBy":[{"uid":"5277-2542"}]},"5277-1752":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/asn1.js","moduleParts":{"metamask-sdk.js":"5277-1753"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1696"},{"uid":"5277-2541"},{"uid":"5277-2542"}],"importedBy":[{"uid":"5277-2511"}]},"5277-1754":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/aesid.json","moduleParts":{"metamask-sdk.js":"5277-1755"},"imported":[],"importedBy":[{"uid":"5277-2512"}]},"5277-1756":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/fixProc.js","moduleParts":{"metamask-sdk.js":"5277-1757"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2458"},{"uid":"5277-2455"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2513"}]},"5277-1758":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/index.js","moduleParts":{"metamask-sdk.js":"5277-1759"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2511"},{"uid":"5277-2512"},{"uid":"5277-2513"},{"uid":"5277-2455"},{"uid":"5277-2403"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2462"}]},"5277-1760":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/curves.json","moduleParts":{"metamask-sdk.js":"5277-1761"},"imported":[],"importedBy":[{"uid":"5277-2463"}]},"5277-1762":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/sign.js","moduleParts":{"metamask-sdk.js":"5277-1763"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1602"},{"uid":"5277-2423"},{"uid":"5277-2401"},{"uid":"5277-2460"},{"uid":"5277-1694"},{"uid":"5277-2461"},{"uid":"5277-2462"},{"uid":"5277-2463"}],"importedBy":[{"uid":"5277-1766"}]},"5277-1764":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/verify.js","moduleParts":{"metamask-sdk.js":"5277-1765"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"},{"uid":"5277-2461"},{"uid":"5277-1694"},{"uid":"5277-2462"},{"uid":"5277-2463"}],"importedBy":[{"uid":"5277-1766"}]},"5277-1766":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/index.js","moduleParts":{"metamask-sdk.js":"5277-1767"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2423"},{"uid":"5277-2400"},{"uid":"5277-2424"},{"uid":"5277-2425"},{"uid":"5277-1762"},{"uid":"5277-1764"},{"uid":"5277-2426"}],"importedBy":[{"uid":"5277-1798"}]},"5277-1768":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1769"},"imported":[],"importedBy":[{"uid":"5277-1770"}]},"5277-1770":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-1771"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1768"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2427"}]},"5277-1772":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/browser.js","moduleParts":{"metamask-sdk.js":"5277-1773"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1694"},{"uid":"5277-2427"}],"importedBy":[{"uid":"5277-1798"}]},"5277-1774":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1775"},"imported":[],"importedBy":[{"uid":"5277-1790"}]},"5277-1776":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/mgf.js","moduleParts":{"metamask-sdk.js":"5277-1777"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2400"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2523"}]},"5277-1778":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/xor.js","moduleParts":{"metamask-sdk.js":"5277-1779"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2524"}]},"5277-1780":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1781"},"imported":[],"importedBy":[{"uid":"5277-1782"}]},"5277-1782":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-1783"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1780"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2525"}]},"5277-1784":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/withPublic.js","moduleParts":{"metamask-sdk.js":"5277-1785"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2525"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2526"}]},"5277-1786":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/publicEncrypt.js","moduleParts":{"metamask-sdk.js":"5277-1787"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2462"},{"uid":"5277-2399"},{"uid":"5277-2400"},{"uid":"5277-2523"},{"uid":"5277-2524"},{"uid":"5277-2525"},{"uid":"5277-2526"},{"uid":"5277-2460"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2469"}]},"5277-1788":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/privateDecrypt.js","moduleParts":{"metamask-sdk.js":"5277-1789"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2462"},{"uid":"5277-2523"},{"uid":"5277-2524"},{"uid":"5277-2525"},{"uid":"5277-2460"},{"uid":"5277-2400"},{"uid":"5277-2526"},{"uid":"5277-2423"}],"importedBy":[{"uid":"5277-2470"}]},"5277-1790":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/browser.js","moduleParts":{"metamask-sdk.js":"5277-1791"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1774"},{"uid":"5277-2469"},{"uid":"5277-2470"}],"importedBy":[{"uid":"5277-2405"}]},"5277-1792":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-globals/src/browser.js","moduleParts":{"metamask-sdk.js":"5277-1793"},"imported":[],"importedBy":[{"uid":"5277-1796"},{"uid":"5277-2024"}]},"5277-1794":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randomfill/browser.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1795"},"imported":[],"importedBy":[{"uid":"5277-1796"}]},"5277-1796":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randomfill/browser.js","moduleParts":{"metamask-sdk.js":"5277-1797"},"imported":[{"uid":"5277-1792"},{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1794"},{"uid":"5277-2423"},{"uid":"5277-2399"}],"importedBy":[{"uid":"5277-2406"}]},"5277-1798":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/crypto-browserify/index.js","moduleParts":{"metamask-sdk.js":"5277-1799"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1312"},{"uid":"5277-2399"},{"uid":"5277-2400"},{"uid":"5277-2401"},{"uid":"5277-2402"},{"uid":"5277-2403"},{"uid":"5277-2404"},{"uid":"5277-1562"},{"uid":"5277-1766"},{"uid":"5277-1772"},{"uid":"5277-2405"},{"uid":"5277-2406"}],"importedBy":[{"uid":"5277-1814"},{"uid":"5277-1800"},{"uid":"5277-1552"}]},"5277-1800":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js","moduleParts":{"metamask-sdk.js":"5277-1801"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1310"},{"uid":"5277-1798"}],"importedBy":[{"uid":"5277-2421"}]},"5277-1802":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/index.js","moduleParts":{"metamask-sdk.js":"5277-1803"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2428"}]},"5277-1804":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-1805"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1694"}],"importedBy":[{"uid":"5277-2429"}]},"5277-1806":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-1807"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2428"},{"uid":"5277-2429"}],"importedBy":[{"uid":"5277-2384"}]},"5277-1808":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1809"},"imported":[],"importedBy":[{"uid":"5277-1814"}]},"5277-1810":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1811"},"imported":[],"importedBy":[{"uid":"5277-1812"}]},"5277-1812":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js","moduleParts":{"metamask-sdk.js":"5277-1813"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1810"}],"importedBy":[{"uid":"5277-2359"}]},"5277-1814":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-1815"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1808"},{"uid":"5277-1798"},{"uid":"5277-2384"},{"uid":"5277-2359"}],"importedBy":[{"uid":"5277-2358"}]},"5277-1816":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1817"},"imported":[],"importedBy":[{"uid":"5277-1818"}]},"5277-1818":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js","moduleParts":{"metamask-sdk.js":"5277-1819"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1816"},{"uid":"5277-2421"},{"uid":"5277-2384"},{"uid":"5277-2358"},{"uid":"5277-2359"}],"importedBy":[{"uid":"5277-2383"}]},"5277-1820":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js","moduleParts":{"metamask-sdk.js":"5277-1821"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1308"},{"uid":"5277-2421"},{"uid":"5277-2384"},{"uid":"5277-2358"},{"uid":"5277-2383"}],"importedBy":[{"uid":"5277-2382"}]},"5277-1822":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js","moduleParts":{"metamask-sdk.js":"5277-1823"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1306"},{"uid":"5277-2382"},{"uid":"5277-2383"}],"importedBy":[{"uid":"5277-2357"}]},"5277-1824":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-1825"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1304"},{"uid":"5277-2357"},{"uid":"5277-2358"},{"uid":"5277-2359"}],"importedBy":[{"uid":"5277-1902"}]},"5277-1826":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1827"},"imported":[],"importedBy":[{"uid":"5277-1828"}]},"5277-1828":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js","moduleParts":{"metamask-sdk.js":"5277-1829"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-1826"}],"importedBy":[{"uid":"5277-1902"},{"uid":"5277-2350"}]},"5277-1830":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/rng.js","moduleParts":{"metamask-sdk.js":"5277-1831"},"imported":[],"importedBy":[{"uid":"5277-2360"},{"uid":"5277-1838"}]},"5277-1832":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/regex.js","moduleParts":{"metamask-sdk.js":"5277-1833"},"imported":[],"importedBy":[{"uid":"5277-1834"}]},"5277-1834":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/validate.js","moduleParts":{"metamask-sdk.js":"5277-1835"},"imported":[{"uid":"5277-1832"}],"importedBy":[{"uid":"5277-2354"},{"uid":"5277-2364"},{"uid":"5277-1836"},{"uid":"5277-2365"}]},"5277-1836":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/stringify.js","moduleParts":{"metamask-sdk.js":"5277-1837"},"imported":[{"uid":"5277-1834"}],"importedBy":[{"uid":"5277-2354"},{"uid":"5277-2360"},{"uid":"5277-1838"},{"uid":"5277-2372"}]},"5277-1838":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v4.js","moduleParts":{"metamask-sdk.js":"5277-1839"},"imported":[{"uid":"5277-1830"},{"uid":"5277-1836"}],"importedBy":[{"uid":"5277-2354"}]},"5277-1840":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/commons.js","moduleParts":{"metamask-sdk.js":"5277-1841"},"imported":[],"importedBy":[{"uid":"5277-1842"},{"uid":"5277-1846"}]},"5277-1842":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/encodePacket.browser.js","moduleParts":{"metamask-sdk.js":"5277-1843"},"imported":[{"uid":"5277-1840"}],"importedBy":[{"uid":"5277-1848"}]},"5277-1844":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/contrib/base64-arraybuffer.js","moduleParts":{"metamask-sdk.js":"5277-1845"},"imported":[],"importedBy":[{"uid":"5277-1846"}]},"5277-1846":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/decodePacket.browser.js","moduleParts":{"metamask-sdk.js":"5277-1847"},"imported":[{"uid":"5277-1840"},{"uid":"5277-1844"}],"importedBy":[{"uid":"5277-1848"}]},"5277-1848":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-1849"},"imported":[{"uid":"5277-1842"},{"uid":"5277-1846"}],"importedBy":[{"uid":"5277-1878"},{"uid":"5277-1858"},{"uid":"5277-1866"},{"uid":"5277-1870"},{"uid":"5277-1872"}]},"5277-1850":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@socket.io/component-emitter/index.mjs","moduleParts":{"metamask-sdk.js":"5277-1851"},"imported":[],"importedBy":[{"uid":"5277-1894"},{"uid":"5277-1890"},{"uid":"5277-1886"},{"uid":"5277-1878"},{"uid":"5277-1858"},{"uid":"5277-1866"}]},"5277-1852":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/globalThis.browser.js","moduleParts":{"metamask-sdk.js":"5277-1853"},"imported":[],"importedBy":[{"uid":"5277-1854"},{"uid":"5277-1868"},{"uid":"5277-1866"},{"uid":"5277-1864"}]},"5277-1854":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/util.js","moduleParts":{"metamask-sdk.js":"5277-1855"},"imported":[{"uid":"5277-1852"}],"importedBy":[{"uid":"5277-2375"},{"uid":"5277-1878"},{"uid":"5277-1858"},{"uid":"5277-1866"},{"uid":"5277-1870"}]},"5277-1856":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/parseqs.js","moduleParts":{"metamask-sdk.js":"5277-1857"},"imported":[],"importedBy":[{"uid":"5277-1878"},{"uid":"5277-1858"}]},"5277-1858":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transport.js","moduleParts":{"metamask-sdk.js":"5277-1859"},"imported":[{"uid":"5277-1848"},{"uid":"5277-1850"},{"uid":"5277-1854"},{"uid":"5277-1856"}],"importedBy":[{"uid":"5277-2375"},{"uid":"5277-1866"},{"uid":"5277-1870"},{"uid":"5277-1872"}]},"5277-1860":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/yeast.js","moduleParts":{"metamask-sdk.js":"5277-1861"},"imported":[],"importedBy":[{"uid":"5277-1866"},{"uid":"5277-1870"}]},"5277-1862":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/has-cors.js","moduleParts":{"metamask-sdk.js":"5277-1863"},"imported":[],"importedBy":[{"uid":"5277-1864"}]},"5277-1864":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/xmlhttprequest.browser.js","moduleParts":{"metamask-sdk.js":"5277-1865"},"imported":[{"uid":"5277-1862"},{"uid":"5277-1852"}],"importedBy":[{"uid":"5277-1866"}]},"5277-1866":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/polling.js","moduleParts":{"metamask-sdk.js":"5277-1867"},"imported":[{"uid":"5277-1858"},{"uid":"5277-1860"},{"uid":"5277-1848"},{"uid":"5277-1864"},{"uid":"5277-1850"},{"uid":"5277-1854"},{"uid":"5277-1852"}],"importedBy":[{"uid":"5277-1874"}]},"5277-1868":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/websocket-constructor.browser.js","moduleParts":{"metamask-sdk.js":"5277-1869"},"imported":[{"uid":"5277-1852"}],"importedBy":[{"uid":"5277-2375"},{"uid":"5277-1870"},{"uid":"5277-1872"}]},"5277-1870":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/websocket.js","moduleParts":{"metamask-sdk.js":"5277-1871"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1858"},{"uid":"5277-1860"},{"uid":"5277-1854"},{"uid":"5277-1868"},{"uid":"5277-1848"}],"importedBy":[{"uid":"5277-1874"}]},"5277-1872":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/webtransport.js","moduleParts":{"metamask-sdk.js":"5277-1873"},"imported":[{"uid":"5277-1858"},{"uid":"5277-1868"},{"uid":"5277-1848"}],"importedBy":[{"uid":"5277-1874"}]},"5277-1874":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/transports/index.js","moduleParts":{"metamask-sdk.js":"5277-1875"},"imported":[{"uid":"5277-1866"},{"uid":"5277-1870"},{"uid":"5277-1872"}],"importedBy":[{"uid":"5277-2375"},{"uid":"5277-1878"}]},"5277-1876":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/contrib/parseuri.js","moduleParts":{"metamask-sdk.js":"5277-1877"},"imported":[],"importedBy":[{"uid":"5277-2375"},{"uid":"5277-1878"}]},"5277-1878":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/socket.js","moduleParts":{"metamask-sdk.js":"5277-1879"},"imported":[{"uid":"5277-1874"},{"uid":"5277-1854"},{"uid":"5277-1856"},{"uid":"5277-1876"},{"uid":"5277-1850"},{"uid":"5277-1848"}],"importedBy":[{"uid":"5277-2375"}]},"5277-1880":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/url.js","moduleParts":{"metamask-sdk.js":"5277-1881"},"imported":[{"uid":"5277-2375"}],"importedBy":[{"uid":"5277-1896"}]},"5277-1882":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm/is-binary.js","moduleParts":{"metamask-sdk.js":"5277-1883"},"imported":[],"importedBy":[{"uid":"5277-1886"},{"uid":"5277-1884"}]},"5277-1884":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm/binary.js","moduleParts":{"metamask-sdk.js":"5277-1885"},"imported":[{"uid":"5277-1882"}],"importedBy":[{"uid":"5277-1886"}]},"5277-1886":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-1887"},"imported":[{"uid":"5277-1850"},{"uid":"5277-1884"},{"uid":"5277-1882"}],"importedBy":[{"uid":"5277-1896"},{"uid":"5277-1894"},{"uid":"5277-1890"}]},"5277-1888":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/on.js","moduleParts":{"metamask-sdk.js":"5277-1889"},"imported":[],"importedBy":[{"uid":"5277-1894"},{"uid":"5277-1890"}]},"5277-1890":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/socket.js","moduleParts":{"metamask-sdk.js":"5277-1891"},"imported":[{"uid":"5277-1886"},{"uid":"5277-1888"},{"uid":"5277-1850"}],"importedBy":[{"uid":"5277-1896"},{"uid":"5277-1894"}]},"5277-1892":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/contrib/backo2.js","moduleParts":{"metamask-sdk.js":"5277-1893"},"imported":[],"importedBy":[{"uid":"5277-1894"}]},"5277-1894":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/manager.js","moduleParts":{"metamask-sdk.js":"5277-1895"},"imported":[{"uid":"5277-2375"},{"uid":"5277-1890"},{"uid":"5277-1886"},{"uid":"5277-1888"},{"uid":"5277-1892"},{"uid":"5277-1850"}],"importedBy":[{"uid":"5277-1896"}]},"5277-1896":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-1897"},"imported":[{"uid":"5277-1880"},{"uid":"5277-1894"},{"uid":"5277-1890"},{"uid":"5277-1886"}],"importedBy":[{"uid":"5277-1902"}]},"5277-1898":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/browser-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-1899"},"imported":[],"importedBy":[{"uid":"5277-1900"}]},"5277-1900":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/browser-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-1901"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1898"}],"importedBy":[{"uid":"5277-1902"}]},"5277-1902":{"id":"-communication-layer/dist/browser/es/metamask-sdk-communication-layer.js","moduleParts":{"metamask-sdk.js":"5277-1903"},"imported":[{"uid":"5277-1292"},{"uid":"5277-1824"},{"uid":"5277-1828"},{"uid":"5277-2354"},{"uid":"5277-1896"},{"uid":"5277-1900"}],"importedBy":[{"uid":"5277-2352"},{"uid":"5277-2152"},{"uid":"5277-2158"},{"uid":"5277-2160"},{"uid":"5277-2188"},{"uid":"5277-2344"},{"uid":"5277-2190"},{"uid":"5277-2204"},{"uid":"5277-2284"},{"uid":"5277-2156"},{"uid":"5277-2186"},{"uid":"5277-2230"},{"uid":"5277-2154"},{"uid":"5277-2216"},{"uid":"5277-2236"},{"uid":"5277-2172"},{"uid":"5277-2262"},{"uid":"5277-2268"},{"uid":"5277-2278"}]},"5277-1904":{"id":"\u0000tslib.js","moduleParts":{"metamask-sdk.js":"5277-1905"},"imported":[],"importedBy":[{"uid":"5277-2106"},{"uid":"5277-2350"},{"uid":"5277-2104"},{"uid":"5277-2348"},{"uid":"5277-2144"},{"uid":"5277-2146"},{"uid":"5277-2158"},{"uid":"5277-2346"},{"uid":"5277-2188"},{"uid":"5277-2344"},{"uid":"5277-2190"},{"uid":"5277-2196"},{"uid":"5277-2204"},{"uid":"5277-2232"},{"uid":"5277-2284"},{"uid":"5277-2290"},{"uid":"5277-2156"},{"uid":"5277-2186"},{"uid":"5277-2292"},{"uid":"5277-2294"},{"uid":"5277-2342"},{"uid":"5277-2194"},{"uid":"5277-2202"},{"uid":"5277-2244"},{"uid":"5277-2154"},{"uid":"5277-2182"},{"uid":"5277-2198"},{"uid":"5277-2228"},{"uid":"5277-2234"},{"uid":"5277-2236"},{"uid":"5277-2240"},{"uid":"5277-2242"},{"uid":"5277-2282"},{"uid":"5277-2286"},{"uid":"5277-2172"},{"uid":"5277-2170"},{"uid":"5277-2264"},{"uid":"5277-2268"},{"uid":"5277-2445"},{"uid":"5277-2276"},{"uid":"5277-2278"},{"uid":"5277-2274"},{"uid":"5277-2272"}]},"5277-1906":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1907"},"imported":[],"importedBy":[{"uid":"5277-2096"}]},"5277-1908":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1909"},"imported":[],"importedBy":[{"uid":"5277-1978"}]},"5277-1910":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1911"},"imported":[],"importedBy":[{"uid":"5277-1912"}]},"5277-1912":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-1913"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1910"},{"uid":"5277-1332"}],"importedBy":[{"uid":"5277-2385"}]},"5277-1914":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1915"},"imported":[],"importedBy":[{"uid":"5277-1934"}]},"5277-1916":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1917"},"imported":[],"importedBy":[{"uid":"5277-1920"}]},"5277-1918":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js","moduleParts":{"metamask-sdk.js":"5277-1919"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2407"}]},"5277-1920":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js","moduleParts":{"metamask-sdk.js":"5277-1921"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1916"},{"uid":"5277-2407"}],"importedBy":[{"uid":"5277-2376"}]},"5277-1922":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1923"},"imported":[],"importedBy":[{"uid":"5277-1928"}]},"5277-1924":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1925"},"imported":[],"importedBy":[{"uid":"5277-1926"}]},"5277-1926":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js","moduleParts":{"metamask-sdk.js":"5277-1927"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1924"}],"importedBy":[{"uid":"5277-2379"}]},"5277-1928":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-1929"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1922"},{"uid":"5277-2379"},{"uid":"5277-2376"}],"importedBy":[{"uid":"5277-2377"}]},"5277-1930":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1931"},"imported":[],"importedBy":[{"uid":"5277-1932"}]},"5277-1932":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js","moduleParts":{"metamask-sdk.js":"5277-1933"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1930"},{"uid":"5277-2376"},{"uid":"5277-2377"},{"uid":"5277-2379"}],"importedBy":[{"uid":"5277-2378"}]},"5277-1934":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-1935"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1914"},{"uid":"5277-2376"},{"uid":"5277-2377"},{"uid":"5277-2378"},{"uid":"5277-2379"}],"importedBy":[{"uid":"5277-2100"},{"uid":"5277-2386"}]},"5277-1936":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js","moduleParts":{"metamask-sdk.js":"5277-1937"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2387"}]},"5277-1938":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1939"},"imported":[],"importedBy":[{"uid":"5277-1964"}]},"5277-1940":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1941"},"imported":[],"importedBy":[{"uid":"5277-1946"}]},"5277-1942":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1943"},"imported":[],"importedBy":[{"uid":"5277-1944"}]},"5277-1944":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js","moduleParts":{"metamask-sdk.js":"5277-1945"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1942"}],"importedBy":[{"uid":"5277-2433"}]},"5277-1946":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-1947"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1940"},{"uid":"5277-2433"}],"importedBy":[{"uid":"5277-2430"}]},"5277-1948":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1949"},"imported":[],"importedBy":[{"uid":"5277-1950"}]},"5277-1950":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-1951"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1948"}],"importedBy":[{"uid":"5277-2431"}]},"5277-1952":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1953"},"imported":[],"importedBy":[{"uid":"5277-1954"}]},"5277-1954":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-1955"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1952"}],"importedBy":[{"uid":"5277-2432"}]},"5277-1956":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1957"},"imported":[],"importedBy":[{"uid":"5277-1958"}]},"5277-1958":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js","moduleParts":{"metamask-sdk.js":"5277-1959"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1956"},{"uid":"5277-2385"},{"uid":"5277-2386"}],"importedBy":[{"uid":"5277-2434"}]},"5277-1960":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1961"},"imported":[],"importedBy":[{"uid":"5277-1962"}]},"5277-1962":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-1963"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1960"},{"uid":"5277-2434"}],"importedBy":[{"uid":"5277-2435"}]},"5277-1964":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-1965"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1938"},{"uid":"5277-2430"},{"uid":"5277-2431"},{"uid":"5277-2432"},{"uid":"5277-2433"},{"uid":"5277-2434"},{"uid":"5277-2435"}],"importedBy":[{"uid":"5277-2388"}]},"5277-1966":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1967"},"imported":[],"importedBy":[{"uid":"5277-1968"}]},"5277-1968":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js","moduleParts":{"metamask-sdk.js":"5277-1969"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1966"}],"importedBy":[{"uid":"5277-2389"}]},"5277-1970":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1971"},"imported":[],"importedBy":[{"uid":"5277-1976"}]},"5277-1972":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1973"},"imported":[],"importedBy":[{"uid":"5277-1974"}]},"5277-1974":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-1975"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1972"},{"uid":"5277-2389"}],"importedBy":[{"uid":"5277-2436"}]},"5277-1976":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-1977"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1970"},{"uid":"5277-2388"},{"uid":"5277-2386"},{"uid":"5277-2436"}],"importedBy":[{"uid":"5277-2390"}]},"5277-1978":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js","moduleParts":{"metamask-sdk.js":"5277-1979"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1908"},{"uid":"5277-2385"},{"uid":"5277-2386"},{"uid":"5277-2387"},{"uid":"5277-2388"},{"uid":"5277-2389"},{"uid":"5277-2390"}],"importedBy":[{"uid":"5277-2366"}]},"5277-1980":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1981"},"imported":[],"importedBy":[{"uid":"5277-2086"}]},"5277-1982":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1983"},"imported":[],"importedBy":[{"uid":"5277-1984"}]},"5277-1984":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-1985"},"imported":[{"uid":"5277-1300"},{"uid":"5277-1302"},{"uid":"5277-1982"},{"uid":"5277-1418"}],"importedBy":[{"uid":"5277-2391"}]},"5277-1986":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/es/index.js","moduleParts":{"metamask-sdk.js":"5277-1987"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-1988"}]},"5277-1988":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/es/index.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-1989"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1986"}],"importedBy":[{"uid":"5277-2086"}]},"5277-1990":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1991"},"imported":[],"importedBy":[{"uid":"5277-2082"}]},"5277-1992":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1993"},"imported":[],"importedBy":[{"uid":"5277-1994"}]},"5277-1994":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js","moduleParts":{"metamask-sdk.js":"5277-1995"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1992"},{"uid":"5277-2389"},{"uid":"5277-2390"}],"importedBy":[{"uid":"5277-2393"}]},"5277-1996":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1997"},"imported":[],"importedBy":[{"uid":"5277-2080"}]},"5277-1998":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-1999"},"imported":[],"importedBy":[{"uid":"5277-2052"}]},"5277-2000":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2001"},"imported":[],"importedBy":[{"uid":"5277-2038"}]},"5277-2002":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2003"},"imported":[],"importedBy":[{"uid":"5277-2004"}]},"5277-2004":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js","moduleParts":{"metamask-sdk.js":"5277-2005"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2002"}],"importedBy":[{"uid":"5277-2548"}]},"5277-2006":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/isarray/index.js","moduleParts":{"metamask-sdk.js":"5277-2007"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2549"}]},"5277-2008":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/stream-browser.js","moduleParts":{"metamask-sdk.js":"5277-2009"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1332"}],"importedBy":[{"uid":"5277-2550"}]},"5277-2010":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2011"},"imported":[],"importedBy":[{"uid":"5277-2012"}]},"5277-2012":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js","moduleParts":{"metamask-sdk.js":"5277-2013"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2010"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2551"}]},"5277-2014":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2015"},"imported":[],"importedBy":[{"uid":"5277-2016"}]},"5277-2016":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js","moduleParts":{"metamask-sdk.js":"5277-2017"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2014"},{"uid":"5277-1310"}],"importedBy":[{"uid":"5277-2552"}]},"5277-2018":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2019"},"imported":[],"importedBy":[{"uid":"5277-2020"}]},"5277-2020":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js","moduleParts":{"metamask-sdk.js":"5277-2021"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2018"},{"uid":"5277-2551"},{"uid":"5277-1340"}],"importedBy":[{"uid":"5277-2032"}]},"5277-2022":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-2023"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2548"}],"importedBy":[{"uid":"5277-2553"}]},"5277-2024":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-2025"},"imported":[{"uid":"5277-1792"},{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2548"},{"uid":"5277-2552"},{"uid":"5277-2425"},{"uid":"5277-2510"},{"uid":"5277-2550"},{"uid":"5277-2551"},{"uid":"5277-2553"},{"uid":"5277-2026"}],"importedBy":[{"uid":"5277-2038"},{"uid":"5277-2026"}]},"5277-2026":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-2027"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2548"},{"uid":"5277-2552"},{"uid":"5277-2425"},{"uid":"5277-2032"},{"uid":"5277-2024"}],"importedBy":[{"uid":"5277-2038"},{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2034"}]},"5277-2028":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2029"},"imported":[],"importedBy":[{"uid":"5277-2030"}]},"5277-2030":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-2031"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2028"},{"uid":"5277-2551"}],"importedBy":[{"uid":"5277-2032"}]},"5277-2032":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-2033"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2548"},{"uid":"5277-2549"},{"uid":"5277-1332"},{"uid":"5277-2550"},{"uid":"5277-2551"},{"uid":"5277-2552"},{"uid":"5277-2425"},{"uid":"5277-1340"},{"uid":"5277-2020"},{"uid":"5277-2553"},{"uid":"5277-2026"},{"uid":"5277-2030"}],"importedBy":[{"uid":"5277-2038"},{"uid":"5277-2026"}]},"5277-2034":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-2035"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2026"},{"uid":"5277-2552"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2527"}]},"5277-2036":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-2037"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2527"},{"uid":"5277-2552"},{"uid":"5277-2425"}],"importedBy":[{"uid":"5277-2528"}]},"5277-2038":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js","moduleParts":{"metamask-sdk.js":"5277-2039"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2000"},{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2026"},{"uid":"5277-2527"},{"uid":"5277-2528"}],"importedBy":[{"uid":"5277-2481"}]},"5277-2040":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2041"},"imported":[],"importedBy":[{"uid":"5277-2044"}]},"5277-2042":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js","moduleParts":{"metamask-sdk.js":"5277-2043"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2484"}]},"5277-2044":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js","moduleParts":{"metamask-sdk.js":"5277-2045"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2040"},{"uid":"5277-2484"}],"importedBy":[{"uid":"5277-2440"}]},"5277-2046":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-2047"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2440"}],"importedBy":[{"uid":"5277-2441"}]},"5277-2048":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2049"},"imported":[],"importedBy":[{"uid":"5277-2050"}]},"5277-2050":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js","moduleParts":{"metamask-sdk.js":"5277-2051"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2048"},{"uid":"5277-2481"}],"importedBy":[{"uid":"5277-2482"}]},"5277-2052":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js","moduleParts":{"metamask-sdk.js":"5277-2053"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1998"},{"uid":"5277-2481"},{"uid":"5277-2441"},{"uid":"5277-2440"},{"uid":"5277-2482"}],"importedBy":[{"uid":"5277-2437"}]},"5277-2054":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-2055"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2437"}],"importedBy":[{"uid":"5277-2394"}]},"5277-2056":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-2057"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2395"}]},"5277-2058":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2059"},"imported":[],"importedBy":[{"uid":"5277-2072"}]},"5277-2060":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2061"},"imported":[],"importedBy":[{"uid":"5277-2062"}]},"5277-2062":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js","moduleParts":{"metamask-sdk.js":"5277-2063"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2060"},{"uid":"5277-2481"}],"importedBy":[{"uid":"5277-2438"}]},"5277-2064":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2065"},"imported":[],"importedBy":[{"uid":"5277-2070"}]},"5277-2066":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2067"},"imported":[],"importedBy":[{"uid":"5277-2068"}]},"5277-2068":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-2069"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2066"},{"uid":"5277-1332"}],"importedBy":[{"uid":"5277-2483"}]},"5277-2070":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-2071"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2064"},{"uid":"5277-2483"},{"uid":"5277-2481"}],"importedBy":[{"uid":"5277-2439"}]},"5277-2072":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-2073"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2058"},{"uid":"5277-2438"},{"uid":"5277-2439"}],"importedBy":[{"uid":"5277-2396"}]},"5277-2074":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/empty.js","moduleParts":{"metamask-sdk.js":"5277-2075"},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2076"}]},"5277-2076":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/rollup-plugin-node-builtins/src/es6/empty.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-2077"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2074"}],"importedBy":[{"uid":"5277-2078"}]},"5277-2078":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js","moduleParts":{"metamask-sdk.js":"5277-2079"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2440"},{"uid":"5277-2441"},{"uid":"5277-2076"}],"importedBy":[{"uid":"5277-2397"}]},"5277-2080":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js","moduleParts":{"metamask-sdk.js":"5277-2081"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1996"},{"uid":"5277-2394"},{"uid":"5277-2395"},{"uid":"5277-2396"},{"uid":"5277-2397"},{"uid":"5277-2389"},{"uid":"5277-2390"},{"uid":"5277-2366"}],"importedBy":[{"uid":"5277-2371"}]},"5277-2082":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-2083"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1990"},{"uid":"5277-2386"},{"uid":"5277-2393"},{"uid":"5277-2389"},{"uid":"5277-2390"},{"uid":"5277-2371"}],"importedBy":[{"uid":"5277-2369"}]},"5277-2084":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json","moduleParts":{"metamask-sdk.js":"5277-2085"},"imported":[],"importedBy":[{"uid":"5277-2392"}]},"5277-2086":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js","moduleParts":{"metamask-sdk.js":"5277-2087"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1980"},{"uid":"5277-2391"},{"uid":"5277-1988"},{"uid":"5277-2369"},{"uid":"5277-2371"},{"uid":"5277-2390"},{"uid":"5277-2392"}],"importedBy":[{"uid":"5277-2367"}]},"5277-2088":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2089"},"imported":[],"importedBy":[{"uid":"5277-2094"}]},"5277-2090":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2091"},"imported":[],"importedBy":[{"uid":"5277-2092"}]},"5277-2092":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js","moduleParts":{"metamask-sdk.js":"5277-2093"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2090"}],"importedBy":[{"uid":"5277-2370"}]},"5277-2094":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-2095"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2088"},{"uid":"5277-2369"},{"uid":"5277-2370"}],"importedBy":[{"uid":"5277-2368"}]},"5277-2096":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-2097"},"imported":[{"uid":"5277-1302"},{"uid":"5277-1906"},{"uid":"5277-2366"},{"uid":"5277-2367"},{"uid":"5277-2368"},{"uid":"5277-2369"},{"uid":"5277-2370"},{"uid":"5277-2371"}],"importedBy":[{"uid":"5277-2106"},{"uid":"5277-2166"}]},"5277-2098":{"id":"/src/services/SDKProvider/ChainManager/handleChainChanged.ts","moduleParts":{"metamask-sdk.js":"5277-2099"},"imported":[],"importedBy":[{"uid":"5277-2106"}]},"5277-2100":{"id":"/src/services/SDKProvider/ConnectionManager/handleDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-2101"},"imported":[{"uid":"5277-1934"}],"importedBy":[{"uid":"5277-2106"}]},"5277-2102":{"id":"/src/services/SDKProvider/InitializationManager/initializeState.ts","moduleParts":{"metamask-sdk.js":"5277-2103"},"imported":[],"importedBy":[{"uid":"5277-2106"}]},"5277-2104":{"id":"/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts","moduleParts":{"metamask-sdk.js":"5277-2105"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2106"}]},"5277-2106":{"id":"/src/provider/SDKProvider.ts","moduleParts":{"metamask-sdk.js":"5277-2107"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2096"},{"uid":"5277-2098"},{"uid":"5277-2100"},{"uid":"5277-2102"},{"uid":"5277-2104"}],"importedBy":[{"uid":"5277-2352"},{"uid":"5277-2166"}]},"5277-2108":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-2109"},"imported":[],"importedBy":[{"uid":"5277-2142"},{"uid":"5277-2124"},{"uid":"5277-2114"},{"uid":"5277-2112"}]},"5277-2110":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-2111"},"imported":[],"importedBy":[{"uid":"5277-2142"}]},"5277-2112":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-2113"},"imported":[{"uid":"5277-2108"}],"importedBy":[{"uid":"5277-2114"}]},"5277-2114":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-2115"},"imported":[{"uid":"5277-2108"},{"uid":"5277-2112"}],"importedBy":[{"uid":"5277-2116"},{"uid":"5277-2128"}]},"5277-2116":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-2117"},"imported":[{"uid":"5277-2114"}],"importedBy":[{"uid":"5277-2142"}]},"5277-2118":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js","moduleParts":{"metamask-sdk.js":"5277-2119"},"imported":[],"importedBy":[{"uid":"5277-2142"},{"uid":"5277-2124"}]},"5277-2120":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-2121"},"imported":[],"importedBy":[{"uid":"5277-2122"}]},"5277-2122":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/inherits.js","moduleParts":{"metamask-sdk.js":"5277-2123"},"imported":[{"uid":"5277-2120"}],"importedBy":[{"uid":"5277-2142"}]},"5277-2124":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js","moduleParts":{"metamask-sdk.js":"5277-2125"},"imported":[{"uid":"5277-2108"},{"uid":"5277-2118"}],"importedBy":[{"uid":"5277-2142"}]},"5277-2126":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/getPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-2127"},"imported":[],"importedBy":[{"uid":"5277-2142"}]},"5277-2128":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/defineProperty.js","moduleParts":{"metamask-sdk.js":"5277-2129"},"imported":[{"uid":"5277-2114"}],"importedBy":[{"uid":"5277-2142"}]},"5277-2130":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js","moduleParts":{"metamask-sdk.js":"5277-2131"},"imported":[],"importedBy":[{"uid":"5277-2140"}]},"5277-2132":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/iterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-2133"},"imported":[],"importedBy":[{"uid":"5277-2140"}]},"5277-2134":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js","moduleParts":{"metamask-sdk.js":"5277-2135"},"imported":[],"importedBy":[{"uid":"5277-2136"}]},"5277-2136":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-2137"},"imported":[{"uid":"5277-2134"}],"importedBy":[{"uid":"5277-2140"}]},"5277-2138":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js","moduleParts":{"metamask-sdk.js":"5277-2139"},"imported":[],"importedBy":[{"uid":"5277-2140"}]},"5277-2140":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toArray.js","moduleParts":{"metamask-sdk.js":"5277-2141"},"imported":[{"uid":"5277-2130"},{"uid":"5277-2132"},{"uid":"5277-2136"},{"uid":"5277-2138"}],"importedBy":[{"uid":"5277-2142"}]},"5277-2142":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/dist/esm/i18next.js","moduleParts":{"metamask-sdk.js":"5277-2143"},"imported":[{"uid":"5277-2108"},{"uid":"5277-2110"},{"uid":"5277-2116"},{"uid":"5277-2118"},{"uid":"5277-2122"},{"uid":"5277-2124"},{"uid":"5277-2126"},{"uid":"5277-2128"},{"uid":"5277-2140"}],"importedBy":[{"uid":"5277-2350"}]},"5277-2144":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connect.ts","moduleParts":{"metamask-sdk.js":"5277-2145"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2355"}]},"5277-2146":{"id":"/src/services/MetaMaskSDK/ConnectionManager/resume.ts","moduleParts":{"metamask-sdk.js":"5277-2147"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2355"}]},"5277-2148":{"id":"/src/config.ts","moduleParts":{"metamask-sdk.js":"5277-2149"},"imported":[],"importedBy":[{"uid":"5277-2348"},{"uid":"5277-2152"},{"uid":"5277-2158"},{"uid":"5277-2204"},{"uid":"5277-2186"},{"uid":"5277-2154"},{"uid":"5277-2198"},{"uid":"5277-2286"},{"uid":"5277-2170"}]},"5277-2150":{"id":"/src/types/ProviderUpdateType.ts","moduleParts":{"metamask-sdk.js":"5277-2151"},"imported":[],"importedBy":[{"uid":"5277-2352"},{"uid":"5277-2152"},{"uid":"5277-2344"},{"uid":"5277-2186"},{"uid":"5277-2154"}]},"5277-2152":{"id":"/src/services/MetaMaskSDK/ConnectionManager/terminate.ts","moduleParts":{"metamask-sdk.js":"5277-2153"},"imported":[{"uid":"5277-1902"},{"uid":"5277-2148"},{"uid":"5277-2150"}],"importedBy":[{"uid":"5277-2355"}]},"5277-2154":{"id":"/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-2155"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2148"},{"uid":"5277-2150"}],"importedBy":[{"uid":"5277-2380"}]},"5277-2156":{"id":"/src/services/Analytics.ts","moduleParts":{"metamask-sdk.js":"5277-2157"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"}],"importedBy":[{"uid":"5277-2158"},{"uid":"5277-2190"}]},"5277-2158":{"id":"/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts","moduleParts":{"metamask-sdk.js":"5277-2159"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2148"},{"uid":"5277-2380"},{"uid":"5277-2156"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2160":{"id":"/src/services/MetaMaskSDK/InitializerManager/initEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-2161"},"imported":[{"uid":"5277-1902"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2188"}]},"5277-2162":{"id":"/src/constants.ts","moduleParts":{"metamask-sdk.js":"5277-2163"},"imported":[],"importedBy":[{"uid":"5277-2186"},{"uid":"5277-2200"},{"uid":"5277-2164"},{"uid":"5277-2170"},{"uid":"5277-2264"},{"uid":"5277-2268"},{"uid":"5277-2276"},{"uid":"5277-2274"}]},"5277-2164":{"id":"/src/services/RemoteCommunicationPostMessageStream/onMessage.ts","moduleParts":{"metamask-sdk.js":"5277-2165"},"imported":[{"uid":"5277-1300"},{"uid":"5277-2162"}],"importedBy":[{"uid":"5277-2172"}]},"5277-2166":{"id":"/src/services/Ethereum.ts","moduleParts":{"metamask-sdk.js":"5277-2167"},"imported":[{"uid":"5277-2096"},{"uid":"5277-2106"}],"importedBy":[{"uid":"5277-2204"},{"uid":"5277-2186"},{"uid":"5277-2218"},{"uid":"5277-2240"},{"uid":"5277-2282"},{"uid":"5277-2170"},{"uid":"5277-2445"},{"uid":"5277-2276"},{"uid":"5277-2278"},{"uid":"5277-2274"}]},"5277-2168":{"id":"/src/services/RemoteCommunicationPostMessageStream/extractMethod.ts","moduleParts":{"metamask-sdk.js":"5277-2169"},"imported":[{"uid":"5277-1300"}],"importedBy":[{"uid":"5277-2170"}]},"5277-2170":{"id":"/src/services/RemoteCommunicationPostMessageStream/write.ts","moduleParts":{"metamask-sdk.js":"5277-2171"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2148"},{"uid":"5277-2162"},{"uid":"5277-2166"},{"uid":"5277-2168"}],"importedBy":[{"uid":"5277-2172"}]},"5277-2172":{"id":"/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-2173"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1416"},{"uid":"5277-1902"},{"uid":"5277-2164"},{"uid":"5277-2170"}],"importedBy":[{"uid":"5277-2174"}]},"5277-2174":{"id":"/src/PostMessageStream/getPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-2175"},"imported":[{"uid":"5277-2172"}],"importedBy":[{"uid":"5277-2186"}]},"5277-2176":{"id":"/src/utils/wait.ts","moduleParts":{"metamask-sdk.js":"5277-2177"},"imported":[],"importedBy":[{"uid":"5277-2186"},{"uid":"5277-2242"}]},"5277-2178":{"id":"\u0000/node_modules/cross-fetch/dist/browser-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2179"},"imported":[],"importedBy":[{"uid":"5277-2180"}]},"5277-2180":{"id":"/node_modules/cross-fetch/dist/browser-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-2181"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2178"}],"importedBy":[{"uid":"5277-2182"}]},"5277-2182":{"id":"/src/services/rpc-requests/RPCRequestHandler.ts","moduleParts":{"metamask-sdk.js":"5277-2183"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2180"}],"importedBy":[{"uid":"5277-2186"}]},"5277-2184":{"id":"/package.json","moduleParts":{"metamask-sdk.js":"5277-2185"},"imported":[],"importedBy":[{"uid":"5277-2186"},{"uid":"5277-2254"},{"uid":"5277-2258"},{"uid":"5277-2262"}]},"5277-2186":{"id":"/src/provider/initializeMobileProvider.ts","moduleParts":{"metamask-sdk.js":"5277-2187"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2174"},{"uid":"5277-2148"},{"uid":"5277-2162"},{"uid":"5277-2166"},{"uid":"5277-2150"},{"uid":"5277-2176"},{"uid":"5277-2182"},{"uid":"5277-2184"}],"importedBy":[{"uid":"5277-2188"}]},"5277-2188":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeProviderAndEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-2189"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2186"},{"uid":"5277-2160"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2190":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.ts","moduleParts":{"metamask-sdk.js":"5277-2191"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2156"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2192":{"id":"/src/utils/extractFavicon.ts","moduleParts":{"metamask-sdk.js":"5277-2193"},"imported":[],"importedBy":[{"uid":"5277-2196"}]},"5277-2194":{"id":"/src/utils/getBase64FromUrl.ts","moduleParts":{"metamask-sdk.js":"5277-2195"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2196"}]},"5277-2196":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.ts","moduleParts":{"metamask-sdk.js":"5277-2197"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2192"},{"uid":"5277-2194"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2198":{"id":"/src/provider/wrapExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-2199"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2148"}],"importedBy":[{"uid":"5277-2202"}]},"5277-2200":{"id":"/src/utils/eip6963RequestProvider.ts","moduleParts":{"metamask-sdk.js":"5277-2201"},"imported":[{"uid":"5277-2162"}],"importedBy":[{"uid":"5277-2202"}]},"5277-2202":{"id":"/src/utils/get-browser-extension.ts","moduleParts":{"metamask-sdk.js":"5277-2203"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2198"},{"uid":"5277-2200"}],"importedBy":[{"uid":"5277-2204"}]},"5277-2204":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts","moduleParts":{"metamask-sdk.js":"5277-2205"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2148"},{"uid":"5277-2202"},{"uid":"5277-2166"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2206":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/es5.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2207"},"imported":[],"importedBy":[{"uid":"5277-2208"}]},"5277-2208":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/es5.js","moduleParts":{"metamask-sdk.js":"5277-2209"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2206"}],"importedBy":[{"uid":"5277-2230"},{"uid":"5277-2238"}]},"5277-2210":{"id":"/src/types/WakeLockStatus.ts","moduleParts":{"metamask-sdk.js":"5277-2211"},"imported":[],"importedBy":[{"uid":"5277-2230"},{"uid":"5277-2212"},{"uid":"5277-2214"}]},"5277-2212":{"id":"/src/services/PlatfformManager/disableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-2213"},"imported":[{"uid":"5277-2210"}],"importedBy":[{"uid":"5277-2230"}]},"5277-2214":{"id":"/src/services/PlatfformManager/enableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-2215"},"imported":[{"uid":"5277-2230"},{"uid":"5277-2210"}],"importedBy":[{"uid":"5277-2230"}]},"5277-2216":{"id":"/src/services/PlatfformManager/getPlatformType.ts","moduleParts":{"metamask-sdk.js":"5277-2217"},"imported":[{"uid":"5277-1902"}],"importedBy":[{"uid":"5277-2230"}]},"5277-2218":{"id":"/src/services/PlatfformManager/isMetaMaskInstalled.ts","moduleParts":{"metamask-sdk.js":"5277-2219"},"imported":[{"uid":"5277-2166"}],"importedBy":[{"uid":"5277-2230"}]},"5277-2220":{"id":"/src/services/PlatfformManager/openDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-2221"},"imported":[{"uid":"5277-2230"}],"importedBy":[{"uid":"5277-2230"}]},"5277-2222":{"id":"/src/utils/hasNativeWakeLockSupport.ts","moduleParts":{"metamask-sdk.js":"5277-2223"},"imported":[],"importedBy":[{"uid":"5277-2228"}]},"5277-2224":{"id":"/src/utils/isOldIOS.ts","moduleParts":{"metamask-sdk.js":"5277-2225"},"imported":[],"importedBy":[{"uid":"5277-2228"}]},"5277-2226":{"id":"/src/Platform/Media.ts","moduleParts":{"metamask-sdk.js":"5277-2227"},"imported":[],"importedBy":[{"uid":"5277-2228"}]},"5277-2228":{"id":"/src/Platform/WakeLockManager.ts","moduleParts":{"metamask-sdk.js":"5277-2229"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2222"},{"uid":"5277-2224"},{"uid":"5277-2226"}],"importedBy":[{"uid":"5277-2230"}]},"5277-2230":{"id":"/src/Platform/PlatfformManager.ts","moduleParts":{"metamask-sdk.js":"5277-2231"},"imported":[{"uid":"5277-1902"},{"uid":"5277-2208"},{"uid":"5277-2212"},{"uid":"5277-2214"},{"uid":"5277-2216"},{"uid":"5277-2218"},{"uid":"5277-2220"},{"uid":"5277-2210"},{"uid":"5277-2228"}],"importedBy":[{"uid":"5277-2232"},{"uid":"5277-2214"},{"uid":"5277-2220"}]},"5277-2232":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupPlatformManager.ts","moduleParts":{"metamask-sdk.js":"5277-2233"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2230"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2234":{"id":"/src/services/MetaMaskInstaller/checkInstallation.ts","moduleParts":{"metamask-sdk.js":"5277-2235"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2244"}]},"5277-2236":{"id":"/src/services/MetaMaskInstaller/redirectToProperInstall.ts","moduleParts":{"metamask-sdk.js":"5277-2237"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"}],"importedBy":[{"uid":"5277-2244"}]},"5277-2238":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/onboarding/dist/metamask-onboarding.es.js","moduleParts":{"metamask-sdk.js":"5277-2239"},"imported":[{"uid":"5277-2208"}],"importedBy":[{"uid":"5277-2240"}]},"5277-2240":{"id":"/src/services/MetaMaskInstaller/startDesktopOnboarding.ts","moduleParts":{"metamask-sdk.js":"5277-2241"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2238"},{"uid":"5277-2166"}],"importedBy":[{"uid":"5277-2244"}]},"5277-2242":{"id":"/src/services/MetaMaskInstaller/startInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-2243"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2176"}],"importedBy":[{"uid":"5277-2244"}]},"5277-2244":{"id":"/src/Platform/MetaMaskInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-2245"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2234"},{"uid":"5277-2236"},{"uid":"5277-2240"},{"uid":"5277-2242"}],"importedBy":[{"uid":"5277-2284"}]},"5277-2246":{"id":"\u0000-install-modal-web/dist/umd/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2247"},"imported":[],"importedBy":[{"uid":"5277-2252"}]},"5277-2248":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/qr-code-styling/lib/qr-code-styling.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2249"},"imported":[],"importedBy":[{"uid":"5277-2250"}]},"5277-2250":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/qr-code-styling/lib/qr-code-styling.js","moduleParts":{"metamask-sdk.js":"5277-2251"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2248"}],"importedBy":[{"uid":"5277-2252"}]},"5277-2252":{"id":"-install-modal-web/dist/umd/index.js","moduleParts":{"metamask-sdk.js":"5277-2253"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2246"},{"uid":"5277-2250"}],"importedBy":[{"uid":"5277-2254"},{"uid":"5277-2258"}]},"5277-2254":{"id":"/src/ui/InstallModal/InstallModal-web.ts","moduleParts":{"metamask-sdk.js":"5277-2255"},"imported":[{"uid":"5277-2252"},{"uid":"5277-2184"}],"importedBy":[{"uid":"5277-2256"}]},"5277-2256":{"id":"/src/ui/InstallModal/installModal.ts","moduleParts":{"metamask-sdk.js":"5277-2257"},"imported":[{"uid":"5277-2254"}],"importedBy":[{"uid":"5277-2282"}]},"5277-2258":{"id":"/src/ui/InstallModal/pendingModal-web.ts","moduleParts":{"metamask-sdk.js":"5277-2259"},"imported":[{"uid":"5277-2252"},{"uid":"5277-2184"}],"importedBy":[{"uid":"5277-2260"}]},"5277-2260":{"id":"/src/ui/InstallModal/pendingModal.ts","moduleParts":{"metamask-sdk.js":"5277-2261"},"imported":[{"uid":"5277-2258"}],"importedBy":[{"uid":"5277-2282"}]},"5277-2262":{"id":"/src/services/RemoteConnection/ConnectionInitializer/initializeConnector.ts","moduleParts":{"metamask-sdk.js":"5277-2263"},"imported":[{"uid":"5277-1902"},{"uid":"5277-2184"}],"importedBy":[{"uid":"5277-2417"}]},"5277-2264":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-2265"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2162"}],"importedBy":[{"uid":"5277-2418"},{"uid":"5277-2276"}]},"5277-2266":{"id":"/src/services/RemoteConnection/ModalManager/showInstallModal.ts","moduleParts":{"metamask-sdk.js":"5277-2267"},"imported":[],"importedBy":[{"uid":"5277-2420"},{"uid":"5277-2268"}]},"5277-2268":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithModalInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-2269"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2266"},{"uid":"5277-2162"}],"importedBy":[{"uid":"5277-2418"},{"uid":"5277-2276"}]},"5277-2270":{"id":"/src/services/RemoteConnection/ModalManager/onOTPModalDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-2271"},"imported":[],"importedBy":[{"uid":"5277-2274"}]},"5277-2272":{"id":"/src/services/RemoteConnection/ModalManager/waitForOTPAnswer.ts","moduleParts":{"metamask-sdk.js":"5277-2273"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2274"}]},"5277-2274":{"id":"/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts","moduleParts":{"metamask-sdk.js":"5277-2275"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2166"},{"uid":"5277-2162"},{"uid":"5277-2270"},{"uid":"5277-2272"}],"importedBy":[{"uid":"5277-2420"},{"uid":"5277-2276"}]},"5277-2276":{"id":"/src/services/RemoteConnection/ConnectionManager/startConnection.ts","moduleParts":{"metamask-sdk.js":"5277-2277"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2162"},{"uid":"5277-2166"},{"uid":"5277-2274"},{"uid":"5277-2264"},{"uid":"5277-2268"}],"importedBy":[{"uid":"5277-2418"}]},"5277-2278":{"id":"/src/services/RemoteConnection/EventListeners/setupListeners.ts","moduleParts":{"metamask-sdk.js":"5277-2279"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2166"}],"importedBy":[{"uid":"5277-2419"}]},"5277-2280":{"id":"/src/services/RemoteConnection/ModalManager/showActiveModal.ts","moduleParts":{"metamask-sdk.js":"5277-2281"},"imported":[],"importedBy":[{"uid":"5277-2420"}]},"5277-2282":{"id":"/src/services/RemoteConnection/RemoteConnection.ts","moduleParts":{"metamask-sdk.js":"5277-2283"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2256"},{"uid":"5277-2260"},{"uid":"5277-2166"},{"uid":"5277-2417"},{"uid":"5277-2418"},{"uid":"5277-2419"},{"uid":"5277-2420"}],"importedBy":[{"uid":"5277-2381"}]},"5277-2284":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-2285"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2244"},{"uid":"5277-2381"},{"uid":"5277-2380"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2286":{"id":"/src/storage-manager/StorageManagerWeb.ts","moduleParts":{"metamask-sdk.js":"5277-2287"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2148"}],"importedBy":[{"uid":"5277-2288"}]},"5277-2288":{"id":"/src/storage-manager/getStorageManager.ts","moduleParts":{"metamask-sdk.js":"5277-2289"},"imported":[{"uid":"5277-2286"}],"importedBy":[{"uid":"5277-2290"}]},"5277-2290":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupStorage.ts","moduleParts":{"metamask-sdk.js":"5277-2291"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2288"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2344"}]},"5277-2292":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupInfuraProvider.ts","moduleParts":{"metamask-sdk.js":"5277-2293"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2344"}]},"5277-2294":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupReadOnlyRPCProviders.ts","moduleParts":{"metamask-sdk.js":"5277-2295"},"imported":[{"uid":"5277-1904"}],"importedBy":[{"uid":"5277-2344"}]},"5277-2296":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-2297"},"imported":[],"importedBy":[{"uid":"5277-2306"}]},"5277-2298":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-2299"},"imported":[],"importedBy":[{"uid":"5277-2302"},{"uid":"5277-2300"}]},"5277-2300":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-2301"},"imported":[{"uid":"5277-2298"}],"importedBy":[{"uid":"5277-2302"}]},"5277-2302":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-2303"},"imported":[{"uid":"5277-2298"},{"uid":"5277-2300"}],"importedBy":[{"uid":"5277-2304"}]},"5277-2304":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-2305"},"imported":[{"uid":"5277-2302"}],"importedBy":[{"uid":"5277-2306"}]},"5277-2306":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/dist/esm/i18nextBrowserLanguageDetector.js","moduleParts":{"metamask-sdk.js":"5277-2307"},"imported":[{"uid":"5277-2296"},{"uid":"5277-2304"}],"importedBy":[{"uid":"5277-2342"}]},"5277-2308":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2309"},"imported":[],"importedBy":[{"uid":"5277-2318"}]},"5277-2310":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-2311"},"imported":[],"importedBy":[{"uid":"5277-2312"}]},"5277-2312":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js","moduleParts":{"metamask-sdk.js":"5277-2313"},"imported":[{"uid":"5277-1302"},{"uid":"5277-2310"}],"importedBy":[{"uid":"5277-2318"}]},"5277-2314":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-2315"},"imported":[],"importedBy":[{"uid":"5277-2316"}]},"5277-2316":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js","moduleParts":{"metamask-sdk.js":"5277-2317"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2314"}],"importedBy":[{"uid":"5277-2318"}]},"5277-2318":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js","moduleParts":{"metamask-sdk.js":"5277-2319"},"imported":[{"uid":"5277-1314"},{"uid":"5277-1302"},{"uid":"5277-2308"},{"uid":"5277-2312"},{"uid":"5277-2316"}],"importedBy":[{"uid":"5277-2408"},{"uid":"5277-2409"},{"uid":"5277-2410"},{"uid":"5277-2411"},{"uid":"5277-2413"},{"uid":"5277-2414"},{"uid":"5277-2415"},{"uid":"5277-2326"}]},"5277-2320":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/unescape.js","moduleParts":{"metamask-sdk.js":"5277-2321"},"imported":[],"importedBy":[{"uid":"5277-2322"}]},"5277-2322":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/defaults.js","moduleParts":{"metamask-sdk.js":"5277-2323"},"imported":[{"uid":"5277-2320"}],"importedBy":[{"uid":"5277-2398"},{"uid":"5277-2409"},{"uid":"5277-2324"},{"uid":"5277-2326"}]},"5277-2324":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/initReactI18next.js","moduleParts":{"metamask-sdk.js":"5277-2325"},"imported":[{"uid":"5277-2322"},{"uid":"5277-2416"}],"importedBy":[{"uid":"5277-2398"},{"uid":"5277-2326"}]},"5277-2326":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/context.js","moduleParts":{"metamask-sdk.js":"5277-2327"},"imported":[{"uid":"5277-2318"},{"uid":"5277-2322"},{"uid":"5277-2416"},{"uid":"5277-2324"}],"importedBy":[{"uid":"5277-2398"},{"uid":"5277-2408"},{"uid":"5277-2410"},{"uid":"5277-2413"},{"uid":"5277-2414"},{"uid":"5277-2415"}]},"5277-2328":{"id":"/src/locales/en.json","moduleParts":{"metamask-sdk.js":"5277-2329"},"imported":[],"importedBy":[{"uid":"5277-2342"}]},"5277-2330":{"id":"/src/locales/es.json","moduleParts":{"metamask-sdk.js":"5277-2331"},"imported":[],"importedBy":[{"uid":"5277-2342"}]},"5277-2332":{"id":"/src/locales/fr.json","moduleParts":{"metamask-sdk.js":"5277-2333"},"imported":[],"importedBy":[{"uid":"5277-2342"}]},"5277-2334":{"id":"/src/locales/he.json","moduleParts":{"metamask-sdk.js":"5277-2335"},"imported":[],"importedBy":[{"uid":"5277-2342"}]},"5277-2336":{"id":"/src/locales/it.json","moduleParts":{"metamask-sdk.js":"5277-2337"},"imported":[],"importedBy":[{"uid":"5277-2342"}]},"5277-2338":{"id":"/src/locales/pt.json","moduleParts":{"metamask-sdk.js":"5277-2339"},"imported":[],"importedBy":[{"uid":"5277-2342"}]},"5277-2340":{"id":"/src/locales/tr.json","moduleParts":{"metamask-sdk.js":"5277-2341"},"imported":[],"importedBy":[{"uid":"5277-2342"}]},"5277-2342":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeI18next.ts","moduleParts":{"metamask-sdk.js":"5277-2343"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2306"},{"uid":"5277-2398"},{"uid":"5277-2328"},{"uid":"5277-2330"},{"uid":"5277-2332"},{"uid":"5277-2334"},{"uid":"5277-2336"},{"uid":"5277-2338"},{"uid":"5277-2340"}],"importedBy":[{"uid":"5277-2344"}]},"5277-2344":{"id":"/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts","moduleParts":{"metamask-sdk.js":"5277-2345"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1902"},{"uid":"5277-2150"},{"uid":"5277-2158"},{"uid":"5277-2188"},{"uid":"5277-2190"},{"uid":"5277-2196"},{"uid":"5277-2204"},{"uid":"5277-2232"},{"uid":"5277-2284"},{"uid":"5277-2290"},{"uid":"5277-2292"},{"uid":"5277-2294"},{"uid":"5277-2342"}],"importedBy":[{"uid":"5277-2356"},{"uid":"5277-2346"}]},"5277-2346":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeMetaMaskSDK.ts","moduleParts":{"metamask-sdk.js":"5277-2347"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2344"}],"importedBy":[{"uid":"5277-2356"}]},"5277-2348":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connectAndSign.ts","moduleParts":{"metamask-sdk.js":"5277-2349"},"imported":[{"uid":"5277-1904"},{"uid":"5277-2148"}],"importedBy":[{"uid":"5277-2350"}]},"5277-2350":{"id":"/src/sdk.ts","moduleParts":{"metamask-sdk.js":"5277-2351"},"imported":[{"uid":"5277-1904"},{"uid":"5277-1828"},{"uid":"5277-2142"},{"uid":"5277-2355"},{"uid":"5277-2356"},{"uid":"5277-2348"}],"importedBy":[{"uid":"5277-2352"}]},"5277-2352":{"id":"/src/index.ts","moduleParts":{"metamask-sdk.js":"5277-2353"},"imported":[{"uid":"5277-1902"},{"uid":"5277-2106"},{"uid":"5277-2350"},{"uid":"5277-2150"}],"importedBy":[],"isEntry":true},"5277-2354":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/index.js","moduleParts":{},"imported":[{"uid":"5277-2360"},{"uid":"5277-2361"},{"uid":"5277-1838"},{"uid":"5277-2362"},{"uid":"5277-2363"},{"uid":"5277-2364"},{"uid":"5277-1834"},{"uid":"5277-1836"},{"uid":"5277-2365"}],"importedBy":[{"uid":"5277-1902"}]},"5277-2355":{"id":"/src/services/MetaMaskSDK/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-2144"},{"uid":"5277-2146"},{"uid":"5277-2152"}],"importedBy":[{"uid":"5277-2350"}]},"5277-2356":{"id":"/src/services/MetaMaskSDK/InitializerManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-2158"},{"uid":"5277-2160"},{"uid":"5277-2346"},{"uid":"5277-2188"},{"uid":"5277-2344"},{"uid":"5277-2190"},{"uid":"5277-2196"},{"uid":"5277-2204"},{"uid":"5277-2232"},{"uid":"5277-2284"},{"uid":"5277-2290"}],"importedBy":[{"uid":"5277-2350"}]},"5277-2357":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1822"}],"importedBy":[{"uid":"5277-1824"}]},"5277-2358":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1814"}],"importedBy":[{"uid":"5277-1824"},{"uid":"5277-1820"},{"uid":"5277-1818"}]},"5277-2359":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1812"}],"importedBy":[{"uid":"5277-1824"},{"uid":"5277-1814"},{"uid":"5277-1818"}]},"5277-2360":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v1.js","moduleParts":{},"imported":[{"uid":"5277-1830"},{"uid":"5277-1836"}],"importedBy":[{"uid":"5277-2354"}]},"5277-2361":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v3.js","moduleParts":{},"imported":[{"uid":"5277-2372"},{"uid":"5277-2373"}],"importedBy":[{"uid":"5277-2354"}]},"5277-2362":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v5.js","moduleParts":{},"imported":[{"uid":"5277-2372"},{"uid":"5277-2374"}],"importedBy":[{"uid":"5277-2354"}]},"5277-2363":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/nil.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-2354"}]},"5277-2364":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/version.js","moduleParts":{},"imported":[{"uid":"5277-1834"}],"importedBy":[{"uid":"5277-2354"}]},"5277-2365":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/parse.js","moduleParts":{},"imported":[{"uid":"5277-1834"}],"importedBy":[{"uid":"5277-2354"},{"uid":"5277-2372"}]},"5277-2366":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1978"}],"importedBy":[{"uid":"5277-2096"},{"uid":"5277-2080"}]},"5277-2367":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2086"}],"importedBy":[{"uid":"5277-2096"}]},"5277-2368":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2094"}],"importedBy":[{"uid":"5277-2096"}]},"5277-2369":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2082"}],"importedBy":[{"uid":"5277-2096"},{"uid":"5277-2086"},{"uid":"5277-2094"}]},"5277-2370":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2092"}],"importedBy":[{"uid":"5277-2096"},{"uid":"5277-2094"}]},"5277-2371":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2080"}],"importedBy":[{"uid":"5277-2096"},{"uid":"5277-2086"},{"uid":"5277-2082"}]},"5277-2372":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v35.js","moduleParts":{},"imported":[{"uid":"5277-1836"},{"uid":"5277-2365"}],"importedBy":[{"uid":"5277-2361"},{"uid":"5277-2362"}]},"5277-2373":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/md5.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-2361"}]},"5277-2374":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/sha1.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-2362"}]},"5277-2375":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm/index.js","moduleParts":{},"imported":[{"uid":"5277-1878"},{"uid":"5277-1858"},{"uid":"5277-1874"},{"uid":"5277-1854"},{"uid":"5277-1876"},{"uid":"5277-1868"}],"importedBy":[{"uid":"5277-1880"},{"uid":"5277-1894"}]},"5277-2376":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1920"}],"importedBy":[{"uid":"5277-1934"},{"uid":"5277-1928"},{"uid":"5277-1932"}]},"5277-2377":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1928"}],"importedBy":[{"uid":"5277-1934"},{"uid":"5277-1932"}]},"5277-2378":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1932"}],"importedBy":[{"uid":"5277-1934"}]},"5277-2379":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1926"}],"importedBy":[{"uid":"5277-1934"},{"uid":"5277-1928"},{"uid":"5277-1932"}]},"5277-2380":{"id":"/src/services/MetaMaskSDK/ProviderManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-2154"}],"importedBy":[{"uid":"5277-2158"},{"uid":"5277-2284"}]},"5277-2381":{"id":"/src/services/RemoteConnection/index.ts","moduleParts":{},"imported":[{"uid":"5277-2282"}],"importedBy":[{"uid":"5277-2284"}]},"5277-2382":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1820"}],"importedBy":[{"uid":"5277-1822"}]},"5277-2383":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1818"}],"importedBy":[{"uid":"5277-1822"},{"uid":"5277-1820"}]},"5277-2384":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/elliptic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1806"}],"importedBy":[{"uid":"5277-1814"},{"uid":"5277-1820"},{"uid":"5277-1818"}]},"5277-2385":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1912"}],"importedBy":[{"uid":"5277-1978"},{"uid":"5277-1958"}]},"5277-2386":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1934"}],"importedBy":[{"uid":"5277-1978"},{"uid":"5277-2082"},{"uid":"5277-1976"},{"uid":"5277-1958"}]},"5277-2387":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1936"}],"importedBy":[{"uid":"5277-1978"}]},"5277-2388":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1964"}],"importedBy":[{"uid":"5277-1978"},{"uid":"5277-1976"}]},"5277-2389":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1968"}],"importedBy":[{"uid":"5277-1978"},{"uid":"5277-2082"},{"uid":"5277-2080"},{"uid":"5277-1994"},{"uid":"5277-1974"}]},"5277-2390":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1976"}],"importedBy":[{"uid":"5277-1978"},{"uid":"5277-2086"},{"uid":"5277-2082"},{"uid":"5277-2080"},{"uid":"5277-1994"}]},"5277-2391":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1984"}],"importedBy":[{"uid":"5277-2086"}]},"5277-2392":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2084"}],"importedBy":[{"uid":"5277-2086"}]},"5277-2393":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1994"}],"importedBy":[{"uid":"5277-2082"}]},"5277-2394":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2054"}],"importedBy":[{"uid":"5277-2080"}]},"5277-2395":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2056"}],"importedBy":[{"uid":"5277-2080"}]},"5277-2396":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2072"}],"importedBy":[{"uid":"5277-2080"}]},"5277-2397":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2078"}],"importedBy":[{"uid":"5277-2080"}]},"5277-2398":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/index.js","moduleParts":{},"imported":[{"uid":"5277-2408"},{"uid":"5277-2409"},{"uid":"5277-2410"},{"uid":"5277-2411"},{"uid":"5277-2412"},{"uid":"5277-2413"},{"uid":"5277-2414"},{"uid":"5277-2415"},{"uid":"5277-2324"},{"uid":"5277-2322"},{"uid":"5277-2416"},{"uid":"5277-2326"}],"importedBy":[{"uid":"5277-2342"}]},"5277-2399":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randombytes/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1322"}],"importedBy":[{"uid":"5277-1798"},{"uid":"5277-1556"},{"uid":"5277-1560"},{"uid":"5277-1796"},{"uid":"5277-1608"},{"uid":"5277-1786"}]},"5277-2400":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1424"}],"importedBy":[{"uid":"5277-1798"},{"uid":"5277-1766"},{"uid":"5277-1786"},{"uid":"5277-1788"},{"uid":"5277-1776"}]},"5277-2401":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1430"}],"importedBy":[{"uid":"5277-1798"},{"uid":"5277-1762"}]},"5277-2402":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/algos.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1434"}],"importedBy":[{"uid":"5277-1798"}]},"5277-2403":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1448"}],"importedBy":[{"uid":"5277-1798"},{"uid":"5277-1758"}]},"5277-2404":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-cipher/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1538"}],"importedBy":[{"uid":"5277-1798"}]},"5277-2405":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1790"}],"importedBy":[{"uid":"5277-1798"}]},"5277-2406":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/randomfill/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1796"}],"importedBy":[{"uid":"5277-1798"}]},"5277-2407":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1918"}],"importedBy":[{"uid":"5277-1920"}]},"5277-2408":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Trans.js","moduleParts":{},"imported":[{"uid":"5277-2318"},{"uid":"5277-2409"},{"uid":"5277-2326"}],"importedBy":[{"uid":"5277-2398"}]},"5277-2409":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/TransWithoutContext.js","moduleParts":{},"imported":[{"uid":"5277-2442"},{"uid":"5277-2318"},{"uid":"5277-2443"},{"uid":"5277-2444"},{"uid":"5277-2322"},{"uid":"5277-2416"}],"importedBy":[{"uid":"5277-2398"},{"uid":"5277-2408"}]},"5277-2410":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useTranslation.js","moduleParts":{},"imported":[{"uid":"5277-2318"},{"uid":"5277-2326"},{"uid":"5277-2444"}],"importedBy":[{"uid":"5277-2398"},{"uid":"5277-2411"},{"uid":"5277-2412"}]},"5277-2411":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withTranslation.js","moduleParts":{},"imported":[{"uid":"5277-2318"},{"uid":"5277-2410"},{"uid":"5277-2444"}],"importedBy":[{"uid":"5277-2398"}]},"5277-2412":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Translation.js","moduleParts":{},"imported":[{"uid":"5277-2410"}],"importedBy":[{"uid":"5277-2398"}]},"5277-2413":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/I18nextProvider.js","moduleParts":{},"imported":[{"uid":"5277-2318"},{"uid":"5277-2326"}],"importedBy":[{"uid":"5277-2398"}]},"5277-2414":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withSSR.js","moduleParts":{},"imported":[{"uid":"5277-2318"},{"uid":"5277-2415"},{"uid":"5277-2326"},{"uid":"5277-2444"}],"importedBy":[{"uid":"5277-2398"}]},"5277-2415":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useSSR.js","moduleParts":{},"imported":[{"uid":"5277-2318"},{"uid":"5277-2326"}],"importedBy":[{"uid":"5277-2398"},{"uid":"5277-2414"}]},"5277-2416":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/i18nInstance.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-2398"},{"uid":"5277-2409"},{"uid":"5277-2324"},{"uid":"5277-2326"}]},"5277-2417":{"id":"/src/services/RemoteConnection/ConnectionInitializer/index.ts","moduleParts":{},"imported":[{"uid":"5277-2262"}],"importedBy":[{"uid":"5277-2282"}]},"5277-2418":{"id":"/src/services/RemoteConnection/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-2264"},{"uid":"5277-2268"},{"uid":"5277-2445"},{"uid":"5277-2276"}],"importedBy":[{"uid":"5277-2282"}]},"5277-2419":{"id":"/src/services/RemoteConnection/EventListeners/index.ts","moduleParts":{},"imported":[{"uid":"5277-2278"}],"importedBy":[{"uid":"5277-2282"}]},"5277-2420":{"id":"/src/services/RemoteConnection/ModalManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-2274"},{"uid":"5277-2280"},{"uid":"5277-2266"}],"importedBy":[{"uid":"5277-2282"}]},"5277-2421":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1800"}],"importedBy":[{"uid":"5277-1820"},{"uid":"5277-1818"}]},"5277-2422":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/lib/primes.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1558"}],"importedBy":[{"uid":"5277-1562"}]},"5277-2423":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safe-buffer/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1320"}],"importedBy":[{"uid":"5277-1766"},{"uid":"5277-1322"},{"uid":"5277-1430"},{"uid":"5277-1762"},{"uid":"5277-1764"},{"uid":"5277-1796"},{"uid":"5277-1380"},{"uid":"5277-1422"},{"uid":"5277-1426"},{"uid":"5277-1446"},{"uid":"5277-1444"},{"uid":"5277-1472"},{"uid":"5277-1524"},{"uid":"5277-1758"},{"uid":"5277-1786"},{"uid":"5277-1788"},{"uid":"5277-1584"},{"uid":"5277-1378"},{"uid":"5277-1388"},{"uid":"5277-1390"},{"uid":"5277-1394"},{"uid":"5277-1392"},{"uid":"5277-1398"},{"uid":"5277-1396"},{"uid":"5277-1442"},{"uid":"5277-1526"},{"uid":"5277-1530"},{"uid":"5277-1490"},{"uid":"5277-1494"},{"uid":"5277-1498"},{"uid":"5277-1508"},{"uid":"5277-1756"},{"uid":"5277-1776"},{"uid":"5277-1784"},{"uid":"5277-1386"},{"uid":"5277-1520"},{"uid":"5277-1522"},{"uid":"5277-1516"},{"uid":"5277-1360"},{"uid":"5277-1518"}]},"5277-2424":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/readable-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1600"}],"importedBy":[{"uid":"5277-1766"}]},"5277-2425":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1326"}],"importedBy":[{"uid":"5277-1766"},{"uid":"5277-1424"},{"uid":"5277-1430"},{"uid":"5277-1380"},{"uid":"5277-1382"},{"uid":"5277-1422"},{"uid":"5277-1426"},{"uid":"5277-1472"},{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-1580"},{"uid":"5277-1594"},{"uid":"5277-1596"},{"uid":"5277-1378"},{"uid":"5277-1388"},{"uid":"5277-1390"},{"uid":"5277-1394"},{"uid":"5277-1392"},{"uid":"5277-1398"},{"uid":"5277-1396"},{"uid":"5277-1526"},{"uid":"5277-1530"},{"uid":"5277-1630"},{"uid":"5277-1632"},{"uid":"5277-1634"},{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2026"},{"uid":"5277-2034"},{"uid":"5277-2036"},{"uid":"5277-1462"},{"uid":"5277-1466"},{"uid":"5277-1468"},{"uid":"5277-1520"},{"uid":"5277-1522"},{"uid":"5277-1644"},{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-1356"},{"uid":"5277-1370"},{"uid":"5277-1372"},{"uid":"5277-1738"},{"uid":"5277-1712"},{"uid":"5277-1716"},{"uid":"5277-1732"},{"uid":"5277-1734"},{"uid":"5277-1724"},{"uid":"5277-1726"}]},"5277-2426":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/algorithms.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1432"}],"importedBy":[{"uid":"5277-1766"},{"uid":"5277-1434"}]},"5277-2427":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-ecdh/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1770"}],"importedBy":[{"uid":"5277-1772"}]},"5277-2428":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1802"}],"importedBy":[{"uid":"5277-1806"}]},"5277-2429":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/elliptic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1804"}],"importedBy":[{"uid":"5277-1806"}]},"5277-2430":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1946"}],"importedBy":[{"uid":"5277-1964"}]},"5277-2431":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1950"}],"importedBy":[{"uid":"5277-1964"}]},"5277-2432":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1954"}],"importedBy":[{"uid":"5277-1964"}]},"5277-2433":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1944"}],"importedBy":[{"uid":"5277-1964"},{"uid":"5277-1946"}]},"5277-2434":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1958"}],"importedBy":[{"uid":"5277-1964"},{"uid":"5277-1962"}]},"5277-2435":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1962"}],"importedBy":[{"uid":"5277-1964"}]},"5277-2436":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1974"}],"importedBy":[{"uid":"5277-1976"}]},"5277-2437":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2052"}],"importedBy":[{"uid":"5277-2054"}]},"5277-2438":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2062"}],"importedBy":[{"uid":"5277-2072"}]},"5277-2439":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2070"}],"importedBy":[{"uid":"5277-2072"}]},"5277-2440":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2044"}],"importedBy":[{"uid":"5277-2078"},{"uid":"5277-2052"},{"uid":"5277-2046"}]},"5277-2441":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2046"}],"importedBy":[{"uid":"5277-2078"},{"uid":"5277-2052"}]},"5277-2442":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/node_modules/@babel/runtime/helpers/esm/extends.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-2409"}]},"5277-2443":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/html-parse-stringify/dist/html-parse-stringify.module.js","moduleParts":{},"imported":[{"uid":"5277-2471"}],"importedBy":[{"uid":"5277-2409"}]},"5277-2444":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/utils.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-2409"},{"uid":"5277-2410"},{"uid":"5277-2411"},{"uid":"5277-2414"}]},"5277-2445":{"id":"/src/services/RemoteConnection/ConnectionManager/handleDisconnect.ts","moduleParts":{},"imported":[{"uid":"5277-1904"},{"uid":"5277-2166"}],"importedBy":[{"uid":"5277-2418"}]},"5277-2446":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/md5.js/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1380"}],"importedBy":[{"uid":"5277-1424"},{"uid":"5277-1428"},{"uid":"5277-1524"}]},"5277-2447":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/ripemd160/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1382"}],"importedBy":[{"uid":"5277-1424"},{"uid":"5277-1430"},{"uid":"5277-1444"}]},"5277-2448":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1400"}],"importedBy":[{"uid":"5277-1424"},{"uid":"5277-1430"},{"uid":"5277-1444"}]},"5277-2449":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cipher-base/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1422"}],"importedBy":[{"uid":"5277-1424"},{"uid":"5277-1430"},{"uid":"5277-1426"},{"uid":"5277-1472"},{"uid":"5277-1526"},{"uid":"5277-1530"},{"uid":"5277-1520"},{"uid":"5277-1522"}]},"5277-2450":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hmac/legacy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1426"}],"importedBy":[{"uid":"5277-1430"}]},"5277-2451":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/create-hash/md5.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1428"}],"importedBy":[{"uid":"5277-1430"},{"uid":"5277-1444"}]},"5277-2452":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/async.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1446"}],"importedBy":[{"uid":"5277-1448"}]},"5277-2453":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/sync-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1444"}],"importedBy":[{"uid":"5277-1448"},{"uid":"5277-1446"}]},"5277-2454":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1472"}],"importedBy":[{"uid":"5277-1538"}]},"5277-2455":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1532"}],"importedBy":[{"uid":"5277-1538"},{"uid":"5277-1758"},{"uid":"5277-1756"}]},"5277-2456":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1512"}],"importedBy":[{"uid":"5277-1538"},{"uid":"5277-1526"},{"uid":"5277-1530"}]},"5277-2457":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-des/modes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1536"}],"importedBy":[{"uid":"5277-1538"}]},"5277-2458":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/evp_bytestokey/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1524"}],"importedBy":[{"uid":"5277-1538"},{"uid":"5277-1526"},{"uid":"5277-1530"},{"uid":"5277-1756"}]},"5277-2459":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/diffie-hellman/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1544"}],"importedBy":[{"uid":"5277-1556"},{"uid":"5277-1560"}]},"5277-2460":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-rsa/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1608"}],"importedBy":[{"uid":"5277-1762"},{"uid":"5277-1786"},{"uid":"5277-1788"}]},"5277-2461":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1606"}],"importedBy":[{"uid":"5277-1762"},{"uid":"5277-1764"},{"uid":"5277-1608"}]},"5277-2462":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1758"}],"importedBy":[{"uid":"5277-1762"},{"uid":"5277-1764"},{"uid":"5277-1786"},{"uid":"5277-1788"}]},"5277-2463":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/browser/curves.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1760"}],"importedBy":[{"uid":"5277-1762"},{"uid":"5277-1764"}]},"5277-2464":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1612"}],"importedBy":[{"uid":"5277-1694"}]},"5277-2465":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1624"}],"importedBy":[{"uid":"5277-1694"},{"uid":"5277-1686"},{"uid":"5277-1678"},{"uid":"5277-1692"},{"uid":"5277-1682"},{"uid":"5277-1684"},{"uid":"5277-1628"},{"uid":"5277-1630"},{"uid":"5277-1632"},{"uid":"5277-1634"},{"uid":"5277-1688"},{"uid":"5277-1690"}]},"5277-2466":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1636"}],"importedBy":[{"uid":"5277-1694"},{"uid":"5277-1678"}]},"5277-2467":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1678"}],"importedBy":[{"uid":"5277-1694"},{"uid":"5277-1686"},{"uid":"5277-1692"}]},"5277-2468":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1692"}],"importedBy":[{"uid":"5277-1694"}]},"5277-2469":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/publicEncrypt.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1786"}],"importedBy":[{"uid":"5277-1790"}]},"5277-2470":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/privateDecrypt.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1788"}],"importedBy":[{"uid":"5277-1790"}]},"5277-2471":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/void-elements/index.js","moduleParts":{},"imported":[{"uid":"5277-1302"}],"importedBy":[{"uid":"5277-2443"}]},"5277-2472":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/miller-rabin/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1548"}],"importedBy":[{"uid":"5277-1554"}]},"5277-2473":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_transform.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1594"}],"importedBy":[{"uid":"5277-1600"},{"uid":"5277-1596"}]},"5277-2474":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/_stream_passthrough.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1596"}],"importedBy":[{"uid":"5277-1600"}]},"5277-2475":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/end-of-stream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1586"}],"importedBy":[{"uid":"5277-1600"},{"uid":"5277-1588"},{"uid":"5277-1598"}]},"5277-2476":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/pipeline.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1598"}],"importedBy":[{"uid":"5277-1600"}]},"5277-2477":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1618"}],"importedBy":[{"uid":"5277-1686"},{"uid":"5277-1624"},{"uid":"5277-1682"},{"uid":"5277-1684"},{"uid":"5277-1628"},{"uid":"5277-1630"},{"uid":"5277-1632"},{"uid":"5277-1634"},{"uid":"5277-1690"}]},"5277-2478":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hmac-drbg/lib/hmac-drbg.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1680"}],"importedBy":[{"uid":"5277-1686"}]},"5277-2479":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/key.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1682"}],"importedBy":[{"uid":"5277-1686"}]},"5277-2480":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/signature.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1684"}],"importedBy":[{"uid":"5277-1686"}]},"5277-2481":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2038"}],"importedBy":[{"uid":"5277-2052"},{"uid":"5277-2062"},{"uid":"5277-2070"},{"uid":"5277-2050"}]},"5277-2482":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2050"}],"importedBy":[{"uid":"5277-2052"}]},"5277-2483":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2068"}],"importedBy":[{"uid":"5277-2070"}]},"5277-2484":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2042"}],"importedBy":[{"uid":"5277-2044"}]},"5277-2485":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1378"}],"importedBy":[{"uid":"5277-1380"},{"uid":"5277-1382"}]},"5277-2486":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1388"}],"importedBy":[{"uid":"5277-1400"}]},"5277-2487":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1390"}],"importedBy":[{"uid":"5277-1400"}]},"5277-2488":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha224.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1394"}],"importedBy":[{"uid":"5277-1400"}]},"5277-2489":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha256.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1392"}],"importedBy":[{"uid":"5277-1400"},{"uid":"5277-1394"}]},"5277-2490":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha384.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1398"}],"importedBy":[{"uid":"5277-1400"}]},"5277-2491":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/sha512.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1396"}],"importedBy":[{"uid":"5277-1400"},{"uid":"5277-1398"}]},"5277-2492":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/precondition.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1438"}],"importedBy":[{"uid":"5277-1446"},{"uid":"5277-1444"}]},"5277-2493":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/default-encoding.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1440"}],"importedBy":[{"uid":"5277-1446"},{"uid":"5277-1444"}]},"5277-2494":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pbkdf2/lib/to-buffer.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1442"}],"importedBy":[{"uid":"5277-1446"},{"uid":"5277-1444"}]},"5277-2495":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1470"}],"importedBy":[{"uid":"5277-1472"}]},"5277-2496":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/encrypter.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1526"}],"importedBy":[{"uid":"5277-1532"}]},"5277-2497":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/decrypter.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1530"}],"importedBy":[{"uid":"5277-1532"}]},"5277-2498":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/list.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1510"}],"importedBy":[{"uid":"5277-1532"},{"uid":"5277-1512"}]},"5277-2499":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ecb.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1480"}],"importedBy":[{"uid":"5277-1512"}]},"5277-2500":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cbc.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1486"}],"importedBy":[{"uid":"5277-1512"}]},"5277-2501":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1490"}],"importedBy":[{"uid":"5277-1512"}]},"5277-2502":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb8.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1494"}],"importedBy":[{"uid":"5277-1512"}]},"5277-2503":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/cfb1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1498"}],"importedBy":[{"uid":"5277-1512"}]},"5277-2504":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ofb.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1502"}],"importedBy":[{"uid":"5277-1512"}]},"5277-2505":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/modes/ctr.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1508"}],"importedBy":[{"uid":"5277-1512"}]},"5277-2506":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/stream-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1566"}],"importedBy":[{"uid":"5277-1592"},{"uid":"5277-1578"}]},"5277-2507":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/destroy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1570"}],"importedBy":[{"uid":"5277-1592"},{"uid":"5277-1578"}]},"5277-2508":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/lib/internal/streams/state.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1576"}],"importedBy":[{"uid":"5277-1592"},{"uid":"5277-1578"}]},"5277-2509":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-sign/node_modules/readable-stream/errors-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1574"}],"importedBy":[{"uid":"5277-1592"},{"uid":"5277-1578"},{"uid":"5277-1594"},{"uid":"5277-1586"},{"uid":"5277-1598"},{"uid":"5277-1576"}]},"5277-2510":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/util-deprecate/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1352"}],"importedBy":[{"uid":"5277-1578"},{"uid":"5277-2024"},{"uid":"5277-1354"}]},"5277-2511":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/asn1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1752"}],"importedBy":[{"uid":"5277-1758"}]},"5277-2512":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/aesid.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1754"}],"importedBy":[{"uid":"5277-1758"}]},"5277-2513":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/fixProc.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1756"}],"importedBy":[{"uid":"5277-1758"}]},"5277-2514":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-assert/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1458"}],"importedBy":[{"uid":"5277-1624"},{"uid":"5277-1680"},{"uid":"5277-1460"},{"uid":"5277-1462"},{"uid":"5277-1466"},{"uid":"5277-1468"},{"uid":"5277-1644"},{"uid":"5277-1648"},{"uid":"5277-1672"},{"uid":"5277-1658"},{"uid":"5277-1662"},{"uid":"5277-1718"}]},"5277-2515":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1622"}],"importedBy":[{"uid":"5277-1624"},{"uid":"5277-1680"}]},"5277-2516":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/base.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1628"}],"importedBy":[{"uid":"5277-1636"},{"uid":"5277-1630"},{"uid":"5277-1632"},{"uid":"5277-1634"}]},"5277-2517":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/short.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1630"}],"importedBy":[{"uid":"5277-1636"}]},"5277-2518":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/mont.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1632"}],"importedBy":[{"uid":"5277-1636"}]},"5277-2519":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/edwards.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1634"}],"importedBy":[{"uid":"5277-1636"}]},"5277-2520":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1674"}],"importedBy":[{"uid":"5277-1678"},{"uid":"5277-1692"},{"uid":"5277-1680"}]},"5277-2521":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/key.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1688"}],"importedBy":[{"uid":"5277-1692"}]},"5277-2522":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/signature.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1690"}],"importedBy":[{"uid":"5277-1692"}]},"5277-2523":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/mgf.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1776"}],"importedBy":[{"uid":"5277-1786"},{"uid":"5277-1788"}]},"5277-2524":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/xor.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1778"}],"importedBy":[{"uid":"5277-1786"},{"uid":"5277-1788"}]},"5277-2525":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1782"}],"importedBy":[{"uid":"5277-1786"},{"uid":"5277-1788"},{"uid":"5277-1784"}]},"5277-2526":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/public-encrypt/withPublic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1784"}],"importedBy":[{"uid":"5277-1786"},{"uid":"5277-1788"}]},"5277-2527":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_transform.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2034"}],"importedBy":[{"uid":"5277-2038"},{"uid":"5277-2036"}]},"5277-2528":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_passthrough.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2036"}],"importedBy":[{"uid":"5277-2038"}]},"5277-2529":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/readable-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1376"}],"importedBy":[{"uid":"5277-1378"}]},"5277-2530":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/sha.js/hash.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1386"}],"importedBy":[{"uid":"5277-1388"},{"uid":"5277-1390"},{"uid":"5277-1394"},{"uid":"5277-1392"},{"uid":"5277-1398"},{"uid":"5277-1396"}]},"5277-2531":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1456"}],"importedBy":[{"uid":"5277-1470"},{"uid":"5277-1462"}]},"5277-2532":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cipher.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1460"}],"importedBy":[{"uid":"5277-1470"},{"uid":"5277-1462"},{"uid":"5277-1468"}]},"5277-2533":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/des.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1462"}],"importedBy":[{"uid":"5277-1470"},{"uid":"5277-1468"}]},"5277-2534":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/cbc.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1466"}],"importedBy":[{"uid":"5277-1470"}]},"5277-2535":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/des.js/lib/des/ede.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1468"}],"importedBy":[{"uid":"5277-1470"}]},"5277-2536":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/authCipher.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1520"}],"importedBy":[{"uid":"5277-1526"},{"uid":"5277-1530"}]},"5277-2537":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/streamCipher.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1522"}],"importedBy":[{"uid":"5277-1526"},{"uid":"5277-1530"}]},"5277-2538":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/aes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1516"}],"importedBy":[{"uid":"5277-1526"},{"uid":"5277-1530"},{"uid":"5277-1520"},{"uid":"5277-1522"}]},"5277-2539":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/buffer-xor/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1484"}],"importedBy":[{"uid":"5277-1486"},{"uid":"5277-1490"},{"uid":"5277-1502"},{"uid":"5277-1508"},{"uid":"5277-1520"}]},"5277-2540":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/incr32.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1506"}],"importedBy":[{"uid":"5277-1508"},{"uid":"5277-1520"}]},"5277-2541":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1748"}],"importedBy":[{"uid":"5277-1752"},{"uid":"5277-1750"}]},"5277-2542":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/parse-asn1/certificate.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1750"}],"importedBy":[{"uid":"5277-1752"}]},"5277-2543":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1644"}],"importedBy":[{"uid":"5277-1674"},{"uid":"5277-1648"},{"uid":"5277-1670"},{"uid":"5277-1672"},{"uid":"5277-1656"},{"uid":"5277-1660"},{"uid":"5277-1658"},{"uid":"5277-1664"},{"uid":"5277-1662"},{"uid":"5277-1654"}]},"5277-2544":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1648"}],"importedBy":[{"uid":"5277-1674"},{"uid":"5277-1670"},{"uid":"5277-1656"},{"uid":"5277-1658"},{"uid":"5277-1662"}]},"5277-2545":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1666"}],"importedBy":[{"uid":"5277-1674"}]},"5277-2546":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1670"}],"importedBy":[{"uid":"5277-1674"}]},"5277-2547":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/hmac.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1672"}],"importedBy":[{"uid":"5277-1674"}]},"5277-2548":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2004"}],"importedBy":[{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2026"},{"uid":"5277-2022"}]},"5277-2549":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/isarray/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2006"}],"importedBy":[{"uid":"5277-2032"}]},"5277-2550":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/stream-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2008"}],"importedBy":[{"uid":"5277-2032"},{"uid":"5277-2024"}]},"5277-2551":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2012"}],"importedBy":[{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2020"},{"uid":"5277-2030"}]},"5277-2552":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2016"}],"importedBy":[{"uid":"5277-2032"},{"uid":"5277-2024"},{"uid":"5277-2026"},{"uid":"5277-2034"},{"uid":"5277-2036"}]},"5277-2553":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/destroy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-2022"}],"importedBy":[{"uid":"5277-2032"},{"uid":"5277-2024"}]},"5277-2554":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_transform.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1370"}],"importedBy":[{"uid":"5277-1376"},{"uid":"5277-1372"}]},"5277-2555":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/_stream_passthrough.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1372"}],"importedBy":[{"uid":"5277-1376"}]},"5277-2556":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/end-of-stream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1362"}],"importedBy":[{"uid":"5277-1376"},{"uid":"5277-1364"},{"uid":"5277-1374"}]},"5277-2557":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/pipeline.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1374"}],"importedBy":[{"uid":"5277-1376"}]},"5277-2558":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/browserify-aes/ghash.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1518"}],"importedBy":[{"uid":"5277-1520"}]},"5277-2559":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1702"}],"importedBy":[{"uid":"5277-1748"},{"uid":"5277-1732"}]},"5277-2560":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/api.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1738"}],"importedBy":[{"uid":"5277-1748"}]},"5277-2561":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1742"}],"importedBy":[{"uid":"5277-1748"}]},"5277-2562":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1746"}],"importedBy":[{"uid":"5277-1748"}]},"5277-2563":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1736"}],"importedBy":[{"uid":"5277-1748"},{"uid":"5277-1738"}]},"5277-2564":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1728"}],"importedBy":[{"uid":"5277-1748"},{"uid":"5277-1738"}]},"5277-2565":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1656"}],"importedBy":[{"uid":"5277-1666"}]},"5277-2566":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/224.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1660"}],"importedBy":[{"uid":"5277-1666"}]},"5277-2567":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/256.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1658"}],"importedBy":[{"uid":"5277-1666"},{"uid":"5277-1660"}]},"5277-2568":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/384.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1664"}],"importedBy":[{"uid":"5277-1666"}]},"5277-2569":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/512.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1662"}],"importedBy":[{"uid":"5277-1666"},{"uid":"5277-1664"}]},"5277-2570":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/stream-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1334"}],"importedBy":[{"uid":"5277-1368"},{"uid":"5277-1354"}]},"5277-2571":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/destroy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1344"}],"importedBy":[{"uid":"5277-1368"},{"uid":"5277-1354"}]},"5277-2572":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/lib/internal/streams/state.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1350"}],"importedBy":[{"uid":"5277-1368"},{"uid":"5277-1354"}]},"5277-2573":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash-base/node_modules/readable-stream/errors-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1348"}],"importedBy":[{"uid":"5277-1368"},{"uid":"5277-1354"},{"uid":"5277-1370"},{"uid":"5277-1362"},{"uid":"5277-1374"},{"uid":"5277-1350"}]},"5277-2574":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/reporter.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1712"}],"importedBy":[{"uid":"5277-1742"},{"uid":"5277-1716"},{"uid":"5277-1718"}]},"5277-2575":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/buffer.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1716"}],"importedBy":[{"uid":"5277-1742"},{"uid":"5277-1718"},{"uid":"5277-1732"}]},"5277-2576":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/base/node.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1718"}],"importedBy":[{"uid":"5277-1742"},{"uid":"5277-1732"},{"uid":"5277-1724"}]},"5277-2577":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/constants/der.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1722"}],"importedBy":[{"uid":"5277-1746"},{"uid":"5277-1732"},{"uid":"5277-1724"}]},"5277-2578":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/der.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1732"}],"importedBy":[{"uid":"5277-1736"},{"uid":"5277-1734"}]},"5277-2579":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/decoders/pem.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1734"}],"importedBy":[{"uid":"5277-1736"}]},"5277-2580":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/der.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1724"}],"importedBy":[{"uid":"5277-1728"},{"uid":"5277-1726"}]},"5277-2581":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/asn1.js/lib/asn1/encoders/pem.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1726"}],"importedBy":[{"uid":"5277-1728"}]},"5277-2582":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1654"}],"importedBy":[{"uid":"5277-1656"},{"uid":"5277-1658"}]},"5277-2583":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/safer-buffer/safer.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-1708"}],"importedBy":[{"uid":"5277-1716"},{"uid":"5277-1734"},{"uid":"5277-1724"}]}},"env":{"rollup":"3.29.4"},"options":{"gzip":false,"brotli":false,"sourcemap":false}};
+
+    const run = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      const chartNode = document.querySelector("main");
+      drawChart.default(chartNode, data, width, height);
+    };
+
+    window.addEventListener('resize', run);
+
+    document.addEventListener('DOMContentLoaded', run);
+    /*-->*/
+  </script>
+</body>
+</html>
+

--- a/packages/sdk/bundle_stats/node-stats-0.11.0.html
+++ b/packages/sdk/bundle_stats/node-stats-0.11.0.html
@@ -1,0 +1,4838 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <title>Rollup Visualizer</title>
+  <style>
+:root {
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --background-color: #2b2d42;
+  --text-color: #edf2f4;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+html {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: var(--font-family);
+}
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+svg {
+  vertical-align: middle;
+  width: 100%;
+  height: 100%;
+  max-height: 100vh;
+}
+
+main {
+  flex-grow: 1;
+  height: 100vh;
+  padding: 20px;
+}
+
+.tooltip {
+  position: absolute;
+  z-index: 1070;
+  border: 2px solid;
+  border-radius: 5px;
+  padding: 5px;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.tooltip-hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  font-size: 0.7rem;
+  align-items: center;
+  margin: 0 50px;
+  height: 20px;
+}
+
+.size-selectors {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.size-selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+}
+.size-selector input {
+  margin: 0 0.3rem 0 0;
+}
+
+.filters {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.module-filters {
+  display: flex;
+  flex-grow: 1;
+}
+
+.module-filter {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+.module-filter input {
+  flex: 1;
+  height: 1rem;
+  padding: 0.01rem;
+  font-size: 0.7rem;
+  margin-left: 0.3rem;
+}
+.module-filter + .module-filter {
+  margin-left: 0.5rem;
+}
+  </style>
+</head>
+<body>
+  <main></main>
+  <script>
+  /*<!--*/
+var drawChart = (function (exports) {
+  'use strict';
+
+  var n,l$1,u$1,t$1,o$2,r$1,f$1,e$1,c$1={},s$1=[],a$1=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,v$1=Array.isArray;function h$1(n,l){for(var u in l)n[u]=l[u];return n}function p$1(n){var l=n.parentNode;l&&l.removeChild(n);}function y$1(l,u,i){var t,o,r,f={};for(r in u)"key"==r?t=u[r]:"ref"==r?o=u[r]:f[r]=u[r];if(arguments.length>2&&(f.children=arguments.length>3?n.call(arguments,2):i),"function"==typeof l&&null!=l.defaultProps)for(r in l.defaultProps)void 0===f[r]&&(f[r]=l.defaultProps[r]);return d$1(l,f,t,o,null)}function d$1(n,i,t,o,r){var f={type:n,props:i,key:t,ref:o,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:null==r?++u$1:r};return null==r&&null!=l$1.vnode&&l$1.vnode(f),f}function k$1(n){return n.children}function b$1(n,l){this.props=n,this.context=l;}function g$1(n,l){if(null==l)return n.__?g$1(n.__,n.__.__k.indexOf(n)+1):null;for(var u;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e)return u.__e;return "function"==typeof n.type?g$1(n):null}function m$1(n){var l,u;if(null!=(n=n.__)&&null!=n.__c){for(n.__e=n.__c.base=null,l=0;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e){n.__e=n.__c.base=u.__e;break}return m$1(n)}}function w$1(n){(!n.__d&&(n.__d=!0)&&t$1.push(n)&&!x.__r++||o$2!==l$1.debounceRendering)&&((o$2=l$1.debounceRendering)||r$1)(x);}function x(){var n,l,u,i,o,r,e,c;for(t$1.sort(f$1);n=t$1.shift();)n.__d&&(l=t$1.length,i=void 0,o=void 0,e=(r=(u=n).__v).__e,(c=u.__P)&&(i=[],(o=h$1({},r)).__v=r.__v+1,L(c,r,o,u.__n,void 0!==c.ownerSVGElement,null!=r.__h?[e]:null,i,null==e?g$1(r):e,r.__h),M(i,r),r.__e!=e&&m$1(r)),t$1.length>l&&t$1.sort(f$1));x.__r=0;}function P(n,l,u,i,t,o,r,f,e,a){var h,p,y,_,b,m,w,x=i&&i.__k||s$1,P=x.length;for(u.__k=[],h=0;h<l.length;h++)if(null!=(_=u.__k[h]=null==(_=l[h])||"boolean"==typeof _||"function"==typeof _?null:"string"==typeof _||"number"==typeof _||"bigint"==typeof _?d$1(null,_,null,null,_):v$1(_)?d$1(k$1,{children:_},null,null,null):_.__b>0?d$1(_.type,_.props,_.key,_.ref?_.ref:null,_.__v):_)){if(_.__=u,_.__b=u.__b+1,null===(y=x[h])||y&&_.key==y.key&&_.type===y.type)x[h]=void 0;else for(p=0;p<P;p++){if((y=x[p])&&_.key==y.key&&_.type===y.type){x[p]=void 0;break}y=null;}L(n,_,y=y||c$1,t,o,r,f,e,a),b=_.__e,(p=_.ref)&&y.ref!=p&&(w||(w=[]),y.ref&&w.push(y.ref,null,_),w.push(p,_.__c||b,_)),null!=b?(null==m&&(m=b),"function"==typeof _.type&&_.__k===y.__k?_.__d=e=C(_,e,n):e=$(n,_,y,x,b,e),"function"==typeof u.type&&(u.__d=e)):e&&y.__e==e&&e.parentNode!=n&&(e=g$1(y));}for(u.__e=m,h=P;h--;)null!=x[h]&&("function"==typeof u.type&&null!=x[h].__e&&x[h].__e==u.__d&&(u.__d=A(i).nextSibling),q$1(x[h],x[h]));if(w)for(h=0;h<w.length;h++)O(w[h],w[++h],w[++h]);}function C(n,l,u){for(var i,t=n.__k,o=0;t&&o<t.length;o++)(i=t[o])&&(i.__=n,l="function"==typeof i.type?C(i,l,u):$(u,i,i,t,i.__e,l));return l}function $(n,l,u,i,t,o){var r,f,e;if(void 0!==l.__d)r=l.__d,l.__d=void 0;else if(null==u||t!=o||null==t.parentNode)n:if(null==o||o.parentNode!==n)n.appendChild(t),r=null;else {for(f=o,e=0;(f=f.nextSibling)&&e<i.length;e+=1)if(f==t)break n;n.insertBefore(t,o),r=o;}return void 0!==r?r:t.nextSibling}function A(n){var l,u,i;if(null==n.type||"string"==typeof n.type)return n.__e;if(n.__k)for(l=n.__k.length-1;l>=0;l--)if((u=n.__k[l])&&(i=A(u)))return i;return null}function H(n,l,u,i,t){var o;for(o in u)"children"===o||"key"===o||o in l||T$1(n,o,null,u[o],i);for(o in l)t&&"function"!=typeof l[o]||"children"===o||"key"===o||"value"===o||"checked"===o||u[o]===l[o]||T$1(n,o,l[o],u[o],i);}function I(n,l,u){"-"===l[0]?n.setProperty(l,null==u?"":u):n[l]=null==u?"":"number"!=typeof u||a$1.test(l)?u:u+"px";}function T$1(n,l,u,i,t){var o;n:if("style"===l)if("string"==typeof u)n.style.cssText=u;else {if("string"==typeof i&&(n.style.cssText=i=""),i)for(l in i)u&&l in u||I(n.style,l,"");if(u)for(l in u)i&&u[l]===i[l]||I(n.style,l,u[l]);}else if("o"===l[0]&&"n"===l[1])o=l!==(l=l.replace(/Capture$/,"")),l=l.toLowerCase()in n?l.toLowerCase().slice(2):l.slice(2),n.l||(n.l={}),n.l[l+o]=u,u?i||n.addEventListener(l,o?z$1:j$1,o):n.removeEventListener(l,o?z$1:j$1,o);else if("dangerouslySetInnerHTML"!==l){if(t)l=l.replace(/xlink(H|:h)/,"h").replace(/sName$/,"s");else if("width"!==l&&"height"!==l&&"href"!==l&&"list"!==l&&"form"!==l&&"tabIndex"!==l&&"download"!==l&&"rowSpan"!==l&&"colSpan"!==l&&l in n)try{n[l]=null==u?"":u;break n}catch(n){}"function"==typeof u||(null==u||!1===u&&"-"!==l[4]?n.removeAttribute(l):n.setAttribute(l,u));}}function j$1(n){return this.l[n.type+!1](l$1.event?l$1.event(n):n)}function z$1(n){return this.l[n.type+!0](l$1.event?l$1.event(n):n)}function L(n,u,i,t,o,r,f,e,c){var s,a,p,y,d,_,g,m,w,x,C,S,$,A,H,I=u.type;if(void 0!==u.constructor)return null;null!=i.__h&&(c=i.__h,e=u.__e=i.__e,u.__h=null,r=[e]),(s=l$1.__b)&&s(u);try{n:if("function"==typeof I){if(m=u.props,w=(s=I.contextType)&&t[s.__c],x=s?w?w.props.value:s.__:t,i.__c?g=(a=u.__c=i.__c).__=a.__E:("prototype"in I&&I.prototype.render?u.__c=a=new I(m,x):(u.__c=a=new b$1(m,x),a.constructor=I,a.render=B$1),w&&w.sub(a),a.props=m,a.state||(a.state={}),a.context=x,a.__n=t,p=a.__d=!0,a.__h=[],a._sb=[]),null==a.__s&&(a.__s=a.state),null!=I.getDerivedStateFromProps&&(a.__s==a.state&&(a.__s=h$1({},a.__s)),h$1(a.__s,I.getDerivedStateFromProps(m,a.__s))),y=a.props,d=a.state,a.__v=u,p)null==I.getDerivedStateFromProps&&null!=a.componentWillMount&&a.componentWillMount(),null!=a.componentDidMount&&a.__h.push(a.componentDidMount);else {if(null==I.getDerivedStateFromProps&&m!==y&&null!=a.componentWillReceiveProps&&a.componentWillReceiveProps(m,x),!a.__e&&null!=a.shouldComponentUpdate&&!1===a.shouldComponentUpdate(m,a.__s,x)||u.__v===i.__v){for(u.__v!==i.__v&&(a.props=m,a.state=a.__s,a.__d=!1),a.__e=!1,u.__e=i.__e,u.__k=i.__k,u.__k.forEach(function(n){n&&(n.__=u);}),C=0;C<a._sb.length;C++)a.__h.push(a._sb[C]);a._sb=[],a.__h.length&&f.push(a);break n}null!=a.componentWillUpdate&&a.componentWillUpdate(m,a.__s,x),null!=a.componentDidUpdate&&a.__h.push(function(){a.componentDidUpdate(y,d,_);});}if(a.context=x,a.props=m,a.__P=n,S=l$1.__r,$=0,"prototype"in I&&I.prototype.render){for(a.state=a.__s,a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),A=0;A<a._sb.length;A++)a.__h.push(a._sb[A]);a._sb=[];}else do{a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),a.state=a.__s;}while(a.__d&&++$<25);a.state=a.__s,null!=a.getChildContext&&(t=h$1(h$1({},t),a.getChildContext())),p||null==a.getSnapshotBeforeUpdate||(_=a.getSnapshotBeforeUpdate(y,d)),P(n,v$1(H=null!=s&&s.type===k$1&&null==s.key?s.props.children:s)?H:[H],u,i,t,o,r,f,e,c),a.base=u.__e,u.__h=null,a.__h.length&&f.push(a),g&&(a.__E=a.__=null),a.__e=!1;}else null==r&&u.__v===i.__v?(u.__k=i.__k,u.__e=i.__e):u.__e=N(i.__e,u,i,t,o,r,f,c);(s=l$1.diffed)&&s(u);}catch(n){u.__v=null,(c||null!=r)&&(u.__e=e,u.__h=!!c,r[r.indexOf(e)]=null),l$1.__e(n,u,i);}}function M(n,u){l$1.__c&&l$1.__c(u,n),n.some(function(u){try{n=u.__h,u.__h=[],n.some(function(n){n.call(u);});}catch(n){l$1.__e(n,u.__v);}});}function N(l,u,i,t,o,r,f,e){var s,a,h,y=i.props,d=u.props,_=u.type,k=0;if("svg"===_&&(o=!0),null!=r)for(;k<r.length;k++)if((s=r[k])&&"setAttribute"in s==!!_&&(_?s.localName===_:3===s.nodeType)){l=s,r[k]=null;break}if(null==l){if(null===_)return document.createTextNode(d);l=o?document.createElementNS("http://www.w3.org/2000/svg",_):document.createElement(_,d.is&&d),r=null,e=!1;}if(null===_)y===d||e&&l.data===d||(l.data=d);else {if(r=r&&n.call(l.childNodes),a=(y=i.props||c$1).dangerouslySetInnerHTML,h=d.dangerouslySetInnerHTML,!e){if(null!=r)for(y={},k=0;k<l.attributes.length;k++)y[l.attributes[k].name]=l.attributes[k].value;(h||a)&&(h&&(a&&h.__html==a.__html||h.__html===l.innerHTML)||(l.innerHTML=h&&h.__html||""));}if(H(l,d,y,o,e),h)u.__k=[];else if(P(l,v$1(k=u.props.children)?k:[k],u,i,t,o&&"foreignObject"!==_,r,f,r?r[0]:i.__k&&g$1(i,0),e),null!=r)for(k=r.length;k--;)null!=r[k]&&p$1(r[k]);e||("value"in d&&void 0!==(k=d.value)&&(k!==l.value||"progress"===_&&!k||"option"===_&&k!==y.value)&&T$1(l,"value",k,y.value,!1),"checked"in d&&void 0!==(k=d.checked)&&k!==l.checked&&T$1(l,"checked",k,y.checked,!1));}return l}function O(n,u,i){try{"function"==typeof n?n(u):n.current=u;}catch(n){l$1.__e(n,i);}}function q$1(n,u,i){var t,o;if(l$1.unmount&&l$1.unmount(n),(t=n.ref)&&(t.current&&t.current!==n.__e||O(t,null,u)),null!=(t=n.__c)){if(t.componentWillUnmount)try{t.componentWillUnmount();}catch(n){l$1.__e(n,u);}t.base=t.__P=null,n.__c=void 0;}if(t=n.__k)for(o=0;o<t.length;o++)t[o]&&q$1(t[o],u,i||"function"!=typeof n.type);i||null==n.__e||p$1(n.__e),n.__=n.__e=n.__d=void 0;}function B$1(n,l,u){return this.constructor(n,u)}function D(u,i,t){var o,r,f;l$1.__&&l$1.__(u,i),r=(o="function"==typeof t)?null:t&&t.__k||i.__k,f=[],L(i,u=(!o&&t||i).__k=y$1(k$1,null,[u]),r||c$1,c$1,void 0!==i.ownerSVGElement,!o&&t?[t]:r?null:i.firstChild?n.call(i.childNodes):null,f,!o&&t?t:r?r.__e:i.firstChild,o),M(f,u);}function G(n,l){var u={__c:l="__cC"+e$1++,__:n,Consumer:function(n,l){return n.children(l)},Provider:function(n){var u,i;return this.getChildContext||(u=[],(i={})[l]=this,this.getChildContext=function(){return i},this.shouldComponentUpdate=function(n){this.props.value!==n.value&&u.some(function(n){n.__e=!0,w$1(n);});},this.sub=function(n){u.push(n);var l=n.componentWillUnmount;n.componentWillUnmount=function(){u.splice(u.indexOf(n),1),l&&l.call(n);};}),n.children}};return u.Provider.__=u.Consumer.contextType=u}n=s$1.slice,l$1={__e:function(n,l,u,i){for(var t,o,r;l=l.__;)if((t=l.__c)&&!t.__)try{if((o=t.constructor)&&null!=o.getDerivedStateFromError&&(t.setState(o.getDerivedStateFromError(n)),r=t.__d),null!=t.componentDidCatch&&(t.componentDidCatch(n,i||{}),r=t.__d),r)return t.__E=t}catch(l){n=l;}throw n}},u$1=0,b$1.prototype.setState=function(n,l){var u;u=null!=this.__s&&this.__s!==this.state?this.__s:this.__s=h$1({},this.state),"function"==typeof n&&(n=n(h$1({},u),this.props)),n&&h$1(u,n),null!=n&&this.__v&&(l&&this._sb.push(l),w$1(this));},b$1.prototype.forceUpdate=function(n){this.__v&&(this.__e=!0,n&&this.__h.push(n),w$1(this));},b$1.prototype.render=k$1,t$1=[],r$1="function"==typeof Promise?Promise.prototype.then.bind(Promise.resolve()):setTimeout,f$1=function(n,l){return n.__v.__b-l.__v.__b},x.__r=0,e$1=0;
+
+  var _$1=0;function o$1(o,e,n,t,f,l){var s,u,a={};for(u in e)"ref"==u?s=e[u]:a[u]=e[u];var i={type:o,props:a,key:n,ref:s,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:--_$1,__source:f,__self:l};if("function"==typeof o&&(s=o.defaultProps))for(u in s)void 0===a[u]&&(a[u]=s[u]);return l$1.vnode&&l$1.vnode(i),i}
+
+  function count$1(node) {
+    var sum = 0,
+        children = node.children,
+        i = children && children.length;
+    if (!i) sum = 1;
+    else while (--i >= 0) sum += children[i].value;
+    node.value = sum;
+  }
+
+  function node_count() {
+    return this.eachAfter(count$1);
+  }
+
+  function node_each(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_eachBefore(callback, that) {
+    var node = this, nodes = [node], children, i, index = -1;
+    while (node = nodes.pop()) {
+      callback.call(that, node, ++index, this);
+      if (children = node.children) {
+        for (i = children.length - 1; i >= 0; --i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    return this;
+  }
+
+  function node_eachAfter(callback, that) {
+    var node = this, nodes = [node], next = [], children, i, n, index = -1;
+    while (node = nodes.pop()) {
+      next.push(node);
+      if (children = node.children) {
+        for (i = 0, n = children.length; i < n; ++i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    while (node = next.pop()) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_find(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      if (callback.call(that, node, ++index, this)) {
+        return node;
+      }
+    }
+  }
+
+  function node_sum(value) {
+    return this.eachAfter(function(node) {
+      var sum = +value(node.data) || 0,
+          children = node.children,
+          i = children && children.length;
+      while (--i >= 0) sum += children[i].value;
+      node.value = sum;
+    });
+  }
+
+  function node_sort(compare) {
+    return this.eachBefore(function(node) {
+      if (node.children) {
+        node.children.sort(compare);
+      }
+    });
+  }
+
+  function node_path(end) {
+    var start = this,
+        ancestor = leastCommonAncestor(start, end),
+        nodes = [start];
+    while (start !== ancestor) {
+      start = start.parent;
+      nodes.push(start);
+    }
+    var k = nodes.length;
+    while (end !== ancestor) {
+      nodes.splice(k, 0, end);
+      end = end.parent;
+    }
+    return nodes;
+  }
+
+  function leastCommonAncestor(a, b) {
+    if (a === b) return a;
+    var aNodes = a.ancestors(),
+        bNodes = b.ancestors(),
+        c = null;
+    a = aNodes.pop();
+    b = bNodes.pop();
+    while (a === b) {
+      c = a;
+      a = aNodes.pop();
+      b = bNodes.pop();
+    }
+    return c;
+  }
+
+  function node_ancestors() {
+    var node = this, nodes = [node];
+    while (node = node.parent) {
+      nodes.push(node);
+    }
+    return nodes;
+  }
+
+  function node_descendants() {
+    return Array.from(this);
+  }
+
+  function node_leaves() {
+    var leaves = [];
+    this.eachBefore(function(node) {
+      if (!node.children) {
+        leaves.push(node);
+      }
+    });
+    return leaves;
+  }
+
+  function node_links() {
+    var root = this, links = [];
+    root.each(function(node) {
+      if (node !== root) { // Don’t include the root’s parent, if any.
+        links.push({source: node.parent, target: node});
+      }
+    });
+    return links;
+  }
+
+  function* node_iterator() {
+    var node = this, current, next = [node], children, i, n;
+    do {
+      current = next.reverse(), next = [];
+      while (node = current.pop()) {
+        yield node;
+        if (children = node.children) {
+          for (i = 0, n = children.length; i < n; ++i) {
+            next.push(children[i]);
+          }
+        }
+      }
+    } while (next.length);
+  }
+
+  function hierarchy(data, children) {
+    if (data instanceof Map) {
+      data = [undefined, data];
+      if (children === undefined) children = mapChildren;
+    } else if (children === undefined) {
+      children = objectChildren;
+    }
+
+    var root = new Node$1(data),
+        node,
+        nodes = [root],
+        child,
+        childs,
+        i,
+        n;
+
+    while (node = nodes.pop()) {
+      if ((childs = children(node.data)) && (n = (childs = Array.from(childs)).length)) {
+        node.children = childs;
+        for (i = n - 1; i >= 0; --i) {
+          nodes.push(child = childs[i] = new Node$1(childs[i]));
+          child.parent = node;
+          child.depth = node.depth + 1;
+        }
+      }
+    }
+
+    return root.eachBefore(computeHeight);
+  }
+
+  function node_copy() {
+    return hierarchy(this).eachBefore(copyData);
+  }
+
+  function objectChildren(d) {
+    return d.children;
+  }
+
+  function mapChildren(d) {
+    return Array.isArray(d) ? d[1] : null;
+  }
+
+  function copyData(node) {
+    if (node.data.value !== undefined) node.value = node.data.value;
+    node.data = node.data.data;
+  }
+
+  function computeHeight(node) {
+    var height = 0;
+    do node.height = height;
+    while ((node = node.parent) && (node.height < ++height));
+  }
+
+  function Node$1(data) {
+    this.data = data;
+    this.depth =
+    this.height = 0;
+    this.parent = null;
+  }
+
+  Node$1.prototype = hierarchy.prototype = {
+    constructor: Node$1,
+    count: node_count,
+    each: node_each,
+    eachAfter: node_eachAfter,
+    eachBefore: node_eachBefore,
+    find: node_find,
+    sum: node_sum,
+    sort: node_sort,
+    path: node_path,
+    ancestors: node_ancestors,
+    descendants: node_descendants,
+    leaves: node_leaves,
+    links: node_links,
+    copy: node_copy,
+    [Symbol.iterator]: node_iterator
+  };
+
+  function required(f) {
+    if (typeof f !== "function") throw new Error;
+    return f;
+  }
+
+  function constantZero() {
+    return 0;
+  }
+
+  function constant$1(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function roundNode(node) {
+    node.x0 = Math.round(node.x0);
+    node.y0 = Math.round(node.y0);
+    node.x1 = Math.round(node.x1);
+    node.y1 = Math.round(node.y1);
+  }
+
+  function treemapDice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (x1 - x0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.y0 = y0, node.y1 = y1;
+      node.x0 = x0, node.x1 = x0 += node.value * k;
+    }
+  }
+
+  function treemapSlice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (y1 - y0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.x0 = x0, node.x1 = x1;
+      node.y0 = y0, node.y1 = y0 += node.value * k;
+    }
+  }
+
+  var phi = (1 + Math.sqrt(5)) / 2;
+
+  function squarifyRatio(ratio, parent, x0, y0, x1, y1) {
+    var rows = [],
+        nodes = parent.children,
+        row,
+        nodeValue,
+        i0 = 0,
+        i1 = 0,
+        n = nodes.length,
+        dx, dy,
+        value = parent.value,
+        sumValue,
+        minValue,
+        maxValue,
+        newRatio,
+        minRatio,
+        alpha,
+        beta;
+
+    while (i0 < n) {
+      dx = x1 - x0, dy = y1 - y0;
+
+      // Find the next non-empty node.
+      do sumValue = nodes[i1++].value; while (!sumValue && i1 < n);
+      minValue = maxValue = sumValue;
+      alpha = Math.max(dy / dx, dx / dy) / (value * ratio);
+      beta = sumValue * sumValue * alpha;
+      minRatio = Math.max(maxValue / beta, beta / minValue);
+
+      // Keep adding nodes while the aspect ratio maintains or improves.
+      for (; i1 < n; ++i1) {
+        sumValue += nodeValue = nodes[i1].value;
+        if (nodeValue < minValue) minValue = nodeValue;
+        if (nodeValue > maxValue) maxValue = nodeValue;
+        beta = sumValue * sumValue * alpha;
+        newRatio = Math.max(maxValue / beta, beta / minValue);
+        if (newRatio > minRatio) { sumValue -= nodeValue; break; }
+        minRatio = newRatio;
+      }
+
+      // Position and record the row orientation.
+      rows.push(row = {value: sumValue, dice: dx < dy, children: nodes.slice(i0, i1)});
+      if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += dy * sumValue / value : y1);
+      else treemapSlice(row, x0, y0, value ? x0 += dx * sumValue / value : x1, y1);
+      value -= sumValue, i0 = i1;
+    }
+
+    return rows;
+  }
+
+  var squarify = (function custom(ratio) {
+
+    function squarify(parent, x0, y0, x1, y1) {
+      squarifyRatio(ratio, parent, x0, y0, x1, y1);
+    }
+
+    squarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return squarify;
+  })(phi);
+
+  function treemap() {
+    var tile = squarify,
+        round = false,
+        dx = 1,
+        dy = 1,
+        paddingStack = [0],
+        paddingInner = constantZero,
+        paddingTop = constantZero,
+        paddingRight = constantZero,
+        paddingBottom = constantZero,
+        paddingLeft = constantZero;
+
+    function treemap(root) {
+      root.x0 =
+      root.y0 = 0;
+      root.x1 = dx;
+      root.y1 = dy;
+      root.eachBefore(positionNode);
+      paddingStack = [0];
+      if (round) root.eachBefore(roundNode);
+      return root;
+    }
+
+    function positionNode(node) {
+      var p = paddingStack[node.depth],
+          x0 = node.x0 + p,
+          y0 = node.y0 + p,
+          x1 = node.x1 - p,
+          y1 = node.y1 - p;
+      if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+      if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+      node.x0 = x0;
+      node.y0 = y0;
+      node.x1 = x1;
+      node.y1 = y1;
+      if (node.children) {
+        p = paddingStack[node.depth + 1] = paddingInner(node) / 2;
+        x0 += paddingLeft(node) - p;
+        y0 += paddingTop(node) - p;
+        x1 -= paddingRight(node) - p;
+        y1 -= paddingBottom(node) - p;
+        if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+        if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+        tile(node, x0, y0, x1, y1);
+      }
+    }
+
+    treemap.round = function(x) {
+      return arguments.length ? (round = !!x, treemap) : round;
+    };
+
+    treemap.size = function(x) {
+      return arguments.length ? (dx = +x[0], dy = +x[1], treemap) : [dx, dy];
+    };
+
+    treemap.tile = function(x) {
+      return arguments.length ? (tile = required(x), treemap) : tile;
+    };
+
+    treemap.padding = function(x) {
+      return arguments.length ? treemap.paddingInner(x).paddingOuter(x) : treemap.paddingInner();
+    };
+
+    treemap.paddingInner = function(x) {
+      return arguments.length ? (paddingInner = typeof x === "function" ? x : constant$1(+x), treemap) : paddingInner;
+    };
+
+    treemap.paddingOuter = function(x) {
+      return arguments.length ? treemap.paddingTop(x).paddingRight(x).paddingBottom(x).paddingLeft(x) : treemap.paddingTop();
+    };
+
+    treemap.paddingTop = function(x) {
+      return arguments.length ? (paddingTop = typeof x === "function" ? x : constant$1(+x), treemap) : paddingTop;
+    };
+
+    treemap.paddingRight = function(x) {
+      return arguments.length ? (paddingRight = typeof x === "function" ? x : constant$1(+x), treemap) : paddingRight;
+    };
+
+    treemap.paddingBottom = function(x) {
+      return arguments.length ? (paddingBottom = typeof x === "function" ? x : constant$1(+x), treemap) : paddingBottom;
+    };
+
+    treemap.paddingLeft = function(x) {
+      return arguments.length ? (paddingLeft = typeof x === "function" ? x : constant$1(+x), treemap) : paddingLeft;
+    };
+
+    return treemap;
+  }
+
+  var treemapResquarify = (function custom(ratio) {
+
+    function resquarify(parent, x0, y0, x1, y1) {
+      if ((rows = parent._squarify) && (rows.ratio === ratio)) {
+        var rows,
+            row,
+            nodes,
+            i,
+            j = -1,
+            n,
+            m = rows.length,
+            value = parent.value;
+
+        while (++j < m) {
+          row = rows[j], nodes = row.children;
+          for (i = row.value = 0, n = nodes.length; i < n; ++i) row.value += nodes[i].value;
+          if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += (y1 - y0) * row.value / value : y1);
+          else treemapSlice(row, x0, y0, value ? x0 += (x1 - x0) * row.value / value : x1, y1);
+          value -= row.value;
+        }
+      } else {
+        parent._squarify = rows = squarifyRatio(ratio, parent, x0, y0, x1, y1);
+        rows.ratio = ratio;
+      }
+    }
+
+    resquarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return resquarify;
+  })(phi);
+
+  const isModuleTree = (mod) => "children" in mod;
+
+  let count = 0;
+  class Id {
+      constructor(id) {
+          this._id = id;
+          const url = new URL(window.location.href);
+          url.hash = id;
+          this._href = url.toString();
+      }
+      get id() {
+          return this._id;
+      }
+      get href() {
+          return this._href;
+      }
+      toString() {
+          return `url(${this.href})`;
+      }
+  }
+  function generateUniqueId(name) {
+      count += 1;
+      const id = ["O", name, count].filter(Boolean).join("-");
+      return new Id(id);
+  }
+
+  const LABELS = {
+      renderedLength: "Rendered",
+      gzipLength: "Gzip",
+      brotliLength: "Brotli",
+  };
+  const getAvailableSizeOptions = (options) => {
+      const availableSizeProperties = ["renderedLength"];
+      if (options.gzip) {
+          availableSizeProperties.push("gzipLength");
+      }
+      if (options.brotli) {
+          availableSizeProperties.push("brotliLength");
+      }
+      return availableSizeProperties;
+  };
+
+  var t,r,u,i,o=0,f=[],c=[],e=l$1.__b,a=l$1.__r,v=l$1.diffed,l=l$1.__c,m=l$1.unmount;function d(t,u){l$1.__h&&l$1.__h(r,t,o||u),o=0;var i=r.__H||(r.__H={__:[],__h:[]});return t>=i.__.length&&i.__.push({__V:c}),i.__[t]}function h(n){return o=1,s(B,n)}function s(n,u,i){var o=d(t++,2);if(o.t=n,!o.__c&&(o.__=[i?i(u):B(void 0,u),function(n){var t=o.__N?o.__N[0]:o.__[0],r=o.t(t,n);t!==r&&(o.__N=[r,o.__[1]],o.__c.setState({}));}],o.__c=r,!r.u)){var f=function(n,t,r){if(!o.__c.__H)return !0;var u=o.__c.__H.__.filter(function(n){return n.__c});if(u.every(function(n){return !n.__N}))return !c||c.call(this,n,t,r);var i=!1;return u.forEach(function(n){if(n.__N){var t=n.__[0];n.__=n.__N,n.__N=void 0,t!==n.__[0]&&(i=!0);}}),!(!i&&o.__c.props===n)&&(!c||c.call(this,n,t,r))};r.u=!0;var c=r.shouldComponentUpdate,e=r.componentWillUpdate;r.componentWillUpdate=function(n,t,r){if(this.__e){var u=c;c=void 0,f(n,t,r),c=u;}e&&e.call(this,n,t,r);},r.shouldComponentUpdate=f;}return o.__N||o.__}function p(u,i){var o=d(t++,3);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__H.__h.push(o));}function y(u,i){var o=d(t++,4);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__h.push(o));}function _(n){return o=5,F(function(){return {current:n}},[])}function F(n,r){var u=d(t++,7);return z(u.__H,r)?(u.__V=n(),u.i=r,u.__h=n,u.__V):u.__}function T(n,t){return o=8,F(function(){return n},t)}function q(n){var u=r.context[n.__c],i=d(t++,9);return i.c=n,u?(null==i.__&&(i.__=!0,u.sub(r)),u.props.value):n.__}function b(){for(var t;t=f.shift();)if(t.__P&&t.__H)try{t.__H.__h.forEach(k),t.__H.__h.forEach(w),t.__H.__h=[];}catch(r){t.__H.__h=[],l$1.__e(r,t.__v);}}l$1.__b=function(n){r=null,e&&e(n);},l$1.__r=function(n){a&&a(n),t=0;var i=(r=n.__c).__H;i&&(u===r?(i.__h=[],r.__h=[],i.__.forEach(function(n){n.__N&&(n.__=n.__N),n.__V=c,n.__N=n.i=void 0;})):(i.__h.forEach(k),i.__h.forEach(w),i.__h=[],t=0)),u=r;},l$1.diffed=function(t){v&&v(t);var o=t.__c;o&&o.__H&&(o.__H.__h.length&&(1!==f.push(o)&&i===l$1.requestAnimationFrame||((i=l$1.requestAnimationFrame)||j)(b)),o.__H.__.forEach(function(n){n.i&&(n.__H=n.i),n.__V!==c&&(n.__=n.__V),n.i=void 0,n.__V=c;})),u=r=null;},l$1.__c=function(t,r){r.some(function(t){try{t.__h.forEach(k),t.__h=t.__h.filter(function(n){return !n.__||w(n)});}catch(u){r.some(function(n){n.__h&&(n.__h=[]);}),r=[],l$1.__e(u,t.__v);}}),l&&l(t,r);},l$1.unmount=function(t){m&&m(t);var r,u=t.__c;u&&u.__H&&(u.__H.__.forEach(function(n){try{k(n);}catch(n){r=n;}}),u.__H=void 0,r&&l$1.__e(r,u.__v));};var g="function"==typeof requestAnimationFrame;function j(n){var t,r=function(){clearTimeout(u),g&&cancelAnimationFrame(t),setTimeout(n);},u=setTimeout(r,100);g&&(t=requestAnimationFrame(r));}function k(n){var t=r,u=n.__c;"function"==typeof u&&(n.__c=void 0,u()),r=t;}function w(n){var t=r;n.__c=n.__(),r=t;}function z(n,t){return !n||n.length!==t.length||t.some(function(t,r){return t!==n[r]})}function B(n,t){return "function"==typeof t?t(n):t}
+
+  const PLACEHOLDER = "bundle-*:**/file/**,**/file**, bundle-*:";
+  const SideBar = ({ availableSizeProperties, sizeProperty, setSizeProperty, onExcludeChange, onIncludeChange, }) => {
+      const [includeValue, setIncludeValue] = h("");
+      const [excludeValue, setExcludeValue] = h("");
+      const handleSizePropertyChange = (sizeProp) => () => {
+          if (sizeProp !== sizeProperty) {
+              setSizeProperty(sizeProp);
+          }
+      };
+      const handleIncludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setIncludeValue(value);
+          onIncludeChange(value);
+      };
+      const handleExcludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setExcludeValue(value);
+          onExcludeChange(value);
+      };
+      return (o$1("aside", { className: "sidebar", children: [o$1("div", { className: "size-selectors", children: availableSizeProperties.length > 1 &&
+                      availableSizeProperties.map((sizeProp) => {
+                          const id = `selector-${sizeProp}`;
+                          return (o$1("div", { className: "size-selector", children: [o$1("input", { type: "radio", id: id, checked: sizeProp === sizeProperty, onChange: handleSizePropertyChange(sizeProp) }), o$1("label", { htmlFor: id, children: LABELS[sizeProp] })] }, sizeProp));
+                      }) }), o$1("div", { className: "module-filters", children: [o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-exclude", children: "Exclude" }), o$1("input", { type: "text", id: "module-filter-exclude", value: excludeValue, onInput: handleExcludeChange, placeholder: PLACEHOLDER })] }), o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-include", children: "Include" }), o$1("input", { type: "text", id: "module-filter-include", value: includeValue, onInput: handleIncludeChange, placeholder: PLACEHOLDER })] })] })] }));
+  };
+
+  function getDefaultExportFromCjs (x) {
+  	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+  }
+
+  var utils$3 = {};
+
+  const WIN_SLASH = '\\\\/';
+  const WIN_NO_SLASH = `[^${WIN_SLASH}]`;
+
+  /**
+   * Posix glob regex
+   */
+
+  const DOT_LITERAL = '\\.';
+  const PLUS_LITERAL = '\\+';
+  const QMARK_LITERAL = '\\?';
+  const SLASH_LITERAL = '\\/';
+  const ONE_CHAR = '(?=.)';
+  const QMARK = '[^/]';
+  const END_ANCHOR = `(?:${SLASH_LITERAL}|$)`;
+  const START_ANCHOR = `(?:^|${SLASH_LITERAL})`;
+  const DOTS_SLASH = `${DOT_LITERAL}{1,2}${END_ANCHOR}`;
+  const NO_DOT = `(?!${DOT_LITERAL})`;
+  const NO_DOTS = `(?!${START_ANCHOR}${DOTS_SLASH})`;
+  const NO_DOT_SLASH = `(?!${DOT_LITERAL}{0,1}${END_ANCHOR})`;
+  const NO_DOTS_SLASH = `(?!${DOTS_SLASH})`;
+  const QMARK_NO_DOT = `[^.${SLASH_LITERAL}]`;
+  const STAR = `${QMARK}*?`;
+  const SEP = '/';
+
+  const POSIX_CHARS = {
+    DOT_LITERAL,
+    PLUS_LITERAL,
+    QMARK_LITERAL,
+    SLASH_LITERAL,
+    ONE_CHAR,
+    QMARK,
+    END_ANCHOR,
+    DOTS_SLASH,
+    NO_DOT,
+    NO_DOTS,
+    NO_DOT_SLASH,
+    NO_DOTS_SLASH,
+    QMARK_NO_DOT,
+    STAR,
+    START_ANCHOR,
+    SEP
+  };
+
+  /**
+   * Windows glob regex
+   */
+
+  const WINDOWS_CHARS = {
+    ...POSIX_CHARS,
+
+    SLASH_LITERAL: `[${WIN_SLASH}]`,
+    QMARK: WIN_NO_SLASH,
+    STAR: `${WIN_NO_SLASH}*?`,
+    DOTS_SLASH: `${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$)`,
+    NO_DOT: `(?!${DOT_LITERAL})`,
+    NO_DOTS: `(?!(?:^|[${WIN_SLASH}])${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    NO_DOT_SLASH: `(?!${DOT_LITERAL}{0,1}(?:[${WIN_SLASH}]|$))`,
+    NO_DOTS_SLASH: `(?!${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    QMARK_NO_DOT: `[^.${WIN_SLASH}]`,
+    START_ANCHOR: `(?:^|[${WIN_SLASH}])`,
+    END_ANCHOR: `(?:[${WIN_SLASH}]|$)`,
+    SEP: '\\'
+  };
+
+  /**
+   * POSIX Bracket Regex
+   */
+
+  const POSIX_REGEX_SOURCE$1 = {
+    alnum: 'a-zA-Z0-9',
+    alpha: 'a-zA-Z',
+    ascii: '\\x00-\\x7F',
+    blank: ' \\t',
+    cntrl: '\\x00-\\x1F\\x7F',
+    digit: '0-9',
+    graph: '\\x21-\\x7E',
+    lower: 'a-z',
+    print: '\\x20-\\x7E ',
+    punct: '\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~',
+    space: ' \\t\\r\\n\\v\\f',
+    upper: 'A-Z',
+    word: 'A-Za-z0-9_',
+    xdigit: 'A-Fa-f0-9'
+  };
+
+  var constants$3 = {
+    MAX_LENGTH: 1024 * 64,
+    POSIX_REGEX_SOURCE: POSIX_REGEX_SOURCE$1,
+
+    // regular expressions
+    REGEX_BACKSLASH: /\\(?![*+?^${}(|)[\]])/g,
+    REGEX_NON_SPECIAL_CHARS: /^[^@![\].,$*+?^{}()|\\/]+/,
+    REGEX_SPECIAL_CHARS: /[-*+?.^${}(|)[\]]/,
+    REGEX_SPECIAL_CHARS_BACKREF: /(\\?)((\W)(\3*))/g,
+    REGEX_SPECIAL_CHARS_GLOBAL: /([-*+?.^${}(|)[\]])/g,
+    REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
+
+    // Replace globs with equivalent patterns to reduce parsing time.
+    REPLACEMENTS: {
+      '***': '*',
+      '**/**': '**',
+      '**/**/**': '**'
+    },
+
+    // Digits
+    CHAR_0: 48, /* 0 */
+    CHAR_9: 57, /* 9 */
+
+    // Alphabet chars.
+    CHAR_UPPERCASE_A: 65, /* A */
+    CHAR_LOWERCASE_A: 97, /* a */
+    CHAR_UPPERCASE_Z: 90, /* Z */
+    CHAR_LOWERCASE_Z: 122, /* z */
+
+    CHAR_LEFT_PARENTHESES: 40, /* ( */
+    CHAR_RIGHT_PARENTHESES: 41, /* ) */
+
+    CHAR_ASTERISK: 42, /* * */
+
+    // Non-alphabetic chars.
+    CHAR_AMPERSAND: 38, /* & */
+    CHAR_AT: 64, /* @ */
+    CHAR_BACKWARD_SLASH: 92, /* \ */
+    CHAR_CARRIAGE_RETURN: 13, /* \r */
+    CHAR_CIRCUMFLEX_ACCENT: 94, /* ^ */
+    CHAR_COLON: 58, /* : */
+    CHAR_COMMA: 44, /* , */
+    CHAR_DOT: 46, /* . */
+    CHAR_DOUBLE_QUOTE: 34, /* " */
+    CHAR_EQUAL: 61, /* = */
+    CHAR_EXCLAMATION_MARK: 33, /* ! */
+    CHAR_FORM_FEED: 12, /* \f */
+    CHAR_FORWARD_SLASH: 47, /* / */
+    CHAR_GRAVE_ACCENT: 96, /* ` */
+    CHAR_HASH: 35, /* # */
+    CHAR_HYPHEN_MINUS: 45, /* - */
+    CHAR_LEFT_ANGLE_BRACKET: 60, /* < */
+    CHAR_LEFT_CURLY_BRACE: 123, /* { */
+    CHAR_LEFT_SQUARE_BRACKET: 91, /* [ */
+    CHAR_LINE_FEED: 10, /* \n */
+    CHAR_NO_BREAK_SPACE: 160, /* \u00A0 */
+    CHAR_PERCENT: 37, /* % */
+    CHAR_PLUS: 43, /* + */
+    CHAR_QUESTION_MARK: 63, /* ? */
+    CHAR_RIGHT_ANGLE_BRACKET: 62, /* > */
+    CHAR_RIGHT_CURLY_BRACE: 125, /* } */
+    CHAR_RIGHT_SQUARE_BRACKET: 93, /* ] */
+    CHAR_SEMICOLON: 59, /* ; */
+    CHAR_SINGLE_QUOTE: 39, /* ' */
+    CHAR_SPACE: 32, /*   */
+    CHAR_TAB: 9, /* \t */
+    CHAR_UNDERSCORE: 95, /* _ */
+    CHAR_VERTICAL_LINE: 124, /* | */
+    CHAR_ZERO_WIDTH_NOBREAK_SPACE: 65279, /* \uFEFF */
+
+    /**
+     * Create EXTGLOB_CHARS
+     */
+
+    extglobChars(chars) {
+      return {
+        '!': { type: 'negate', open: '(?:(?!(?:', close: `))${chars.STAR})` },
+        '?': { type: 'qmark', open: '(?:', close: ')?' },
+        '+': { type: 'plus', open: '(?:', close: ')+' },
+        '*': { type: 'star', open: '(?:', close: ')*' },
+        '@': { type: 'at', open: '(?:', close: ')' }
+      };
+    },
+
+    /**
+     * Create GLOB_CHARS
+     */
+
+    globChars(win32) {
+      return win32 === true ? WINDOWS_CHARS : POSIX_CHARS;
+    }
+  };
+
+  (function (exports) {
+
+  	const {
+  	  REGEX_BACKSLASH,
+  	  REGEX_REMOVE_BACKSLASH,
+  	  REGEX_SPECIAL_CHARS,
+  	  REGEX_SPECIAL_CHARS_GLOBAL
+  	} = constants$3;
+
+  	exports.isObject = val => val !== null && typeof val === 'object' && !Array.isArray(val);
+  	exports.hasRegexChars = str => REGEX_SPECIAL_CHARS.test(str);
+  	exports.isRegexChar = str => str.length === 1 && exports.hasRegexChars(str);
+  	exports.escapeRegex = str => str.replace(REGEX_SPECIAL_CHARS_GLOBAL, '\\$1');
+  	exports.toPosixSlashes = str => str.replace(REGEX_BACKSLASH, '/');
+
+  	exports.removeBackslashes = str => {
+  	  return str.replace(REGEX_REMOVE_BACKSLASH, match => {
+  	    return match === '\\' ? '' : match;
+  	  });
+  	};
+
+  	exports.supportsLookbehinds = () => {
+  	  const segs = process.version.slice(1).split('.').map(Number);
+  	  if (segs.length === 3 && segs[0] >= 9 || (segs[0] === 8 && segs[1] >= 10)) {
+  	    return true;
+  	  }
+  	  return false;
+  	};
+
+  	exports.escapeLast = (input, char, lastIdx) => {
+  	  const idx = input.lastIndexOf(char, lastIdx);
+  	  if (idx === -1) return input;
+  	  if (input[idx - 1] === '\\') return exports.escapeLast(input, char, idx - 1);
+  	  return `${input.slice(0, idx)}\\${input.slice(idx)}`;
+  	};
+
+  	exports.removePrefix = (input, state = {}) => {
+  	  let output = input;
+  	  if (output.startsWith('./')) {
+  	    output = output.slice(2);
+  	    state.prefix = './';
+  	  }
+  	  return output;
+  	};
+
+  	exports.wrapOutput = (input, state = {}, options = {}) => {
+  	  const prepend = options.contains ? '' : '^';
+  	  const append = options.contains ? '' : '$';
+
+  	  let output = `${prepend}(?:${input})${append}`;
+  	  if (state.negated === true) {
+  	    output = `(?:^(?!${output}).*$)`;
+  	  }
+  	  return output;
+  	};
+
+  	exports.basename = (path, { windows } = {}) => {
+  	  if (windows) {
+  	    return path.replace(/[\\/]$/, '').replace(/.*[\\/]/, '');
+  	  } else {
+  	    return path.replace(/\/$/, '').replace(/.*\//, '');
+  	  }
+  	}; 
+  } (utils$3));
+
+  const utils$2 = utils$3;
+  const {
+    CHAR_ASTERISK,             /* * */
+    CHAR_AT,                   /* @ */
+    CHAR_BACKWARD_SLASH,       /* \ */
+    CHAR_COMMA,                /* , */
+    CHAR_DOT,                  /* . */
+    CHAR_EXCLAMATION_MARK,     /* ! */
+    CHAR_FORWARD_SLASH,        /* / */
+    CHAR_LEFT_CURLY_BRACE,     /* { */
+    CHAR_LEFT_PARENTHESES,     /* ( */
+    CHAR_LEFT_SQUARE_BRACKET,  /* [ */
+    CHAR_PLUS,                 /* + */
+    CHAR_QUESTION_MARK,        /* ? */
+    CHAR_RIGHT_CURLY_BRACE,    /* } */
+    CHAR_RIGHT_PARENTHESES,    /* ) */
+    CHAR_RIGHT_SQUARE_BRACKET  /* ] */
+  } = constants$3;
+
+  const isPathSeparator = code => {
+    return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+  };
+
+  const depth = token => {
+    if (token.isPrefix !== true) {
+      token.depth = token.isGlobstar ? Infinity : 1;
+    }
+  };
+
+  /**
+   * Quickly scans a glob pattern and returns an object with a handful of
+   * useful properties, like `isGlob`, `path` (the leading non-glob, if it exists),
+   * `glob` (the actual pattern), and `negated` (true if the path starts with `!`).
+   *
+   * ```js
+   * const pm = require('picomatch');
+   * console.log(pm.scan('foo/bar/*.js'));
+   * { isGlob: true, input: 'foo/bar/*.js', base: 'foo/bar', glob: '*.js' }
+   * ```
+   * @param {String} `str`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with tokens and regex source string.
+   * @api public
+   */
+
+  const scan$1 = (input, options) => {
+    const opts = options || {};
+
+    const length = input.length - 1;
+    const scanToEnd = opts.parts === true || opts.scanToEnd === true;
+    const slashes = [];
+    const tokens = [];
+    const parts = [];
+
+    let str = input;
+    let index = -1;
+    let start = 0;
+    let lastIndex = 0;
+    let isBrace = false;
+    let isBracket = false;
+    let isGlob = false;
+    let isExtglob = false;
+    let isGlobstar = false;
+    let braceEscaped = false;
+    let backslashes = false;
+    let negated = false;
+    let finished = false;
+    let braces = 0;
+    let prev;
+    let code;
+    let token = { value: '', depth: 0, isGlob: false };
+
+    const eos = () => index >= length;
+    const peek = () => str.charCodeAt(index + 1);
+    const advance = () => {
+      prev = code;
+      return str.charCodeAt(++index);
+    };
+
+    while (index < length) {
+      code = advance();
+      let next;
+
+      if (code === CHAR_BACKWARD_SLASH) {
+        backslashes = token.backslashes = true;
+        code = advance();
+
+        if (code === CHAR_LEFT_CURLY_BRACE) {
+          braceEscaped = true;
+        }
+        continue;
+      }
+
+      if (braceEscaped === true || code === CHAR_LEFT_CURLY_BRACE) {
+        braces++;
+
+        while (eos() !== true && (code = advance())) {
+          if (code === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (code === CHAR_LEFT_CURLY_BRACE) {
+            braces++;
+            continue;
+          }
+
+          if (braceEscaped !== true && code === CHAR_DOT && (code = advance()) === CHAR_DOT) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (braceEscaped !== true && code === CHAR_COMMA) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (code === CHAR_RIGHT_CURLY_BRACE) {
+            braces--;
+
+            if (braces === 0) {
+              braceEscaped = false;
+              isBrace = token.isBrace = true;
+              finished = true;
+              break;
+            }
+          }
+        }
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+
+      if (code === CHAR_FORWARD_SLASH) {
+        slashes.push(index);
+        tokens.push(token);
+        token = { value: '', depth: 0, isGlob: false };
+
+        if (finished === true) continue;
+        if (prev === CHAR_DOT && index === (start + 1)) {
+          start += 2;
+          continue;
+        }
+
+        lastIndex = index + 1;
+        continue;
+      }
+
+      if (opts.noext !== true) {
+        const isExtglobChar = code === CHAR_PLUS
+          || code === CHAR_AT
+          || code === CHAR_ASTERISK
+          || code === CHAR_QUESTION_MARK
+          || code === CHAR_EXCLAMATION_MARK;
+
+        if (isExtglobChar === true && peek() === CHAR_LEFT_PARENTHESES) {
+          isGlob = token.isGlob = true;
+          isExtglob = token.isExtglob = true;
+          finished = true;
+
+          if (scanToEnd === true) {
+            while (eos() !== true && (code = advance())) {
+              if (code === CHAR_BACKWARD_SLASH) {
+                backslashes = token.backslashes = true;
+                code = advance();
+                continue;
+              }
+
+              if (code === CHAR_RIGHT_PARENTHESES) {
+                isGlob = token.isGlob = true;
+                finished = true;
+                break;
+              }
+            }
+            continue;
+          }
+          break;
+        }
+      }
+
+      if (code === CHAR_ASTERISK) {
+        if (prev === CHAR_ASTERISK) isGlobstar = token.isGlobstar = true;
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_QUESTION_MARK) {
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_LEFT_SQUARE_BRACKET) {
+        while (eos() !== true && (next = advance())) {
+          if (next === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (next === CHAR_RIGHT_SQUARE_BRACKET) {
+            isBracket = token.isBracket = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+            break;
+          }
+        }
+      }
+
+      if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index === start) {
+        negated = token.negated = true;
+        start++;
+        continue;
+      }
+
+      if (opts.noparen !== true && code === CHAR_LEFT_PARENTHESES) {
+        isGlob = token.isGlob = true;
+
+        if (scanToEnd === true) {
+          while (eos() !== true && (code = advance())) {
+            if (code === CHAR_LEFT_PARENTHESES) {
+              backslashes = token.backslashes = true;
+              code = advance();
+              continue;
+            }
+
+            if (code === CHAR_RIGHT_PARENTHESES) {
+              finished = true;
+              break;
+            }
+          }
+          continue;
+        }
+        break;
+      }
+
+      if (isGlob === true) {
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+    }
+
+    if (opts.noext === true) {
+      isExtglob = false;
+      isGlob = false;
+    }
+
+    let base = str;
+    let prefix = '';
+    let glob = '';
+
+    if (start > 0) {
+      prefix = str.slice(0, start);
+      str = str.slice(start);
+      lastIndex -= start;
+    }
+
+    if (base && isGlob === true && lastIndex > 0) {
+      base = str.slice(0, lastIndex);
+      glob = str.slice(lastIndex);
+    } else if (isGlob === true) {
+      base = '';
+      glob = str;
+    } else {
+      base = str;
+    }
+
+    if (base && base !== '' && base !== '/' && base !== str) {
+      if (isPathSeparator(base.charCodeAt(base.length - 1))) {
+        base = base.slice(0, -1);
+      }
+    }
+
+    if (opts.unescape === true) {
+      if (glob) glob = utils$2.removeBackslashes(glob);
+
+      if (base && backslashes === true) {
+        base = utils$2.removeBackslashes(base);
+      }
+    }
+
+    const state = {
+      prefix,
+      input,
+      start,
+      base,
+      glob,
+      isBrace,
+      isBracket,
+      isGlob,
+      isExtglob,
+      isGlobstar,
+      negated
+    };
+
+    if (opts.tokens === true) {
+      state.maxDepth = 0;
+      if (!isPathSeparator(code)) {
+        tokens.push(token);
+      }
+      state.tokens = tokens;
+    }
+
+    if (opts.parts === true || opts.tokens === true) {
+      let prevIndex;
+
+      for (let idx = 0; idx < slashes.length; idx++) {
+        const n = prevIndex ? prevIndex + 1 : start;
+        const i = slashes[idx];
+        const value = input.slice(n, i);
+        if (opts.tokens) {
+          if (idx === 0 && start !== 0) {
+            tokens[idx].isPrefix = true;
+            tokens[idx].value = prefix;
+          } else {
+            tokens[idx].value = value;
+          }
+          depth(tokens[idx]);
+          state.maxDepth += tokens[idx].depth;
+        }
+        if (idx !== 0 || value !== '') {
+          parts.push(value);
+        }
+        prevIndex = i;
+      }
+
+      if (prevIndex && prevIndex + 1 < input.length) {
+        const value = input.slice(prevIndex + 1);
+        parts.push(value);
+
+        if (opts.tokens) {
+          tokens[tokens.length - 1].value = value;
+          depth(tokens[tokens.length - 1]);
+          state.maxDepth += tokens[tokens.length - 1].depth;
+        }
+      }
+
+      state.slashes = slashes;
+      state.parts = parts;
+    }
+
+    return state;
+  };
+
+  var scan_1 = scan$1;
+
+  const constants$2 = constants$3;
+  const utils$1 = utils$3;
+
+  /**
+   * Constants
+   */
+
+  const {
+    MAX_LENGTH,
+    POSIX_REGEX_SOURCE,
+    REGEX_NON_SPECIAL_CHARS,
+    REGEX_SPECIAL_CHARS_BACKREF,
+    REPLACEMENTS
+  } = constants$2;
+
+  /**
+   * Helpers
+   */
+
+  const expandRange = (args, options) => {
+    if (typeof options.expandRange === 'function') {
+      return options.expandRange(...args, options);
+    }
+
+    args.sort();
+    const value = `[${args.join('-')}]`;
+
+    try {
+      /* eslint-disable-next-line no-new */
+      new RegExp(value);
+    } catch (ex) {
+      return args.map(v => utils$1.escapeRegex(v)).join('..');
+    }
+
+    return value;
+  };
+
+  /**
+   * Create the message for a syntax error
+   */
+
+  const syntaxError = (type, char) => {
+    return `Missing ${type}: "${char}" - use "\\\\${char}" to match literal characters`;
+  };
+
+  /**
+   * Parse the given input string.
+   * @param {String} input
+   * @param {Object} options
+   * @return {Object}
+   */
+
+  const parse$2 = (input, options) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected a string');
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+
+    let len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    const bos = { type: 'bos', value: '', output: opts.prepend || '' };
+    const tokens = [bos];
+
+    const capture = opts.capture ? '' : '?:';
+
+    // create constants based on platform, for windows or posix
+    const PLATFORM_CHARS = constants$2.globChars(opts.windows);
+    const EXTGLOB_CHARS = constants$2.extglobChars(PLATFORM_CHARS);
+
+    const {
+      DOT_LITERAL,
+      PLUS_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOT_SLASH,
+      NO_DOTS_SLASH,
+      QMARK,
+      QMARK_NO_DOT,
+      STAR,
+      START_ANCHOR
+    } = PLATFORM_CHARS;
+
+    const globstar = (opts) => {
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const nodot = opts.dot ? '' : NO_DOT;
+    const qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
+    let star = opts.bash === true ? globstar(opts) : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    // minimatch options support
+    if (typeof opts.noext === 'boolean') {
+      opts.noextglob = opts.noext;
+    }
+
+    const state = {
+      input,
+      index: -1,
+      start: 0,
+      dot: opts.dot === true,
+      consumed: '',
+      output: '',
+      prefix: '',
+      backtrack: false,
+      negated: false,
+      brackets: 0,
+      braces: 0,
+      parens: 0,
+      quotes: 0,
+      globstar: false,
+      tokens
+    };
+
+    input = utils$1.removePrefix(input, state);
+    len = input.length;
+
+    const extglobs = [];
+    const braces = [];
+    const stack = [];
+    let prev = bos;
+    let value;
+
+    /**
+     * Tokenizing helpers
+     */
+
+    const eos = () => state.index === len - 1;
+    const peek = state.peek = (n = 1) => input[state.index + n];
+    const advance = state.advance = () => input[++state.index];
+    const remaining = () => input.slice(state.index + 1);
+    const consume = (value = '', num = 0) => {
+      state.consumed += value;
+      state.index += num;
+    };
+    const append = token => {
+      state.output += token.output != null ? token.output : token.value;
+      consume(token.value);
+    };
+
+    const negate = () => {
+      let count = 1;
+
+      while (peek() === '!' && (peek(2) !== '(' || peek(3) === '?')) {
+        advance();
+        state.start++;
+        count++;
+      }
+
+      if (count % 2 === 0) {
+        return false;
+      }
+
+      state.negated = true;
+      state.start++;
+      return true;
+    };
+
+    const increment = type => {
+      state[type]++;
+      stack.push(type);
+    };
+
+    const decrement = type => {
+      state[type]--;
+      stack.pop();
+    };
+
+    /**
+     * Push tokens onto the tokens array. This helper speeds up
+     * tokenizing by 1) helping us avoid backtracking as much as possible,
+     * and 2) helping us avoid creating extra tokens when consecutive
+     * characters are plain text. This improves performance and simplifies
+     * lookbehinds.
+     */
+
+    const push = tok => {
+      if (prev.type === 'globstar') {
+        const isBrace = state.braces > 0 && (tok.type === 'comma' || tok.type === 'brace');
+        const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.type === 'paren'));
+
+        if (tok.type !== 'slash' && tok.type !== 'paren' && !isBrace && !isExtglob) {
+          state.output = state.output.slice(0, -prev.output.length);
+          prev.type = 'star';
+          prev.value = '*';
+          prev.output = star;
+          state.output += prev.output;
+        }
+      }
+
+      if (extglobs.length && tok.type !== 'paren' && !EXTGLOB_CHARS[tok.value]) {
+        extglobs[extglobs.length - 1].inner += tok.value;
+      }
+
+      if (tok.value || tok.output) append(tok);
+      if (prev && prev.type === 'text' && tok.type === 'text') {
+        prev.value += tok.value;
+        prev.output = (prev.output || '') + tok.value;
+        return;
+      }
+
+      tok.prev = prev;
+      tokens.push(tok);
+      prev = tok;
+    };
+
+    const extglobOpen = (type, value) => {
+      const token = { ...EXTGLOB_CHARS[value], conditions: 1, inner: '' };
+
+      token.prev = prev;
+      token.parens = state.parens;
+      token.output = state.output;
+      const output = (opts.capture ? '(' : '') + token.open;
+
+      increment('parens');
+      push({ type, value, output: state.output ? '' : ONE_CHAR });
+      push({ type: 'paren', extglob: true, value: advance(), output });
+      extglobs.push(token);
+    };
+
+    const extglobClose = token => {
+      let output = token.close + (opts.capture ? ')' : '');
+
+      if (token.type === 'negate') {
+        let extglobStar = star;
+
+        if (token.inner && token.inner.length > 1 && token.inner.includes('/')) {
+          extglobStar = globstar(opts);
+        }
+
+        if (extglobStar !== star || eos() || /^\)+$/.test(remaining())) {
+          output = token.close = `)$))${extglobStar}`;
+        }
+
+        if (token.prev.type === 'bos' && eos()) {
+          state.negatedExtglob = true;
+        }
+      }
+
+      push({ type: 'paren', extglob: true, value, output });
+      decrement('parens');
+    };
+
+    /**
+     * Fast paths
+     */
+
+    if (opts.fastpaths !== false && !/(^[*!]|[/()[\]{}"])/.test(input)) {
+      let backslashes = false;
+
+      let output = input.replace(REGEX_SPECIAL_CHARS_BACKREF, (m, esc, chars, first, rest, index) => {
+        if (first === '\\') {
+          backslashes = true;
+          return m;
+        }
+
+        if (first === '?') {
+          if (esc) {
+            return esc + first + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          if (index === 0) {
+            return qmarkNoDot + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          return QMARK.repeat(chars.length);
+        }
+
+        if (first === '.') {
+          return DOT_LITERAL.repeat(chars.length);
+        }
+
+        if (first === '*') {
+          if (esc) {
+            return esc + first + (rest ? star : '');
+          }
+          return star;
+        }
+        return esc ? m : `\\${m}`;
+      });
+
+      if (backslashes === true) {
+        if (opts.unescape === true) {
+          output = output.replace(/\\/g, '');
+        } else {
+          output = output.replace(/\\+/g, m => {
+            return m.length % 2 === 0 ? '\\\\' : (m ? '\\' : '');
+          });
+        }
+      }
+
+      if (output === input && opts.contains === true) {
+        state.output = input;
+        return state;
+      }
+
+      state.output = utils$1.wrapOutput(output, state, options);
+      return state;
+    }
+
+    /**
+     * Tokenize input until we reach end-of-string
+     */
+
+    while (!eos()) {
+      value = advance();
+
+      if (value === '\u0000') {
+        continue;
+      }
+
+      /**
+       * Escaped characters
+       */
+
+      if (value === '\\') {
+        const next = peek();
+
+        if (next === '/' && opts.bash !== true) {
+          continue;
+        }
+
+        if (next === '.' || next === ';') {
+          continue;
+        }
+
+        if (!next) {
+          value += '\\';
+          push({ type: 'text', value });
+          continue;
+        }
+
+        // collapse slashes to reduce potential for exploits
+        const match = /^\\+/.exec(remaining());
+        let slashes = 0;
+
+        if (match && match[0].length > 2) {
+          slashes = match[0].length;
+          state.index += slashes;
+          if (slashes % 2 !== 0) {
+            value += '\\';
+          }
+        }
+
+        if (opts.unescape === true) {
+          value = advance() || '';
+        } else {
+          value += advance() || '';
+        }
+
+        if (state.brackets === 0) {
+          push({ type: 'text', value });
+          continue;
+        }
+      }
+
+      /**
+       * If we're inside a regex character class, continue
+       * until we reach the closing bracket.
+       */
+
+      if (state.brackets > 0 && (value !== ']' || prev.value === '[' || prev.value === '[^')) {
+        if (opts.posix !== false && value === ':') {
+          const inner = prev.value.slice(1);
+          if (inner.includes('[')) {
+            prev.posix = true;
+
+            if (inner.includes(':')) {
+              const idx = prev.value.lastIndexOf('[');
+              const pre = prev.value.slice(0, idx);
+              const rest = prev.value.slice(idx + 2);
+              const posix = POSIX_REGEX_SOURCE[rest];
+              if (posix) {
+                prev.value = pre + posix;
+                state.backtrack = true;
+                advance();
+
+                if (!bos.output && tokens.indexOf(prev) === 1) {
+                  bos.output = ONE_CHAR;
+                }
+                continue;
+              }
+            }
+          }
+        }
+
+        if ((value === '[' && peek() !== ':') || (value === '-' && peek() === ']')) {
+          value = `\\${value}`;
+        }
+
+        if (value === ']' && (prev.value === '[' || prev.value === '[^')) {
+          value = `\\${value}`;
+        }
+
+        if (opts.posix === true && value === '!' && prev.value === '[') {
+          value = '^';
+        }
+
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * If we're inside a quoted string, continue
+       * until we reach the closing double quote.
+       */
+
+      if (state.quotes === 1 && value !== '"') {
+        value = utils$1.escapeRegex(value);
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * Double quotes
+       */
+
+      if (value === '"') {
+        state.quotes = state.quotes === 1 ? 0 : 1;
+        if (opts.keepQuotes === true) {
+          push({ type: 'text', value });
+        }
+        continue;
+      }
+
+      /**
+       * Parentheses
+       */
+
+      if (value === '(') {
+        increment('parens');
+        push({ type: 'paren', value });
+        continue;
+      }
+
+      if (value === ')') {
+        if (state.parens === 0 && opts.strictBrackets === true) {
+          throw new SyntaxError(syntaxError('opening', '('));
+        }
+
+        const extglob = extglobs[extglobs.length - 1];
+        if (extglob && state.parens === extglob.parens + 1) {
+          extglobClose(extglobs.pop());
+          continue;
+        }
+
+        push({ type: 'paren', value, output: state.parens ? ')' : '\\)' });
+        decrement('parens');
+        continue;
+      }
+
+      /**
+       * Square brackets
+       */
+
+      if (value === '[') {
+        if (opts.nobracket === true || !remaining().includes(']')) {
+          if (opts.nobracket !== true && opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('closing', ']'));
+          }
+
+          value = `\\${value}`;
+        } else {
+          increment('brackets');
+        }
+
+        push({ type: 'bracket', value });
+        continue;
+      }
+
+      if (value === ']') {
+        if (opts.nobracket === true || (prev && prev.type === 'bracket' && prev.value.length === 1)) {
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        if (state.brackets === 0) {
+          if (opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('opening', '['));
+          }
+
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        decrement('brackets');
+
+        const prevValue = prev.value.slice(1);
+        if (prev.posix !== true && prevValue[0] === '^' && !prevValue.includes('/')) {
+          value = `/${value}`;
+        }
+
+        prev.value += value;
+        append({ value });
+
+        // when literal brackets are explicitly disabled
+        // assume we should match with a regex character class
+        if (opts.literalBrackets === false || utils$1.hasRegexChars(prevValue)) {
+          continue;
+        }
+
+        const escaped = utils$1.escapeRegex(prev.value);
+        state.output = state.output.slice(0, -prev.value.length);
+
+        // when literal brackets are explicitly enabled
+        // assume we should escape the brackets to match literal characters
+        if (opts.literalBrackets === true) {
+          state.output += escaped;
+          prev.value = escaped;
+          continue;
+        }
+
+        // when the user specifies nothing, try to match both
+        prev.value = `(${capture}${escaped}|${prev.value})`;
+        state.output += prev.value;
+        continue;
+      }
+
+      /**
+       * Braces
+       */
+
+      if (value === '{' && opts.nobrace !== true) {
+        increment('braces');
+
+        const open = {
+          type: 'brace',
+          value,
+          output: '(',
+          outputIndex: state.output.length,
+          tokensIndex: state.tokens.length
+        };
+
+        braces.push(open);
+        push(open);
+        continue;
+      }
+
+      if (value === '}') {
+        const brace = braces[braces.length - 1];
+
+        if (opts.nobrace === true || !brace) {
+          push({ type: 'text', value, output: value });
+          continue;
+        }
+
+        let output = ')';
+
+        if (brace.dots === true) {
+          const arr = tokens.slice();
+          const range = [];
+
+          for (let i = arr.length - 1; i >= 0; i--) {
+            tokens.pop();
+            if (arr[i].type === 'brace') {
+              break;
+            }
+            if (arr[i].type !== 'dots') {
+              range.unshift(arr[i].value);
+            }
+          }
+
+          output = expandRange(range, opts);
+          state.backtrack = true;
+        }
+
+        if (brace.comma !== true && brace.dots !== true) {
+          const out = state.output.slice(0, brace.outputIndex);
+          const toks = state.tokens.slice(brace.tokensIndex);
+          brace.value = brace.output = '\\{';
+          value = output = '\\}';
+          state.output = out;
+          for (const t of toks) {
+            state.output += (t.output || t.value);
+          }
+        }
+
+        push({ type: 'brace', value, output });
+        decrement('braces');
+        braces.pop();
+        continue;
+      }
+
+      /**
+       * Pipes
+       */
+
+      if (value === '|') {
+        if (extglobs.length > 0) {
+          extglobs[extglobs.length - 1].conditions++;
+        }
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Commas
+       */
+
+      if (value === ',') {
+        let output = value;
+
+        const brace = braces[braces.length - 1];
+        if (brace && stack[stack.length - 1] === 'braces') {
+          brace.comma = true;
+          output = '|';
+        }
+
+        push({ type: 'comma', value, output });
+        continue;
+      }
+
+      /**
+       * Slashes
+       */
+
+      if (value === '/') {
+        // if the beginning of the glob is "./", advance the start
+        // to the current index, and don't add the "./" characters
+        // to the state. This greatly simplifies lookbehinds when
+        // checking for BOS characters like "!" and "." (not "./")
+        if (prev.type === 'dot' && state.index === state.start + 1) {
+          state.start = state.index + 1;
+          state.consumed = '';
+          state.output = '';
+          tokens.pop();
+          prev = bos; // reset "prev" to the first token
+          continue;
+        }
+
+        push({ type: 'slash', value, output: SLASH_LITERAL });
+        continue;
+      }
+
+      /**
+       * Dots
+       */
+
+      if (value === '.') {
+        if (state.braces > 0 && prev.type === 'dot') {
+          if (prev.value === '.') prev.output = DOT_LITERAL;
+          const brace = braces[braces.length - 1];
+          prev.type = 'dots';
+          prev.output += value;
+          prev.value += value;
+          brace.dots = true;
+          continue;
+        }
+
+        if ((state.braces + state.parens) === 0 && prev.type !== 'bos' && prev.type !== 'slash') {
+          push({ type: 'text', value, output: DOT_LITERAL });
+          continue;
+        }
+
+        push({ type: 'dot', value, output: DOT_LITERAL });
+        continue;
+      }
+
+      /**
+       * Question marks
+       */
+
+      if (value === '?') {
+        const isGroup = prev && prev.value === '(';
+        if (!isGroup && opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('qmark', value);
+          continue;
+        }
+
+        if (prev && prev.type === 'paren') {
+          const next = peek();
+          let output = value;
+
+          if (next === '<' && !utils$1.supportsLookbehinds()) {
+            throw new Error('Node.js v10 or higher is required for regex lookbehinds');
+          }
+
+          if ((prev.value === '(' && !/[!=<:]/.test(next)) || (next === '<' && !/<([!=]|\w+>)/.test(remaining()))) {
+            output = `\\${value}`;
+          }
+
+          push({ type: 'text', value, output });
+          continue;
+        }
+
+        if (opts.dot !== true && (prev.type === 'slash' || prev.type === 'bos')) {
+          push({ type: 'qmark', value, output: QMARK_NO_DOT });
+          continue;
+        }
+
+        push({ type: 'qmark', value, output: QMARK });
+        continue;
+      }
+
+      /**
+       * Exclamation
+       */
+
+      if (value === '!') {
+        if (opts.noextglob !== true && peek() === '(') {
+          if (peek(2) !== '?' || !/[!=<:]/.test(peek(3))) {
+            extglobOpen('negate', value);
+            continue;
+          }
+        }
+
+        if (opts.nonegate !== true && state.index === 0) {
+          negate();
+          continue;
+        }
+      }
+
+      /**
+       * Plus
+       */
+
+      if (value === '+') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('plus', value);
+          continue;
+        }
+
+        if ((prev && prev.value === '(') || opts.regex === false) {
+          push({ type: 'plus', value, output: PLUS_LITERAL });
+          continue;
+        }
+
+        if ((prev && (prev.type === 'bracket' || prev.type === 'paren' || prev.type === 'brace')) || state.parens > 0) {
+          push({ type: 'plus', value });
+          continue;
+        }
+
+        push({ type: 'plus', value: PLUS_LITERAL });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value === '@') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          push({ type: 'at', extglob: true, value, output: '' });
+          continue;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value !== '*') {
+        if (value === '$' || value === '^') {
+          value = `\\${value}`;
+        }
+
+        const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
+        if (match) {
+          value += match[0];
+          state.index += match[0].length;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Stars
+       */
+
+      if (prev && (prev.type === 'globstar' || prev.star === true)) {
+        prev.type = 'star';
+        prev.star = true;
+        prev.value += value;
+        prev.output = star;
+        state.backtrack = true;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      let rest = remaining();
+      if (opts.noextglob !== true && /^\([^?]/.test(rest)) {
+        extglobOpen('star', value);
+        continue;
+      }
+
+      if (prev.type === 'star') {
+        if (opts.noglobstar === true) {
+          consume(value);
+          continue;
+        }
+
+        const prior = prev.prev;
+        const before = prior.prev;
+        const isStart = prior.type === 'slash' || prior.type === 'bos';
+        const afterStar = before && (before.type === 'star' || before.type === 'globstar');
+
+        if (opts.bash === true && (!isStart || (rest[0] && rest[0] !== '/'))) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        const isBrace = state.braces > 0 && (prior.type === 'comma' || prior.type === 'brace');
+        const isExtglob = extglobs.length && (prior.type === 'pipe' || prior.type === 'paren');
+        if (!isStart && prior.type !== 'paren' && !isBrace && !isExtglob) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        // strip consecutive `/**/`
+        while (rest.slice(0, 3) === '/**') {
+          const after = input[state.index + 4];
+          if (after && after !== '/') {
+            break;
+          }
+          rest = rest.slice(3);
+          consume('/**', 3);
+        }
+
+        if (prior.type === 'bos' && eos()) {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = globstar(opts);
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && !afterStar && eos()) {
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = globstar(opts) + (opts.strictSlashes ? ')' : '|$)');
+          prev.value += value;
+          state.globstar = true;
+          state.output += prior.output + prev.output;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && rest[0] === '/') {
+          const end = rest[1] !== void 0 ? '|$' : '';
+
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = `${globstar(opts)}${SLASH_LITERAL}|${SLASH_LITERAL}${end})`;
+          prev.value += value;
+
+          state.output += prior.output + prev.output;
+          state.globstar = true;
+
+          consume(value + advance());
+
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        if (prior.type === 'bos' && rest[0] === '/') {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value + advance());
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        // remove single star from output
+        state.output = state.output.slice(0, -prev.output.length);
+
+        // reset previous token to globstar
+        prev.type = 'globstar';
+        prev.output = globstar(opts);
+        prev.value += value;
+
+        // reset output with globstar
+        state.output += prev.output;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      const token = { type: 'star', value, output: star };
+
+      if (opts.bash === true) {
+        token.output = '.*?';
+        if (prev.type === 'bos' || prev.type === 'slash') {
+          token.output = nodot + token.output;
+        }
+        push(token);
+        continue;
+      }
+
+      if (prev && (prev.type === 'bracket' || prev.type === 'paren') && opts.regex === true) {
+        token.output = value;
+        push(token);
+        continue;
+      }
+
+      if (state.index === state.start || prev.type === 'slash' || prev.type === 'dot') {
+        if (prev.type === 'dot') {
+          state.output += NO_DOT_SLASH;
+          prev.output += NO_DOT_SLASH;
+
+        } else if (opts.dot === true) {
+          state.output += NO_DOTS_SLASH;
+          prev.output += NO_DOTS_SLASH;
+
+        } else {
+          state.output += nodot;
+          prev.output += nodot;
+        }
+
+        if (peek() !== '*') {
+          state.output += ONE_CHAR;
+          prev.output += ONE_CHAR;
+        }
+      }
+
+      push(token);
+    }
+
+    while (state.brackets > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ']'));
+      state.output = utils$1.escapeLast(state.output, '[');
+      decrement('brackets');
+    }
+
+    while (state.parens > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ')'));
+      state.output = utils$1.escapeLast(state.output, '(');
+      decrement('parens');
+    }
+
+    while (state.braces > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', '}'));
+      state.output = utils$1.escapeLast(state.output, '{');
+      decrement('braces');
+    }
+
+    if (opts.strictSlashes !== true && (prev.type === 'star' || prev.type === 'bracket')) {
+      push({ type: 'maybe_slash', value: '', output: `${SLASH_LITERAL}?` });
+    }
+
+    // rebuild the output if we had to backtrack at any point
+    if (state.backtrack === true) {
+      state.output = '';
+
+      for (const token of state.tokens) {
+        state.output += token.output != null ? token.output : token.value;
+
+        if (token.suffix) {
+          state.output += token.suffix;
+        }
+      }
+    }
+
+    return state;
+  };
+
+  /**
+   * Fast paths for creating regular expressions for common glob patterns.
+   * This can significantly speed up processing and has very little downside
+   * impact when none of the fast paths match.
+   */
+
+  parse$2.fastpaths = (input, options) => {
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+    const len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    // create constants based on platform, for windows or posix
+    const {
+      DOT_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOTS,
+      NO_DOTS_SLASH,
+      STAR,
+      START_ANCHOR
+    } = constants$2.globChars(opts.windows);
+
+    const nodot = opts.dot ? NO_DOTS : NO_DOT;
+    const slashDot = opts.dot ? NO_DOTS_SLASH : NO_DOT;
+    const capture = opts.capture ? '' : '?:';
+    const state = { negated: false, prefix: '' };
+    let star = opts.bash === true ? '.*?' : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    const globstar = (opts) => {
+      if (opts.noglobstar === true) return star;
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const create = str => {
+      switch (str) {
+        case '*':
+          return `${nodot}${ONE_CHAR}${star}`;
+
+        case '.*':
+          return `${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*.*':
+          return `${nodot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*/*':
+          return `${nodot}${star}${SLASH_LITERAL}${ONE_CHAR}${slashDot}${star}`;
+
+        case '**':
+          return nodot + globstar(opts);
+
+        case '**/*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${ONE_CHAR}${star}`;
+
+        case '**/*.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '**/.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        default: {
+          const match = /^(.*?)\.(\w+)$/.exec(str);
+          if (!match) return;
+
+          const source = create(match[1]);
+          if (!source) return;
+
+          return source + DOT_LITERAL + match[2];
+        }
+      }
+    };
+
+    const output = utils$1.removePrefix(input, state);
+    let source = create(output);
+
+    if (source && opts.strictSlashes !== true) {
+      source += `${SLASH_LITERAL}?`;
+    }
+
+    return source;
+  };
+
+  var parse_1 = parse$2;
+
+  const scan = scan_1;
+  const parse$1 = parse_1;
+  const utils = utils$3;
+  const constants$1 = constants$3;
+  const isObject = val => val && typeof val === 'object' && !Array.isArray(val);
+
+  /**
+   * Creates a matcher function from one or more glob patterns. The
+   * returned function takes a string to match as its first argument,
+   * and returns true if the string is a match. The returned matcher
+   * function also takes a boolean as the second argument that, when true,
+   * returns an object with additional information.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch(glob[, options]);
+   *
+   * const isMatch = picomatch('*.!(*a)');
+   * console.log(isMatch('a.a')); //=> false
+   * console.log(isMatch('a.b')); //=> true
+   * ```
+   * @name picomatch
+   * @param {String|Array} `globs` One or more glob patterns.
+   * @param {Object=} `options`
+   * @return {Function=} Returns a matcher function.
+   * @api public
+   */
+
+  const picomatch = (glob, options, returnState = false) => {
+    if (Array.isArray(glob)) {
+      const fns = glob.map(input => picomatch(input, options, returnState));
+      const arrayMatcher = str => {
+        for (const isMatch of fns) {
+          const state = isMatch(str);
+          if (state) return state;
+        }
+        return false;
+      };
+      return arrayMatcher;
+    }
+
+    const isState = isObject(glob) && glob.tokens && glob.input;
+
+    if (glob === '' || (typeof glob !== 'string' && !isState)) {
+      throw new TypeError('Expected pattern to be a non-empty string');
+    }
+
+    const opts = options || {};
+    const posix = opts.windows;
+    const regex = isState
+      ? picomatch.compileRe(glob, options)
+      : picomatch.makeRe(glob, options, false, true);
+
+    const state = regex.state;
+    delete regex.state;
+
+    let isIgnored = () => false;
+    if (opts.ignore) {
+      const ignoreOpts = { ...options, ignore: null, onMatch: null, onResult: null };
+      isIgnored = picomatch(opts.ignore, ignoreOpts, returnState);
+    }
+
+    const matcher = (input, returnObject = false) => {
+      const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+      const result = { glob, state, regex, posix, input, output, match, isMatch };
+
+      if (typeof opts.onResult === 'function') {
+        opts.onResult(result);
+      }
+
+      if (isMatch === false) {
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (isIgnored(input)) {
+        if (typeof opts.onIgnore === 'function') {
+          opts.onIgnore(result);
+        }
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (typeof opts.onMatch === 'function') {
+        opts.onMatch(result);
+      }
+      return returnObject ? result : true;
+    };
+
+    if (returnState) {
+      matcher.state = state;
+    }
+
+    return matcher;
+  };
+
+  /**
+   * Test `input` with the given `regex`. This is used by the main
+   * `picomatch()` function to test the input string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.test(input, regex[, options]);
+   *
+   * console.log(picomatch.test('foo/bar', /^(?:([^/]*?)\/([^/]*?))$/));
+   * // { isMatch: true, match: [ 'foo/', 'foo', 'bar' ], output: 'foo/bar' }
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp} `regex`
+   * @return {Object} Returns an object with matching info.
+   * @api public
+   */
+
+  picomatch.test = (input, regex, options, { glob, posix } = {}) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected input to be a string');
+    }
+
+    if (input === '') {
+      return { isMatch: false, output: '' };
+    }
+
+    const opts = options || {};
+    const format = opts.format || (posix ? utils.toPosixSlashes : null);
+    let match = input === glob;
+    let output = (match && format) ? format(input) : input;
+
+    if (match === false) {
+      output = format ? format(input) : input;
+      match = output === glob;
+    }
+
+    if (match === false || opts.capture === true) {
+      if (opts.matchBase === true || opts.basename === true) {
+        match = picomatch.matchBase(input, regex, options, posix);
+      } else {
+        match = regex.exec(output);
+      }
+    }
+
+    return { isMatch: Boolean(match), match, output };
+  };
+
+  /**
+   * Match the basename of a filepath.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.matchBase(input, glob[, options]);
+   * console.log(picomatch.matchBase('foo/bar.js', '*.js'); // true
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp|String} `glob` Glob pattern or regex created by [.makeRe](#makeRe).
+   * @return {Boolean}
+   * @api public
+   */
+
+  picomatch.matchBase = (input, glob, options) => {
+    const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
+    return regex.test(utils.basename(input));
+  };
+
+  /**
+   * Returns true if **any** of the given glob `patterns` match the specified `string`.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.isMatch(string, patterns[, options]);
+   *
+   * console.log(picomatch.isMatch('a.a', ['b.*', '*.a'])); //=> true
+   * console.log(picomatch.isMatch('a.a', 'b.*')); //=> false
+   * ```
+   * @param {String|Array} str The string to test.
+   * @param {String|Array} patterns One or more glob patterns to use for matching.
+   * @param {Object} [options] See available [options](#options).
+   * @return {Boolean} Returns true if any patterns match `str`
+   * @api public
+   */
+
+  picomatch.isMatch = (str, patterns, options) => picomatch(patterns, options)(str);
+
+  /**
+   * Parse a glob pattern to create the source string for a regular
+   * expression.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const result = picomatch.parse(pattern[, options]);
+   * ```
+   * @param {String} `pattern`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with useful properties and output to be used as a regex source string.
+   * @api public
+   */
+
+  picomatch.parse = (pattern, options) => {
+    if (Array.isArray(pattern)) return pattern.map(p => picomatch.parse(p, options));
+    return parse$1(pattern, { ...options, fastpaths: false });
+  };
+
+  /**
+   * Scan a glob pattern to separate the pattern into segments.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.scan(input[, options]);
+   *
+   * const result = picomatch.scan('!./foo/*.js');
+   * console.log(result);
+   * { prefix: '!./',
+   *   input: '!./foo/*.js',
+   *   start: 3,
+   *   base: 'foo',
+   *   glob: '*.js',
+   *   isBrace: false,
+   *   isBracket: false,
+   *   isGlob: true,
+   *   isExtglob: false,
+   *   isGlobstar: false,
+   *   negated: true }
+   * ```
+   * @param {String} `input` Glob pattern to scan.
+   * @param {Object} `options`
+   * @return {Object} Returns an object with
+   * @api public
+   */
+
+  picomatch.scan = (input, options) => scan(input, options);
+
+  /**
+   * Create a regular expression from a parsed glob pattern.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const state = picomatch.parse('*.js');
+   * // picomatch.compileRe(state[, options]);
+   *
+   * console.log(picomatch.compileRe(state));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `state` The object returned from the `.parse` method.
+   * @param {Object} `options`
+   * @return {RegExp} Returns a regex created from the given pattern.
+   * @api public
+   */
+
+  picomatch.compileRe = (parsed, options, returnOutput = false, returnState = false) => {
+    if (returnOutput === true) {
+      return parsed.output;
+    }
+
+    const opts = options || {};
+    const prepend = opts.contains ? '' : '^';
+    const append = opts.contains ? '' : '$';
+
+    let source = `${prepend}(?:${parsed.output})${append}`;
+    if (parsed && parsed.negated === true) {
+      source = `^(?!${source}).*$`;
+    }
+
+    const regex = picomatch.toRegex(source, options);
+    if (returnState === true) {
+      regex.state = parsed;
+    }
+
+    return regex;
+  };
+
+  picomatch.makeRe = (input, options, returnOutput = false, returnState = false) => {
+    if (!input || typeof input !== 'string') {
+      throw new TypeError('Expected a non-empty string');
+    }
+
+    const opts = options || {};
+    let parsed = { negated: false, fastpaths: true };
+    let prefix = '';
+    let output;
+
+    if (input.startsWith('./')) {
+      input = input.slice(2);
+      prefix = parsed.prefix = './';
+    }
+
+    if (opts.fastpaths !== false && (input[0] === '.' || input[0] === '*')) {
+      output = parse$1.fastpaths(input, options);
+    }
+
+    if (output === undefined) {
+      parsed = parse$1(input, options);
+      parsed.prefix = prefix + (parsed.prefix || '');
+    } else {
+      parsed.output = output;
+    }
+
+    return picomatch.compileRe(parsed, options, returnOutput, returnState);
+  };
+
+  /**
+   * Create a regular expression from the given regex source string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.toRegex(source[, options]);
+   *
+   * const { output } = picomatch.parse('*.js');
+   * console.log(picomatch.toRegex(output));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `source` Regular expression source string.
+   * @param {Object} `options`
+   * @return {RegExp}
+   * @api public
+   */
+
+  picomatch.toRegex = (source, options) => {
+    try {
+      const opts = options || {};
+      return new RegExp(source, opts.flags || (opts.nocase ? 'i' : ''));
+    } catch (err) {
+      if (options && options.debug === true) throw err;
+      return /$^/;
+    }
+  };
+
+  /**
+   * Picomatch constants.
+   * @return {Object}
+   */
+
+  picomatch.constants = constants$1;
+
+  /**
+   * Expose "picomatch"
+   */
+
+  var picomatch_1 = picomatch;
+
+  var picomatchBrowser = picomatch_1;
+
+  var pm = /*@__PURE__*/getDefaultExportFromCjs(picomatchBrowser);
+
+  function isArray(arg) {
+      return Array.isArray(arg);
+  }
+  function ensureArray(thing) {
+      if (isArray(thing))
+          return thing;
+      if (thing == null)
+          return [];
+      return [thing];
+  }
+  const globToTest = (glob) => {
+      const pattern = glob;
+      const fn = pm(pattern, { dot: true });
+      return {
+          test: (what) => {
+              const result = fn(what);
+              return result;
+          },
+      };
+  };
+  const testTrue = {
+      test: () => true,
+  };
+  const getMatcher = (filter) => {
+      const bundleTest = "bundle" in filter && filter.bundle != null ? globToTest(filter.bundle) : testTrue;
+      const fileTest = "file" in filter && filter.file != null ? globToTest(filter.file) : testTrue;
+      return { bundleTest, fileTest };
+  };
+  const createFilter = (include, exclude) => {
+      const includeMatchers = ensureArray(include).map(getMatcher);
+      const excludeMatchers = ensureArray(exclude).map(getMatcher);
+      return (bundleId, id) => {
+          for (let i = 0; i < excludeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = excludeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return false;
+          }
+          for (let i = 0; i < includeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = includeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return true;
+          }
+          return !includeMatchers.length;
+      };
+  };
+
+  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      return (val) => {
+          if (!waiting) {
+              callback(val);
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+              }, limit);
+          }
+      };
+  };
+  const prepareFilter = (filt) => {
+      if (filt === "")
+          return [];
+      return (filt
+          .split(",")
+          // remove spaces before and after
+          .map((entry) => entry.trim())
+          // unquote "
+          .map((entry) => entry.startsWith('"') && entry.endsWith('"') ? entry.substring(1, entry.length - 1) : entry)
+          // unquote '
+          .map((entry) => entry.startsWith("'") && entry.endsWith("'") ? entry.substring(1, entry.length - 1) : entry)
+          // remove empty strings
+          .filter((entry) => entry)
+          // parse bundle:file
+          .map((entry) => entry.split(":"))
+          // normalize entry just in case
+          .flatMap((entry) => {
+          if (entry.length === 0)
+              return [];
+          let bundle = null;
+          let file = null;
+          if (entry.length === 1 && entry[0]) {
+              file = entry[0];
+              return [{ file, bundle }];
+          }
+          bundle = entry[0] || null;
+          file = entry.slice(1).join(":") || null;
+          return [{ bundle, file }];
+      }));
+  };
+  const useFilter = () => {
+      const [includeFilter, setIncludeFilter] = h("");
+      const [excludeFilter, setExcludeFilter] = h("");
+      const setIncludeFilterTrottled = F(() => throttleFilter(setIncludeFilter, 200), []);
+      const setExcludeFilterTrottled = F(() => throttleFilter(setExcludeFilter, 200), []);
+      const isIncluded = F(() => createFilter(prepareFilter(includeFilter), prepareFilter(excludeFilter)), [includeFilter, excludeFilter]);
+      const getModuleFilterMultiplier = T((bundleId, data) => {
+          return isIncluded(bundleId, data.id) ? 1 : 0;
+      }, [isIncluded]);
+      return {
+          getModuleFilterMultiplier,
+          includeFilter,
+          excludeFilter,
+          setExcludeFilter: setExcludeFilterTrottled,
+          setIncludeFilter: setIncludeFilterTrottled,
+      };
+  };
+
+  function ascending(a, b) {
+    return a == null || b == null ? NaN : a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
+  }
+
+  function descending(a, b) {
+    return a == null || b == null ? NaN
+      : b < a ? -1
+      : b > a ? 1
+      : b >= a ? 0
+      : NaN;
+  }
+
+  function bisector(f) {
+    let compare1, compare2, delta;
+
+    // If an accessor is specified, promote it to a comparator. In this case we
+    // can test whether the search value is (self-) comparable. We can’t do this
+    // for a comparator (except for specific, known comparators) because we can’t
+    // tell if the comparator is symmetric, and an asymmetric comparator can’t be
+    // used to test whether a single value is comparable.
+    if (f.length !== 2) {
+      compare1 = ascending;
+      compare2 = (d, x) => ascending(f(d), x);
+      delta = (d, x) => f(d) - x;
+    } else {
+      compare1 = f === ascending || f === descending ? f : zero$1;
+      compare2 = f;
+      delta = f;
+    }
+
+    function left(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) < 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function right(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) <= 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function center(a, x, lo = 0, hi = a.length) {
+      const i = left(a, x, lo, hi - 1);
+      return i > lo && delta(a[i - 1], x) > -delta(a[i], x) ? i - 1 : i;
+    }
+
+    return {left, center, right};
+  }
+
+  function zero$1() {
+    return 0;
+  }
+
+  function number$1(x) {
+    return x === null ? NaN : +x;
+  }
+
+  const ascendingBisect = bisector(ascending);
+  const bisectRight = ascendingBisect.right;
+  bisector(number$1).center;
+  var bisect = bisectRight;
+
+  class InternMap extends Map {
+    constructor(entries, key = keyof) {
+      super();
+      Object.defineProperties(this, {_intern: {value: new Map()}, _key: {value: key}});
+      if (entries != null) for (const [key, value] of entries) this.set(key, value);
+    }
+    get(key) {
+      return super.get(intern_get(this, key));
+    }
+    has(key) {
+      return super.has(intern_get(this, key));
+    }
+    set(key, value) {
+      return super.set(intern_set(this, key), value);
+    }
+    delete(key) {
+      return super.delete(intern_delete(this, key));
+    }
+  }
+
+  function intern_get({_intern, _key}, value) {
+    const key = _key(value);
+    return _intern.has(key) ? _intern.get(key) : value;
+  }
+
+  function intern_set({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) return _intern.get(key);
+    _intern.set(key, value);
+    return value;
+  }
+
+  function intern_delete({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) {
+      value = _intern.get(key);
+      _intern.delete(key);
+    }
+    return value;
+  }
+
+  function keyof(value) {
+    return value !== null && typeof value === "object" ? value.valueOf() : value;
+  }
+
+  function identity$2(x) {
+    return x;
+  }
+
+  function group(values, ...keys) {
+    return nest(values, identity$2, identity$2, keys);
+  }
+
+  function nest(values, map, reduce, keys) {
+    return (function regroup(values, i) {
+      if (i >= keys.length) return reduce(values);
+      const groups = new InternMap();
+      const keyof = keys[i++];
+      let index = -1;
+      for (const value of values) {
+        const key = keyof(value, ++index, values);
+        const group = groups.get(key);
+        if (group) group.push(value);
+        else groups.set(key, [value]);
+      }
+      for (const [key, values] of groups) {
+        groups.set(key, regroup(values, i));
+      }
+      return map(groups);
+    })(values, 0);
+  }
+
+  const e10 = Math.sqrt(50),
+      e5 = Math.sqrt(10),
+      e2 = Math.sqrt(2);
+
+  function tickSpec(start, stop, count) {
+    const step = (stop - start) / Math.max(0, count),
+        power = Math.floor(Math.log10(step)),
+        error = step / Math.pow(10, power),
+        factor = error >= e10 ? 10 : error >= e5 ? 5 : error >= e2 ? 2 : 1;
+    let i1, i2, inc;
+    if (power < 0) {
+      inc = Math.pow(10, -power) / factor;
+      i1 = Math.round(start * inc);
+      i2 = Math.round(stop * inc);
+      if (i1 / inc < start) ++i1;
+      if (i2 / inc > stop) --i2;
+      inc = -inc;
+    } else {
+      inc = Math.pow(10, power) * factor;
+      i1 = Math.round(start / inc);
+      i2 = Math.round(stop / inc);
+      if (i1 * inc < start) ++i1;
+      if (i2 * inc > stop) --i2;
+    }
+    if (i2 < i1 && 0.5 <= count && count < 2) return tickSpec(start, stop, count * 2);
+    return [i1, i2, inc];
+  }
+
+  function ticks(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    if (!(count > 0)) return [];
+    if (start === stop) return [start];
+    const reverse = stop < start, [i1, i2, inc] = reverse ? tickSpec(stop, start, count) : tickSpec(start, stop, count);
+    if (!(i2 >= i1)) return [];
+    const n = i2 - i1 + 1, ticks = new Array(n);
+    if (reverse) {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) * inc;
+    } else {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) * inc;
+    }
+    return ticks;
+  }
+
+  function tickIncrement(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    return tickSpec(start, stop, count)[2];
+  }
+
+  function tickStep(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    const reverse = stop < start, inc = reverse ? tickIncrement(stop, start, count) : tickIncrement(start, stop, count);
+    return (reverse ? -1 : 1) * (inc < 0 ? 1 / -inc : inc);
+  }
+
+  const TOP_PADDING = 20;
+  const PADDING = 2;
+
+  const Node = ({ node, onMouseOver, onClick, selected }) => {
+      const { getModuleColor } = q(StaticContext);
+      const { backgroundColor, fontColor } = getModuleColor(node);
+      const { x0, x1, y1, y0, data, children = null } = node;
+      const textRef = _(null);
+      const textRectRef = _();
+      const width = x1 - x0;
+      const height = y1 - y0;
+      const textProps = {
+          "font-size": "0.7em",
+          "dominant-baseline": "middle",
+          "text-anchor": "middle",
+          x: width / 2,
+      };
+      if (children != null) {
+          textProps.y = (TOP_PADDING + PADDING) / 2;
+      }
+      else {
+          textProps.y = height / 2;
+      }
+      y(() => {
+          if (width == 0 || height == 0 || !textRef.current) {
+              return;
+          }
+          if (textRectRef.current == null) {
+              textRectRef.current = textRef.current.getBoundingClientRect();
+          }
+          let scale = 1;
+          if (children != null) {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, Math.min(height, TOP_PADDING + PADDING) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(Math.min(TOP_PADDING + PADDING, height) / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          else {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, (height * 0.9) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(height / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          textRef.current.setAttribute("transform", `scale(${scale.toFixed(2)})`);
+      }, [children, height, width]);
+      if (width == 0 || height == 0) {
+          return null;
+      }
+      return (o$1("g", { className: "node", transform: `translate(${x0},${y0})`, onClick: (event) => {
+              event.stopPropagation();
+              onClick(node);
+          }, onMouseOver: (event) => {
+              event.stopPropagation();
+              onMouseOver(node);
+          }, children: [o$1("rect", { fill: backgroundColor, rx: 2, ry: 2, width: x1 - x0, height: y1 - y0, stroke: selected ? "#fff" : undefined, "stroke-width": selected ? 2 : undefined }), o$1("text", Object.assign({ ref: textRef, fill: fontColor, onClick: (event) => {
+                      var _a;
+                      if (((_a = window.getSelection()) === null || _a === void 0 ? void 0 : _a.toString()) !== "") {
+                          event.stopPropagation();
+                      }
+                  } }, textProps, { children: data.name }))] }));
+  };
+
+  const TreeMap = ({ root, onNodeHover, selectedNode, onNodeClick, }) => {
+      const { width, height, getModuleIds } = q(StaticContext);
+      console.time("layering");
+      // this will make groups by height
+      const nestedData = F(() => {
+          const nestedDataMap = group(root.descendants(), (d) => d.height);
+          const nestedData = Array.from(nestedDataMap, ([key, values]) => ({
+              key,
+              values,
+          }));
+          nestedData.sort((a, b) => b.key - a.key);
+          return nestedData;
+      }, [root]);
+      console.timeEnd("layering");
+      return (o$1("svg", { xmlns: "http://www.w3.org/2000/svg", viewBox: `0 0 ${width} ${height}`, children: nestedData.map(({ key, values }) => {
+              return (o$1("g", { className: "layer", children: values.map((node) => {
+                      return (o$1(Node, { node: node, onMouseOver: onNodeHover, selected: selectedNode === node, onClick: onNodeClick }, getModuleIds(node.data).nodeUid.id));
+                  }) }, key));
+          }) }));
+  };
+
+  var bytes$1 = {exports: {}};
+
+  /*!
+   * bytes
+   * Copyright(c) 2012-2014 TJ Holowaychuk
+   * Copyright(c) 2015 Jed Watson
+   * MIT Licensed
+   */
+
+  /**
+   * Module exports.
+   * @public
+   */
+
+  bytes$1.exports = bytes;
+  var format_1 = bytes$1.exports.format = format$1;
+  bytes$1.exports.parse = parse;
+
+  /**
+   * Module variables.
+   * @private
+   */
+
+  var formatThousandsRegExp = /\B(?=(\d{3})+(?!\d))/g;
+
+  var formatDecimalsRegExp = /(?:\.0*|(\.[^0]+)0+)$/;
+
+  var map$1 = {
+    b:  1,
+    kb: 1 << 10,
+    mb: 1 << 20,
+    gb: 1 << 30,
+    tb: Math.pow(1024, 4),
+    pb: Math.pow(1024, 5),
+  };
+
+  var parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
+
+  /**
+   * Convert the given value in bytes into a string or parse to string to an integer in bytes.
+   *
+   * @param {string|number} value
+   * @param {{
+   *  case: [string],
+   *  decimalPlaces: [number]
+   *  fixedDecimals: [boolean]
+   *  thousandsSeparator: [string]
+   *  unitSeparator: [string]
+   *  }} [options] bytes options.
+   *
+   * @returns {string|number|null}
+   */
+
+  function bytes(value, options) {
+    if (typeof value === 'string') {
+      return parse(value);
+    }
+
+    if (typeof value === 'number') {
+      return format$1(value, options);
+    }
+
+    return null;
+  }
+
+  /**
+   * Format the given value in bytes into a string.
+   *
+   * If the value is negative, it is kept as such. If it is a float,
+   * it is rounded.
+   *
+   * @param {number} value
+   * @param {object} [options]
+   * @param {number} [options.decimalPlaces=2]
+   * @param {number} [options.fixedDecimals=false]
+   * @param {string} [options.thousandsSeparator=]
+   * @param {string} [options.unit=]
+   * @param {string} [options.unitSeparator=]
+   *
+   * @returns {string|null}
+   * @public
+   */
+
+  function format$1(value, options) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    var mag = Math.abs(value);
+    var thousandsSeparator = (options && options.thousandsSeparator) || '';
+    var unitSeparator = (options && options.unitSeparator) || '';
+    var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
+    var fixedDecimals = Boolean(options && options.fixedDecimals);
+    var unit = (options && options.unit) || '';
+
+    if (!unit || !map$1[unit.toLowerCase()]) {
+      if (mag >= map$1.pb) {
+        unit = 'PB';
+      } else if (mag >= map$1.tb) {
+        unit = 'TB';
+      } else if (mag >= map$1.gb) {
+        unit = 'GB';
+      } else if (mag >= map$1.mb) {
+        unit = 'MB';
+      } else if (mag >= map$1.kb) {
+        unit = 'KB';
+      } else {
+        unit = 'B';
+      }
+    }
+
+    var val = value / map$1[unit.toLowerCase()];
+    var str = val.toFixed(decimalPlaces);
+
+    if (!fixedDecimals) {
+      str = str.replace(formatDecimalsRegExp, '$1');
+    }
+
+    if (thousandsSeparator) {
+      str = str.split('.').map(function (s, i) {
+        return i === 0
+          ? s.replace(formatThousandsRegExp, thousandsSeparator)
+          : s
+      }).join('.');
+    }
+
+    return str + unitSeparator + unit;
+  }
+
+  /**
+   * Parse the string value into an integer in bytes.
+   *
+   * If no unit is given, it is assumed the value is in bytes.
+   *
+   * @param {number|string} val
+   *
+   * @returns {number|null}
+   * @public
+   */
+
+  function parse(val) {
+    if (typeof val === 'number' && !isNaN(val)) {
+      return val;
+    }
+
+    if (typeof val !== 'string') {
+      return null;
+    }
+
+    // Test if the string passed is valid
+    var results = parseRegExp.exec(val);
+    var floatValue;
+    var unit = 'b';
+
+    if (!results) {
+      // Nothing could be extracted from the given string
+      floatValue = parseInt(val, 10);
+      unit = 'b';
+    } else {
+      // Retrieve the value and the unit
+      floatValue = parseFloat(results[1]);
+      unit = results[4].toLowerCase();
+    }
+
+    if (isNaN(floatValue)) {
+      return null;
+    }
+
+    return Math.floor(map$1[unit] * floatValue);
+  }
+
+  const Tooltip_marginX = 10;
+  const Tooltip_marginY = 30;
+  const SOURCEMAP_RENDERED = (o$1("span", { children: [" ", o$1("b", { children: LABELS.renderedLength }), " is a number of characters in the file after individual and ", o$1("br", {}), " ", "whole bundle transformations according to sourcemap."] }));
+  const RENDRED = (o$1("span", { children: [o$1("b", { children: LABELS.renderedLength }), " is a byte size of individual file after transformations and treeshake."] }));
+  const COMPRESSED = (o$1("span", { children: [o$1("b", { children: LABELS.gzipLength }), " and ", o$1("b", { children: LABELS.brotliLength }), " is a byte size of individual file after individual transformations,", o$1("br", {}), " treeshake and compression."] }));
+  const Tooltip = ({ node, visible, root, sizeProperty, }) => {
+      const { availableSizeProperties, getModuleSize, data } = q(StaticContext);
+      const ref = _(null);
+      const [style, setStyle] = h({});
+      const content = F(() => {
+          if (!node)
+              return null;
+          const mainSize = getModuleSize(node.data, sizeProperty);
+          const percentageNum = (100 * mainSize) / getModuleSize(root.data, sizeProperty);
+          const percentage = percentageNum.toFixed(2);
+          const percentageString = percentage + "%";
+          const path = node
+              .ancestors()
+              .reverse()
+              .map((d) => d.data.name)
+              .join("/");
+          let dataNode = null;
+          if (!isModuleTree(node.data)) {
+              const mainUid = data.nodeParts[node.data.uid].metaUid;
+              dataNode = data.nodeMetas[mainUid];
+          }
+          return (o$1(k$1, { children: [o$1("div", { children: path }), availableSizeProperties.map((sizeProp) => {
+                      if (sizeProp === sizeProperty) {
+                          return (o$1("div", { children: [o$1("b", { children: [LABELS[sizeProp], ": ", format_1(mainSize)] }), " ", "(", percentageString, ")"] }, sizeProp));
+                      }
+                      else {
+                          return (o$1("div", { children: [LABELS[sizeProp], ": ", format_1(getModuleSize(node.data, sizeProp))] }, sizeProp));
+                      }
+                  }), o$1("br", {}), dataNode && dataNode.importedBy.length > 0 && (o$1("div", { children: [o$1("div", { children: [o$1("b", { children: "Imported By" }), ":"] }), dataNode.importedBy.map(({ uid }) => {
+                              const id = data.nodeMetas[uid].id;
+                              return o$1("div", { children: id }, id);
+                          })] })), o$1("br", {}), o$1("small", { children: data.options.sourcemap ? SOURCEMAP_RENDERED : RENDRED }), (data.options.gzip || data.options.brotli) && (o$1(k$1, { children: [o$1("br", {}), o$1("small", { children: COMPRESSED })] }))] }));
+      }, [availableSizeProperties, data, getModuleSize, node, root.data, sizeProperty]);
+      const updatePosition = (mouseCoords) => {
+          if (!ref.current)
+              return;
+          const pos = {
+              left: mouseCoords.x + Tooltip_marginX,
+              top: mouseCoords.y + Tooltip_marginY,
+          };
+          const boundingRect = ref.current.getBoundingClientRect();
+          if (pos.left + boundingRect.width > window.innerWidth) {
+              // Shifting horizontally
+              pos.left = window.innerWidth - boundingRect.width;
+          }
+          if (pos.top + boundingRect.height > window.innerHeight) {
+              // Flipping vertically
+              pos.top = mouseCoords.y - Tooltip_marginY - boundingRect.height;
+          }
+          setStyle(pos);
+      };
+      p(() => {
+          const handleMouseMove = (event) => {
+              updatePosition({
+                  x: event.pageX,
+                  y: event.pageY,
+              });
+          };
+          document.addEventListener("mousemove", handleMouseMove, true);
+          return () => {
+              document.removeEventListener("mousemove", handleMouseMove, true);
+          };
+      }, []);
+      return (o$1("div", { className: `tooltip ${visible ? "" : "tooltip-hidden"}`, ref: ref, style: style, children: content }));
+  };
+
+  const Chart = ({ root, sizeProperty, selectedNode, setSelectedNode, }) => {
+      const [showTooltip, setShowTooltip] = h(false);
+      const [tooltipNode, setTooltipNode] = h(undefined);
+      p(() => {
+          const handleMouseOut = () => {
+              setShowTooltip(false);
+          };
+          document.addEventListener("mouseover", handleMouseOut);
+          return () => {
+              document.removeEventListener("mouseover", handleMouseOut);
+          };
+      }, []);
+      return (o$1(k$1, { children: [o$1(TreeMap, { root: root, onNodeHover: (node) => {
+                      setTooltipNode(node);
+                      setShowTooltip(true);
+                  }, selectedNode: selectedNode, onNodeClick: (node) => {
+                      setSelectedNode(selectedNode === node ? undefined : node);
+                  } }), o$1(Tooltip, { visible: showTooltip, node: tooltipNode, root: root, sizeProperty: sizeProperty })] }));
+  };
+
+  const Main = () => {
+      const { availableSizeProperties, rawHierarchy, getModuleSize, layout, data } = q(StaticContext);
+      const [sizeProperty, setSizeProperty] = h(availableSizeProperties[0]);
+      const [selectedNode, setSelectedNode] = h(undefined);
+      const { getModuleFilterMultiplier, setExcludeFilter, setIncludeFilter } = useFilter();
+      console.time("getNodeSizeMultiplier");
+      const getNodeSizeMultiplier = F(() => {
+          const selectedMultiplier = 1; // selectedSize < rootSize * increaseFactor ? (rootSize * increaseFactor) / selectedSize : rootSize / selectedSize;
+          const nonSelectedMultiplier = 0; // 1 / selectedMultiplier
+          if (selectedNode === undefined) {
+              return () => 1;
+          }
+          else if (isModuleTree(selectedNode.data)) {
+              const leaves = new Set(selectedNode.leaves().map((d) => d.data));
+              return (node) => {
+                  if (leaves.has(node)) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+          else {
+              return (node) => {
+                  if (node === selectedNode.data) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+      }, [getModuleSize, rawHierarchy.data, selectedNode, sizeProperty]);
+      console.timeEnd("getNodeSizeMultiplier");
+      console.time("root hierarchy compute");
+      // root here always be the same as rawHierarchy even after layouting
+      const root = F(() => {
+          const rootWithSizesAndSorted = rawHierarchy
+              .sum((node) => {
+              var _a;
+              if (isModuleTree(node))
+                  return 0;
+              const meta = data.nodeMetas[data.nodeParts[node.uid].metaUid];
+              const bundleId = (_a = Object.entries(meta.moduleParts).find(([bundleId, uid]) => uid == node.uid)) === null || _a === void 0 ? void 0 : _a[0];
+              const ownSize = getModuleSize(node, sizeProperty);
+              const zoomMultiplier = getNodeSizeMultiplier(node);
+              const filterMultiplier = getModuleFilterMultiplier(bundleId, meta);
+              return ownSize * zoomMultiplier * filterMultiplier;
+          })
+              .sort((a, b) => getModuleSize(a.data, sizeProperty) - getModuleSize(b.data, sizeProperty));
+          return layout(rootWithSizesAndSorted);
+      }, [
+          data,
+          getModuleFilterMultiplier,
+          getModuleSize,
+          getNodeSizeMultiplier,
+          layout,
+          rawHierarchy,
+          sizeProperty,
+      ]);
+      console.timeEnd("root hierarchy compute");
+      return (o$1(k$1, { children: [o$1(SideBar, { sizeProperty: sizeProperty, availableSizeProperties: availableSizeProperties, setSizeProperty: setSizeProperty, onExcludeChange: setExcludeFilter, onIncludeChange: setIncludeFilter }), o$1(Chart, { root: root, sizeProperty: sizeProperty, selectedNode: selectedNode, setSelectedNode: setSelectedNode })] }));
+  };
+
+  function initRange(domain, range) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: this.range(domain); break;
+      default: this.range(range).domain(domain); break;
+    }
+    return this;
+  }
+
+  function initInterpolator(domain, interpolator) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: {
+        if (typeof domain === "function") this.interpolator(domain);
+        else this.range(domain);
+        break;
+      }
+      default: {
+        this.domain(domain);
+        if (typeof interpolator === "function") this.interpolator(interpolator);
+        else this.range(interpolator);
+        break;
+      }
+    }
+    return this;
+  }
+
+  function define(constructor, factory, prototype) {
+    constructor.prototype = factory.prototype = prototype;
+    prototype.constructor = constructor;
+  }
+
+  function extend(parent, definition) {
+    var prototype = Object.create(parent.prototype);
+    for (var key in definition) prototype[key] = definition[key];
+    return prototype;
+  }
+
+  function Color() {}
+
+  var darker = 0.7;
+  var brighter = 1 / darker;
+
+  var reI = "\\s*([+-]?\\d+)\\s*",
+      reN = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*",
+      reP = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*",
+      reHex = /^#([0-9a-f]{3,8})$/,
+      reRgbInteger = new RegExp(`^rgb\\(${reI},${reI},${reI}\\)$`),
+      reRgbPercent = new RegExp(`^rgb\\(${reP},${reP},${reP}\\)$`),
+      reRgbaInteger = new RegExp(`^rgba\\(${reI},${reI},${reI},${reN}\\)$`),
+      reRgbaPercent = new RegExp(`^rgba\\(${reP},${reP},${reP},${reN}\\)$`),
+      reHslPercent = new RegExp(`^hsl\\(${reN},${reP},${reP}\\)$`),
+      reHslaPercent = new RegExp(`^hsla\\(${reN},${reP},${reP},${reN}\\)$`);
+
+  var named = {
+    aliceblue: 0xf0f8ff,
+    antiquewhite: 0xfaebd7,
+    aqua: 0x00ffff,
+    aquamarine: 0x7fffd4,
+    azure: 0xf0ffff,
+    beige: 0xf5f5dc,
+    bisque: 0xffe4c4,
+    black: 0x000000,
+    blanchedalmond: 0xffebcd,
+    blue: 0x0000ff,
+    blueviolet: 0x8a2be2,
+    brown: 0xa52a2a,
+    burlywood: 0xdeb887,
+    cadetblue: 0x5f9ea0,
+    chartreuse: 0x7fff00,
+    chocolate: 0xd2691e,
+    coral: 0xff7f50,
+    cornflowerblue: 0x6495ed,
+    cornsilk: 0xfff8dc,
+    crimson: 0xdc143c,
+    cyan: 0x00ffff,
+    darkblue: 0x00008b,
+    darkcyan: 0x008b8b,
+    darkgoldenrod: 0xb8860b,
+    darkgray: 0xa9a9a9,
+    darkgreen: 0x006400,
+    darkgrey: 0xa9a9a9,
+    darkkhaki: 0xbdb76b,
+    darkmagenta: 0x8b008b,
+    darkolivegreen: 0x556b2f,
+    darkorange: 0xff8c00,
+    darkorchid: 0x9932cc,
+    darkred: 0x8b0000,
+    darksalmon: 0xe9967a,
+    darkseagreen: 0x8fbc8f,
+    darkslateblue: 0x483d8b,
+    darkslategray: 0x2f4f4f,
+    darkslategrey: 0x2f4f4f,
+    darkturquoise: 0x00ced1,
+    darkviolet: 0x9400d3,
+    deeppink: 0xff1493,
+    deepskyblue: 0x00bfff,
+    dimgray: 0x696969,
+    dimgrey: 0x696969,
+    dodgerblue: 0x1e90ff,
+    firebrick: 0xb22222,
+    floralwhite: 0xfffaf0,
+    forestgreen: 0x228b22,
+    fuchsia: 0xff00ff,
+    gainsboro: 0xdcdcdc,
+    ghostwhite: 0xf8f8ff,
+    gold: 0xffd700,
+    goldenrod: 0xdaa520,
+    gray: 0x808080,
+    green: 0x008000,
+    greenyellow: 0xadff2f,
+    grey: 0x808080,
+    honeydew: 0xf0fff0,
+    hotpink: 0xff69b4,
+    indianred: 0xcd5c5c,
+    indigo: 0x4b0082,
+    ivory: 0xfffff0,
+    khaki: 0xf0e68c,
+    lavender: 0xe6e6fa,
+    lavenderblush: 0xfff0f5,
+    lawngreen: 0x7cfc00,
+    lemonchiffon: 0xfffacd,
+    lightblue: 0xadd8e6,
+    lightcoral: 0xf08080,
+    lightcyan: 0xe0ffff,
+    lightgoldenrodyellow: 0xfafad2,
+    lightgray: 0xd3d3d3,
+    lightgreen: 0x90ee90,
+    lightgrey: 0xd3d3d3,
+    lightpink: 0xffb6c1,
+    lightsalmon: 0xffa07a,
+    lightseagreen: 0x20b2aa,
+    lightskyblue: 0x87cefa,
+    lightslategray: 0x778899,
+    lightslategrey: 0x778899,
+    lightsteelblue: 0xb0c4de,
+    lightyellow: 0xffffe0,
+    lime: 0x00ff00,
+    limegreen: 0x32cd32,
+    linen: 0xfaf0e6,
+    magenta: 0xff00ff,
+    maroon: 0x800000,
+    mediumaquamarine: 0x66cdaa,
+    mediumblue: 0x0000cd,
+    mediumorchid: 0xba55d3,
+    mediumpurple: 0x9370db,
+    mediumseagreen: 0x3cb371,
+    mediumslateblue: 0x7b68ee,
+    mediumspringgreen: 0x00fa9a,
+    mediumturquoise: 0x48d1cc,
+    mediumvioletred: 0xc71585,
+    midnightblue: 0x191970,
+    mintcream: 0xf5fffa,
+    mistyrose: 0xffe4e1,
+    moccasin: 0xffe4b5,
+    navajowhite: 0xffdead,
+    navy: 0x000080,
+    oldlace: 0xfdf5e6,
+    olive: 0x808000,
+    olivedrab: 0x6b8e23,
+    orange: 0xffa500,
+    orangered: 0xff4500,
+    orchid: 0xda70d6,
+    palegoldenrod: 0xeee8aa,
+    palegreen: 0x98fb98,
+    paleturquoise: 0xafeeee,
+    palevioletred: 0xdb7093,
+    papayawhip: 0xffefd5,
+    peachpuff: 0xffdab9,
+    peru: 0xcd853f,
+    pink: 0xffc0cb,
+    plum: 0xdda0dd,
+    powderblue: 0xb0e0e6,
+    purple: 0x800080,
+    rebeccapurple: 0x663399,
+    red: 0xff0000,
+    rosybrown: 0xbc8f8f,
+    royalblue: 0x4169e1,
+    saddlebrown: 0x8b4513,
+    salmon: 0xfa8072,
+    sandybrown: 0xf4a460,
+    seagreen: 0x2e8b57,
+    seashell: 0xfff5ee,
+    sienna: 0xa0522d,
+    silver: 0xc0c0c0,
+    skyblue: 0x87ceeb,
+    slateblue: 0x6a5acd,
+    slategray: 0x708090,
+    slategrey: 0x708090,
+    snow: 0xfffafa,
+    springgreen: 0x00ff7f,
+    steelblue: 0x4682b4,
+    tan: 0xd2b48c,
+    teal: 0x008080,
+    thistle: 0xd8bfd8,
+    tomato: 0xff6347,
+    turquoise: 0x40e0d0,
+    violet: 0xee82ee,
+    wheat: 0xf5deb3,
+    white: 0xffffff,
+    whitesmoke: 0xf5f5f5,
+    yellow: 0xffff00,
+    yellowgreen: 0x9acd32
+  };
+
+  define(Color, color, {
+    copy(channels) {
+      return Object.assign(new this.constructor, this, channels);
+    },
+    displayable() {
+      return this.rgb().displayable();
+    },
+    hex: color_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: color_formatHex,
+    formatHex8: color_formatHex8,
+    formatHsl: color_formatHsl,
+    formatRgb: color_formatRgb,
+    toString: color_formatRgb
+  });
+
+  function color_formatHex() {
+    return this.rgb().formatHex();
+  }
+
+  function color_formatHex8() {
+    return this.rgb().formatHex8();
+  }
+
+  function color_formatHsl() {
+    return hslConvert(this).formatHsl();
+  }
+
+  function color_formatRgb() {
+    return this.rgb().formatRgb();
+  }
+
+  function color(format) {
+    var m, l;
+    format = (format + "").trim().toLowerCase();
+    return (m = reHex.exec(format)) ? (l = m[1].length, m = parseInt(m[1], 16), l === 6 ? rgbn(m) // #ff0000
+        : l === 3 ? new Rgb((m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), ((m & 0xf) << 4) | (m & 0xf), 1) // #f00
+        : l === 8 ? rgba(m >> 24 & 0xff, m >> 16 & 0xff, m >> 8 & 0xff, (m & 0xff) / 0xff) // #ff000000
+        : l === 4 ? rgba((m >> 12 & 0xf) | (m >> 8 & 0xf0), (m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), (((m & 0xf) << 4) | (m & 0xf)) / 0xff) // #f000
+        : null) // invalid hex
+        : (m = reRgbInteger.exec(format)) ? new Rgb(m[1], m[2], m[3], 1) // rgb(255, 0, 0)
+        : (m = reRgbPercent.exec(format)) ? new Rgb(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, 1) // rgb(100%, 0%, 0%)
+        : (m = reRgbaInteger.exec(format)) ? rgba(m[1], m[2], m[3], m[4]) // rgba(255, 0, 0, 1)
+        : (m = reRgbaPercent.exec(format)) ? rgba(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, m[4]) // rgb(100%, 0%, 0%, 1)
+        : (m = reHslPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, 1) // hsl(120, 50%, 50%)
+        : (m = reHslaPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, m[4]) // hsla(120, 50%, 50%, 1)
+        : named.hasOwnProperty(format) ? rgbn(named[format]) // eslint-disable-line no-prototype-builtins
+        : format === "transparent" ? new Rgb(NaN, NaN, NaN, 0)
+        : null;
+  }
+
+  function rgbn(n) {
+    return new Rgb(n >> 16 & 0xff, n >> 8 & 0xff, n & 0xff, 1);
+  }
+
+  function rgba(r, g, b, a) {
+    if (a <= 0) r = g = b = NaN;
+    return new Rgb(r, g, b, a);
+  }
+
+  function rgbConvert(o) {
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Rgb;
+    o = o.rgb();
+    return new Rgb(o.r, o.g, o.b, o.opacity);
+  }
+
+  function rgb$1(r, g, b, opacity) {
+    return arguments.length === 1 ? rgbConvert(r) : new Rgb(r, g, b, opacity == null ? 1 : opacity);
+  }
+
+  function Rgb(r, g, b, opacity) {
+    this.r = +r;
+    this.g = +g;
+    this.b = +b;
+    this.opacity = +opacity;
+  }
+
+  define(Rgb, rgb$1, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    rgb() {
+      return this;
+    },
+    clamp() {
+      return new Rgb(clampi(this.r), clampi(this.g), clampi(this.b), clampa(this.opacity));
+    },
+    displayable() {
+      return (-0.5 <= this.r && this.r < 255.5)
+          && (-0.5 <= this.g && this.g < 255.5)
+          && (-0.5 <= this.b && this.b < 255.5)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    hex: rgb_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: rgb_formatHex,
+    formatHex8: rgb_formatHex8,
+    formatRgb: rgb_formatRgb,
+    toString: rgb_formatRgb
+  }));
+
+  function rgb_formatHex() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}`;
+  }
+
+  function rgb_formatHex8() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}${hex((isNaN(this.opacity) ? 1 : this.opacity) * 255)}`;
+  }
+
+  function rgb_formatRgb() {
+    const a = clampa(this.opacity);
+    return `${a === 1 ? "rgb(" : "rgba("}${clampi(this.r)}, ${clampi(this.g)}, ${clampi(this.b)}${a === 1 ? ")" : `, ${a})`}`;
+  }
+
+  function clampa(opacity) {
+    return isNaN(opacity) ? 1 : Math.max(0, Math.min(1, opacity));
+  }
+
+  function clampi(value) {
+    return Math.max(0, Math.min(255, Math.round(value) || 0));
+  }
+
+  function hex(value) {
+    value = clampi(value);
+    return (value < 16 ? "0" : "") + value.toString(16);
+  }
+
+  function hsla(h, s, l, a) {
+    if (a <= 0) h = s = l = NaN;
+    else if (l <= 0 || l >= 1) h = s = NaN;
+    else if (s <= 0) h = NaN;
+    return new Hsl(h, s, l, a);
+  }
+
+  function hslConvert(o) {
+    if (o instanceof Hsl) return new Hsl(o.h, o.s, o.l, o.opacity);
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Hsl;
+    if (o instanceof Hsl) return o;
+    o = o.rgb();
+    var r = o.r / 255,
+        g = o.g / 255,
+        b = o.b / 255,
+        min = Math.min(r, g, b),
+        max = Math.max(r, g, b),
+        h = NaN,
+        s = max - min,
+        l = (max + min) / 2;
+    if (s) {
+      if (r === max) h = (g - b) / s + (g < b) * 6;
+      else if (g === max) h = (b - r) / s + 2;
+      else h = (r - g) / s + 4;
+      s /= l < 0.5 ? max + min : 2 - max - min;
+      h *= 60;
+    } else {
+      s = l > 0 && l < 1 ? 0 : h;
+    }
+    return new Hsl(h, s, l, o.opacity);
+  }
+
+  function hsl(h, s, l, opacity) {
+    return arguments.length === 1 ? hslConvert(h) : new Hsl(h, s, l, opacity == null ? 1 : opacity);
+  }
+
+  function Hsl(h, s, l, opacity) {
+    this.h = +h;
+    this.s = +s;
+    this.l = +l;
+    this.opacity = +opacity;
+  }
+
+  define(Hsl, hsl, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    rgb() {
+      var h = this.h % 360 + (this.h < 0) * 360,
+          s = isNaN(h) || isNaN(this.s) ? 0 : this.s,
+          l = this.l,
+          m2 = l + (l < 0.5 ? l : 1 - l) * s,
+          m1 = 2 * l - m2;
+      return new Rgb(
+        hsl2rgb(h >= 240 ? h - 240 : h + 120, m1, m2),
+        hsl2rgb(h, m1, m2),
+        hsl2rgb(h < 120 ? h + 240 : h - 120, m1, m2),
+        this.opacity
+      );
+    },
+    clamp() {
+      return new Hsl(clamph(this.h), clampt(this.s), clampt(this.l), clampa(this.opacity));
+    },
+    displayable() {
+      return (0 <= this.s && this.s <= 1 || isNaN(this.s))
+          && (0 <= this.l && this.l <= 1)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    formatHsl() {
+      const a = clampa(this.opacity);
+      return `${a === 1 ? "hsl(" : "hsla("}${clamph(this.h)}, ${clampt(this.s) * 100}%, ${clampt(this.l) * 100}%${a === 1 ? ")" : `, ${a})`}`;
+    }
+  }));
+
+  function clamph(value) {
+    value = (value || 0) % 360;
+    return value < 0 ? value + 360 : value;
+  }
+
+  function clampt(value) {
+    return Math.max(0, Math.min(1, value || 0));
+  }
+
+  /* From FvD 13.37, CSS Color Module Level 3 */
+  function hsl2rgb(h, m1, m2) {
+    return (h < 60 ? m1 + (m2 - m1) * h / 60
+        : h < 180 ? m2
+        : h < 240 ? m1 + (m2 - m1) * (240 - h) / 60
+        : m1) * 255;
+  }
+
+  var constant = x => () => x;
+
+  function linear$1(a, d) {
+    return function(t) {
+      return a + t * d;
+    };
+  }
+
+  function exponential(a, b, y) {
+    return a = Math.pow(a, y), b = Math.pow(b, y) - a, y = 1 / y, function(t) {
+      return Math.pow(a + t * b, y);
+    };
+  }
+
+  function gamma(y) {
+    return (y = +y) === 1 ? nogamma : function(a, b) {
+      return b - a ? exponential(a, b, y) : constant(isNaN(a) ? b : a);
+    };
+  }
+
+  function nogamma(a, b) {
+    var d = b - a;
+    return d ? linear$1(a, d) : constant(isNaN(a) ? b : a);
+  }
+
+  var rgb = (function rgbGamma(y) {
+    var color = gamma(y);
+
+    function rgb(start, end) {
+      var r = color((start = rgb$1(start)).r, (end = rgb$1(end)).r),
+          g = color(start.g, end.g),
+          b = color(start.b, end.b),
+          opacity = nogamma(start.opacity, end.opacity);
+      return function(t) {
+        start.r = r(t);
+        start.g = g(t);
+        start.b = b(t);
+        start.opacity = opacity(t);
+        return start + "";
+      };
+    }
+
+    rgb.gamma = rgbGamma;
+
+    return rgb;
+  })(1);
+
+  function numberArray(a, b) {
+    if (!b) b = [];
+    var n = a ? Math.min(b.length, a.length) : 0,
+        c = b.slice(),
+        i;
+    return function(t) {
+      for (i = 0; i < n; ++i) c[i] = a[i] * (1 - t) + b[i] * t;
+      return c;
+    };
+  }
+
+  function isNumberArray(x) {
+    return ArrayBuffer.isView(x) && !(x instanceof DataView);
+  }
+
+  function genericArray(a, b) {
+    var nb = b ? b.length : 0,
+        na = a ? Math.min(nb, a.length) : 0,
+        x = new Array(na),
+        c = new Array(nb),
+        i;
+
+    for (i = 0; i < na; ++i) x[i] = interpolate(a[i], b[i]);
+    for (; i < nb; ++i) c[i] = b[i];
+
+    return function(t) {
+      for (i = 0; i < na; ++i) c[i] = x[i](t);
+      return c;
+    };
+  }
+
+  function date(a, b) {
+    var d = new Date;
+    return a = +a, b = +b, function(t) {
+      return d.setTime(a * (1 - t) + b * t), d;
+    };
+  }
+
+  function interpolateNumber(a, b) {
+    return a = +a, b = +b, function(t) {
+      return a * (1 - t) + b * t;
+    };
+  }
+
+  function object(a, b) {
+    var i = {},
+        c = {},
+        k;
+
+    if (a === null || typeof a !== "object") a = {};
+    if (b === null || typeof b !== "object") b = {};
+
+    for (k in b) {
+      if (k in a) {
+        i[k] = interpolate(a[k], b[k]);
+      } else {
+        c[k] = b[k];
+      }
+    }
+
+    return function(t) {
+      for (k in i) c[k] = i[k](t);
+      return c;
+    };
+  }
+
+  var reA = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g,
+      reB = new RegExp(reA.source, "g");
+
+  function zero(b) {
+    return function() {
+      return b;
+    };
+  }
+
+  function one(b) {
+    return function(t) {
+      return b(t) + "";
+    };
+  }
+
+  function string(a, b) {
+    var bi = reA.lastIndex = reB.lastIndex = 0, // scan index for next number in b
+        am, // current match in a
+        bm, // current match in b
+        bs, // string preceding current number in b, if any
+        i = -1, // index in s
+        s = [], // string constants and placeholders
+        q = []; // number interpolators
+
+    // Coerce inputs to strings.
+    a = a + "", b = b + "";
+
+    // Interpolate pairs of numbers in a & b.
+    while ((am = reA.exec(a))
+        && (bm = reB.exec(b))) {
+      if ((bs = bm.index) > bi) { // a string precedes the next number in b
+        bs = b.slice(bi, bs);
+        if (s[i]) s[i] += bs; // coalesce with previous string
+        else s[++i] = bs;
+      }
+      if ((am = am[0]) === (bm = bm[0])) { // numbers in a & b match
+        if (s[i]) s[i] += bm; // coalesce with previous string
+        else s[++i] = bm;
+      } else { // interpolate non-matching numbers
+        s[++i] = null;
+        q.push({i: i, x: interpolateNumber(am, bm)});
+      }
+      bi = reB.lastIndex;
+    }
+
+    // Add remains of b.
+    if (bi < b.length) {
+      bs = b.slice(bi);
+      if (s[i]) s[i] += bs; // coalesce with previous string
+      else s[++i] = bs;
+    }
+
+    // Special optimization for only a single match.
+    // Otherwise, interpolate each of the numbers and rejoin the string.
+    return s.length < 2 ? (q[0]
+        ? one(q[0].x)
+        : zero(b))
+        : (b = q.length, function(t) {
+            for (var i = 0, o; i < b; ++i) s[(o = q[i]).i] = o.x(t);
+            return s.join("");
+          });
+  }
+
+  function interpolate(a, b) {
+    var t = typeof b, c;
+    return b == null || t === "boolean" ? constant(b)
+        : (t === "number" ? interpolateNumber
+        : t === "string" ? ((c = color(b)) ? (b = c, rgb) : string)
+        : b instanceof color ? rgb
+        : b instanceof Date ? date
+        : isNumberArray(b) ? numberArray
+        : Array.isArray(b) ? genericArray
+        : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
+        : interpolateNumber)(a, b);
+  }
+
+  function interpolateRound(a, b) {
+    return a = +a, b = +b, function(t) {
+      return Math.round(a * (1 - t) + b * t);
+    };
+  }
+
+  function constants(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function number(x) {
+    return +x;
+  }
+
+  var unit = [0, 1];
+
+  function identity$1(x) {
+    return x;
+  }
+
+  function normalize(a, b) {
+    return (b -= (a = +a))
+        ? function(x) { return (x - a) / b; }
+        : constants(isNaN(b) ? NaN : 0.5);
+  }
+
+  function clamper(a, b) {
+    var t;
+    if (a > b) t = a, a = b, b = t;
+    return function(x) { return Math.max(a, Math.min(b, x)); };
+  }
+
+  // normalize(a, b)(x) takes a domain value x in [a,b] and returns the corresponding parameter t in [0,1].
+  // interpolate(a, b)(t) takes a parameter t in [0,1] and returns the corresponding range value x in [a,b].
+  function bimap(domain, range, interpolate) {
+    var d0 = domain[0], d1 = domain[1], r0 = range[0], r1 = range[1];
+    if (d1 < d0) d0 = normalize(d1, d0), r0 = interpolate(r1, r0);
+    else d0 = normalize(d0, d1), r0 = interpolate(r0, r1);
+    return function(x) { return r0(d0(x)); };
+  }
+
+  function polymap(domain, range, interpolate) {
+    var j = Math.min(domain.length, range.length) - 1,
+        d = new Array(j),
+        r = new Array(j),
+        i = -1;
+
+    // Reverse descending domains.
+    if (domain[j] < domain[0]) {
+      domain = domain.slice().reverse();
+      range = range.slice().reverse();
+    }
+
+    while (++i < j) {
+      d[i] = normalize(domain[i], domain[i + 1]);
+      r[i] = interpolate(range[i], range[i + 1]);
+    }
+
+    return function(x) {
+      var i = bisect(domain, x, 1, j) - 1;
+      return r[i](d[i](x));
+    };
+  }
+
+  function copy$1(source, target) {
+    return target
+        .domain(source.domain())
+        .range(source.range())
+        .interpolate(source.interpolate())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function transformer$1() {
+    var domain = unit,
+        range = unit,
+        interpolate$1 = interpolate,
+        transform,
+        untransform,
+        unknown,
+        clamp = identity$1,
+        piecewise,
+        output,
+        input;
+
+    function rescale() {
+      var n = Math.min(domain.length, range.length);
+      if (clamp !== identity$1) clamp = clamper(domain[0], domain[n - 1]);
+      piecewise = n > 2 ? polymap : bimap;
+      output = input = null;
+      return scale;
+    }
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : (output || (output = piecewise(domain.map(transform), range, interpolate$1)))(transform(clamp(x)));
+    }
+
+    scale.invert = function(y) {
+      return clamp(untransform((input || (input = piecewise(range, domain.map(transform), interpolateNumber)))(y)));
+    };
+
+    scale.domain = function(_) {
+      return arguments.length ? (domain = Array.from(_, number), rescale()) : domain.slice();
+    };
+
+    scale.range = function(_) {
+      return arguments.length ? (range = Array.from(_), rescale()) : range.slice();
+    };
+
+    scale.rangeRound = function(_) {
+      return range = Array.from(_), interpolate$1 = interpolateRound, rescale();
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = _ ? true : identity$1, rescale()) : clamp !== identity$1;
+    };
+
+    scale.interpolate = function(_) {
+      return arguments.length ? (interpolate$1 = _, rescale()) : interpolate$1;
+    };
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t, u) {
+      transform = t, untransform = u;
+      return rescale();
+    };
+  }
+
+  function continuous() {
+    return transformer$1()(identity$1, identity$1);
+  }
+
+  function formatDecimal(x) {
+    return Math.abs(x = Math.round(x)) >= 1e21
+        ? x.toLocaleString("en").replace(/,/g, "")
+        : x.toString(10);
+  }
+
+  // Computes the decimal coefficient and exponent of the specified number x with
+  // significant digits p, where x is positive and p is in [1, 21] or undefined.
+  // For example, formatDecimalParts(1.23) returns ["123", 0].
+  function formatDecimalParts(x, p) {
+    if ((i = (x = p ? x.toExponential(p - 1) : x.toExponential()).indexOf("e")) < 0) return null; // NaN, ±Infinity
+    var i, coefficient = x.slice(0, i);
+
+    // The string returned by toExponential either has the form \d\.\d+e[-+]\d+
+    // (e.g., 1.2e+3) or the form \de[-+]\d+ (e.g., 1e+3).
+    return [
+      coefficient.length > 1 ? coefficient[0] + coefficient.slice(2) : coefficient,
+      +x.slice(i + 1)
+    ];
+  }
+
+  function exponent(x) {
+    return x = formatDecimalParts(Math.abs(x)), x ? x[1] : NaN;
+  }
+
+  function formatGroup(grouping, thousands) {
+    return function(value, width) {
+      var i = value.length,
+          t = [],
+          j = 0,
+          g = grouping[0],
+          length = 0;
+
+      while (i > 0 && g > 0) {
+        if (length + g + 1 > width) g = Math.max(1, width - length);
+        t.push(value.substring(i -= g, i + g));
+        if ((length += g + 1) > width) break;
+        g = grouping[j = (j + 1) % grouping.length];
+      }
+
+      return t.reverse().join(thousands);
+    };
+  }
+
+  function formatNumerals(numerals) {
+    return function(value) {
+      return value.replace(/[0-9]/g, function(i) {
+        return numerals[+i];
+      });
+    };
+  }
+
+  // [[fill]align][sign][symbol][0][width][,][.precision][~][type]
+  var re = /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
+
+  function formatSpecifier(specifier) {
+    if (!(match = re.exec(specifier))) throw new Error("invalid format: " + specifier);
+    var match;
+    return new FormatSpecifier({
+      fill: match[1],
+      align: match[2],
+      sign: match[3],
+      symbol: match[4],
+      zero: match[5],
+      width: match[6],
+      comma: match[7],
+      precision: match[8] && match[8].slice(1),
+      trim: match[9],
+      type: match[10]
+    });
+  }
+
+  formatSpecifier.prototype = FormatSpecifier.prototype; // instanceof
+
+  function FormatSpecifier(specifier) {
+    this.fill = specifier.fill === undefined ? " " : specifier.fill + "";
+    this.align = specifier.align === undefined ? ">" : specifier.align + "";
+    this.sign = specifier.sign === undefined ? "-" : specifier.sign + "";
+    this.symbol = specifier.symbol === undefined ? "" : specifier.symbol + "";
+    this.zero = !!specifier.zero;
+    this.width = specifier.width === undefined ? undefined : +specifier.width;
+    this.comma = !!specifier.comma;
+    this.precision = specifier.precision === undefined ? undefined : +specifier.precision;
+    this.trim = !!specifier.trim;
+    this.type = specifier.type === undefined ? "" : specifier.type + "";
+  }
+
+  FormatSpecifier.prototype.toString = function() {
+    return this.fill
+        + this.align
+        + this.sign
+        + this.symbol
+        + (this.zero ? "0" : "")
+        + (this.width === undefined ? "" : Math.max(1, this.width | 0))
+        + (this.comma ? "," : "")
+        + (this.precision === undefined ? "" : "." + Math.max(0, this.precision | 0))
+        + (this.trim ? "~" : "")
+        + this.type;
+  };
+
+  // Trims insignificant zeros, e.g., replaces 1.2000k with 1.2k.
+  function formatTrim(s) {
+    out: for (var n = s.length, i = 1, i0 = -1, i1; i < n; ++i) {
+      switch (s[i]) {
+        case ".": i0 = i1 = i; break;
+        case "0": if (i0 === 0) i0 = i; i1 = i; break;
+        default: if (!+s[i]) break out; if (i0 > 0) i0 = 0; break;
+      }
+    }
+    return i0 > 0 ? s.slice(0, i0) + s.slice(i1 + 1) : s;
+  }
+
+  var prefixExponent;
+
+  function formatPrefixAuto(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1],
+        i = exponent - (prefixExponent = Math.max(-8, Math.min(8, Math.floor(exponent / 3))) * 3) + 1,
+        n = coefficient.length;
+    return i === n ? coefficient
+        : i > n ? coefficient + new Array(i - n + 1).join("0")
+        : i > 0 ? coefficient.slice(0, i) + "." + coefficient.slice(i)
+        : "0." + new Array(1 - i).join("0") + formatDecimalParts(x, Math.max(0, p + i - 1))[0]; // less than 1y!
+  }
+
+  function formatRounded(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1];
+    return exponent < 0 ? "0." + new Array(-exponent).join("0") + coefficient
+        : coefficient.length > exponent + 1 ? coefficient.slice(0, exponent + 1) + "." + coefficient.slice(exponent + 1)
+        : coefficient + new Array(exponent - coefficient.length + 2).join("0");
+  }
+
+  var formatTypes = {
+    "%": (x, p) => (x * 100).toFixed(p),
+    "b": (x) => Math.round(x).toString(2),
+    "c": (x) => x + "",
+    "d": formatDecimal,
+    "e": (x, p) => x.toExponential(p),
+    "f": (x, p) => x.toFixed(p),
+    "g": (x, p) => x.toPrecision(p),
+    "o": (x) => Math.round(x).toString(8),
+    "p": (x, p) => formatRounded(x * 100, p),
+    "r": formatRounded,
+    "s": formatPrefixAuto,
+    "X": (x) => Math.round(x).toString(16).toUpperCase(),
+    "x": (x) => Math.round(x).toString(16)
+  };
+
+  function identity(x) {
+    return x;
+  }
+
+  var map = Array.prototype.map,
+      prefixes = ["y","z","a","f","p","n","µ","m","","k","M","G","T","P","E","Z","Y"];
+
+  function formatLocale(locale) {
+    var group = locale.grouping === undefined || locale.thousands === undefined ? identity : formatGroup(map.call(locale.grouping, Number), locale.thousands + ""),
+        currencyPrefix = locale.currency === undefined ? "" : locale.currency[0] + "",
+        currencySuffix = locale.currency === undefined ? "" : locale.currency[1] + "",
+        decimal = locale.decimal === undefined ? "." : locale.decimal + "",
+        numerals = locale.numerals === undefined ? identity : formatNumerals(map.call(locale.numerals, String)),
+        percent = locale.percent === undefined ? "%" : locale.percent + "",
+        minus = locale.minus === undefined ? "−" : locale.minus + "",
+        nan = locale.nan === undefined ? "NaN" : locale.nan + "";
+
+    function newFormat(specifier) {
+      specifier = formatSpecifier(specifier);
+
+      var fill = specifier.fill,
+          align = specifier.align,
+          sign = specifier.sign,
+          symbol = specifier.symbol,
+          zero = specifier.zero,
+          width = specifier.width,
+          comma = specifier.comma,
+          precision = specifier.precision,
+          trim = specifier.trim,
+          type = specifier.type;
+
+      // The "n" type is an alias for ",g".
+      if (type === "n") comma = true, type = "g";
+
+      // The "" type, and any invalid type, is an alias for ".12~g".
+      else if (!formatTypes[type]) precision === undefined && (precision = 12), trim = true, type = "g";
+
+      // If zero fill is specified, padding goes after sign and before digits.
+      if (zero || (fill === "0" && align === "=")) zero = true, fill = "0", align = "=";
+
+      // Compute the prefix and suffix.
+      // For SI-prefix, the suffix is lazily computed.
+      var prefix = symbol === "$" ? currencyPrefix : symbol === "#" && /[boxX]/.test(type) ? "0" + type.toLowerCase() : "",
+          suffix = symbol === "$" ? currencySuffix : /[%p]/.test(type) ? percent : "";
+
+      // What format function should we use?
+      // Is this an integer type?
+      // Can this type generate exponential notation?
+      var formatType = formatTypes[type],
+          maybeSuffix = /[defgprs%]/.test(type);
+
+      // Set the default precision if not specified,
+      // or clamp the specified precision to the supported range.
+      // For significant precision, it must be in [1, 21].
+      // For fixed precision, it must be in [0, 20].
+      precision = precision === undefined ? 6
+          : /[gprs]/.test(type) ? Math.max(1, Math.min(21, precision))
+          : Math.max(0, Math.min(20, precision));
+
+      function format(value) {
+        var valuePrefix = prefix,
+            valueSuffix = suffix,
+            i, n, c;
+
+        if (type === "c") {
+          valueSuffix = formatType(value) + valueSuffix;
+          value = "";
+        } else {
+          value = +value;
+
+          // Determine the sign. -0 is not less than 0, but 1 / -0 is!
+          var valueNegative = value < 0 || 1 / value < 0;
+
+          // Perform the initial formatting.
+          value = isNaN(value) ? nan : formatType(Math.abs(value), precision);
+
+          // Trim insignificant zeros.
+          if (trim) value = formatTrim(value);
+
+          // If a negative value rounds to zero after formatting, and no explicit positive sign is requested, hide the sign.
+          if (valueNegative && +value === 0 && sign !== "+") valueNegative = false;
+
+          // Compute the prefix and suffix.
+          valuePrefix = (valueNegative ? (sign === "(" ? sign : minus) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
+          valueSuffix = (type === "s" ? prefixes[8 + prefixExponent / 3] : "") + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
+
+          // Break the formatted value into the integer “value” part that can be
+          // grouped, and fractional or exponential “suffix” part that is not.
+          if (maybeSuffix) {
+            i = -1, n = value.length;
+            while (++i < n) {
+              if (c = value.charCodeAt(i), 48 > c || c > 57) {
+                valueSuffix = (c === 46 ? decimal + value.slice(i + 1) : value.slice(i)) + valueSuffix;
+                value = value.slice(0, i);
+                break;
+              }
+            }
+          }
+        }
+
+        // If the fill character is not "0", grouping is applied before padding.
+        if (comma && !zero) value = group(value, Infinity);
+
+        // Compute the padding.
+        var length = valuePrefix.length + value.length + valueSuffix.length,
+            padding = length < width ? new Array(width - length + 1).join(fill) : "";
+
+        // If the fill character is "0", grouping is applied after padding.
+        if (comma && zero) value = group(padding + value, padding.length ? width - valueSuffix.length : Infinity), padding = "";
+
+        // Reconstruct the final output based on the desired alignment.
+        switch (align) {
+          case "<": value = valuePrefix + value + valueSuffix + padding; break;
+          case "=": value = valuePrefix + padding + value + valueSuffix; break;
+          case "^": value = padding.slice(0, length = padding.length >> 1) + valuePrefix + value + valueSuffix + padding.slice(length); break;
+          default: value = padding + valuePrefix + value + valueSuffix; break;
+        }
+
+        return numerals(value);
+      }
+
+      format.toString = function() {
+        return specifier + "";
+      };
+
+      return format;
+    }
+
+    function formatPrefix(specifier, value) {
+      var f = newFormat((specifier = formatSpecifier(specifier), specifier.type = "f", specifier)),
+          e = Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3,
+          k = Math.pow(10, -e),
+          prefix = prefixes[8 + e / 3];
+      return function(value) {
+        return f(k * value) + prefix;
+      };
+    }
+
+    return {
+      format: newFormat,
+      formatPrefix: formatPrefix
+    };
+  }
+
+  var locale;
+  var format;
+  var formatPrefix;
+
+  defaultLocale({
+    thousands: ",",
+    grouping: [3],
+    currency: ["$", ""]
+  });
+
+  function defaultLocale(definition) {
+    locale = formatLocale(definition);
+    format = locale.format;
+    formatPrefix = locale.formatPrefix;
+    return locale;
+  }
+
+  function precisionFixed(step) {
+    return Math.max(0, -exponent(Math.abs(step)));
+  }
+
+  function precisionPrefix(step, value) {
+    return Math.max(0, Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3 - exponent(Math.abs(step)));
+  }
+
+  function precisionRound(step, max) {
+    step = Math.abs(step), max = Math.abs(max) - step;
+    return Math.max(0, exponent(max) - exponent(step)) + 1;
+  }
+
+  function tickFormat(start, stop, count, specifier) {
+    var step = tickStep(start, stop, count),
+        precision;
+    specifier = formatSpecifier(specifier == null ? ",f" : specifier);
+    switch (specifier.type) {
+      case "s": {
+        var value = Math.max(Math.abs(start), Math.abs(stop));
+        if (specifier.precision == null && !isNaN(precision = precisionPrefix(step, value))) specifier.precision = precision;
+        return formatPrefix(specifier, value);
+      }
+      case "":
+      case "e":
+      case "g":
+      case "p":
+      case "r": {
+        if (specifier.precision == null && !isNaN(precision = precisionRound(step, Math.max(Math.abs(start), Math.abs(stop))))) specifier.precision = precision - (specifier.type === "e");
+        break;
+      }
+      case "f":
+      case "%": {
+        if (specifier.precision == null && !isNaN(precision = precisionFixed(step))) specifier.precision = precision - (specifier.type === "%") * 2;
+        break;
+      }
+    }
+    return format(specifier);
+  }
+
+  function linearish(scale) {
+    var domain = scale.domain;
+
+    scale.ticks = function(count) {
+      var d = domain();
+      return ticks(d[0], d[d.length - 1], count == null ? 10 : count);
+    };
+
+    scale.tickFormat = function(count, specifier) {
+      var d = domain();
+      return tickFormat(d[0], d[d.length - 1], count == null ? 10 : count, specifier);
+    };
+
+    scale.nice = function(count) {
+      if (count == null) count = 10;
+
+      var d = domain();
+      var i0 = 0;
+      var i1 = d.length - 1;
+      var start = d[i0];
+      var stop = d[i1];
+      var prestep;
+      var step;
+      var maxIter = 10;
+
+      if (stop < start) {
+        step = start, start = stop, stop = step;
+        step = i0, i0 = i1, i1 = step;
+      }
+      
+      while (maxIter-- > 0) {
+        step = tickIncrement(start, stop, count);
+        if (step === prestep) {
+          d[i0] = start;
+          d[i1] = stop;
+          return domain(d);
+        } else if (step > 0) {
+          start = Math.floor(start / step) * step;
+          stop = Math.ceil(stop / step) * step;
+        } else if (step < 0) {
+          start = Math.ceil(start * step) / step;
+          stop = Math.floor(stop * step) / step;
+        } else {
+          break;
+        }
+        prestep = step;
+      }
+
+      return scale;
+    };
+
+    return scale;
+  }
+
+  function linear() {
+    var scale = continuous();
+
+    scale.copy = function() {
+      return copy$1(scale, linear());
+    };
+
+    initRange.apply(scale, arguments);
+
+    return linearish(scale);
+  }
+
+  function transformer() {
+    var x0 = 0,
+        x1 = 1,
+        t0,
+        t1,
+        k10,
+        transform,
+        interpolator = identity$1,
+        clamp = false,
+        unknown;
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : interpolator(k10 === 0 ? 0.5 : (x = (transform(x) - t0) * k10, clamp ? Math.max(0, Math.min(1, x)) : x));
+    }
+
+    scale.domain = function(_) {
+      return arguments.length ? ([x0, x1] = _, t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0), scale) : [x0, x1];
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = !!_, scale) : clamp;
+    };
+
+    scale.interpolator = function(_) {
+      return arguments.length ? (interpolator = _, scale) : interpolator;
+    };
+
+    function range(interpolate) {
+      return function(_) {
+        var r0, r1;
+        return arguments.length ? ([r0, r1] = _, interpolator = interpolate(r0, r1), scale) : [interpolator(0), interpolator(1)];
+      };
+    }
+
+    scale.range = range(interpolate);
+
+    scale.rangeRound = range(interpolateRound);
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t) {
+      transform = t, t0 = t(x0), t1 = t(x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0);
+      return scale;
+    };
+  }
+
+  function copy(source, target) {
+    return target
+        .domain(source.domain())
+        .interpolator(source.interpolator())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function sequential() {
+    var scale = linearish(transformer()(identity$1));
+
+    scale.copy = function() {
+      return copy(scale, sequential());
+    };
+
+    return initInterpolator.apply(scale, arguments);
+  }
+
+  const COLOR_BASE = "#cecece";
+
+  // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+  const rc = 0.2126;
+  const gc = 0.7152;
+  const bc = 0.0722;
+  // low-gamma adjust coefficient
+  const lowc = 1 / 12.92;
+  function adjustGamma(p) {
+      return Math.pow((p + 0.055) / 1.055, 2.4);
+  }
+  function relativeLuminance(o) {
+      const rsrgb = o.r / 255;
+      const gsrgb = o.g / 255;
+      const bsrgb = o.b / 255;
+      const r = rsrgb <= 0.03928 ? rsrgb * lowc : adjustGamma(rsrgb);
+      const g = gsrgb <= 0.03928 ? gsrgb * lowc : adjustGamma(gsrgb);
+      const b = bsrgb <= 0.03928 ? bsrgb * lowc : adjustGamma(bsrgb);
+      return r * rc + g * gc + b * bc;
+  }
+  const createRainbowColor = (root) => {
+      const colorParentMap = new Map();
+      colorParentMap.set(root, COLOR_BASE);
+      if (root.children != null) {
+          const colorScale = sequential([0, root.children.length], (n) => hsl(360 * n, 0.3, 0.85));
+          root.children.forEach((c, id) => {
+              colorParentMap.set(c, colorScale(id).toString());
+          });
+      }
+      const colorMap = new Map();
+      const lightScale = linear().domain([0, root.height]).range([0.9, 0.3]);
+      const getBackgroundColor = (node) => {
+          const parents = node.ancestors();
+          const colorStr = parents.length === 1
+              ? colorParentMap.get(parents[0])
+              : colorParentMap.get(parents[parents.length - 2]);
+          const hslColor = hsl(colorStr);
+          hslColor.l = lightScale(node.depth);
+          return hslColor;
+      };
+      return (node) => {
+          if (!colorMap.has(node)) {
+              const backgroundColor = getBackgroundColor(node);
+              const l = relativeLuminance(backgroundColor.rgb());
+              const fontColor = l > 0.19 ? "#000" : "#fff";
+              colorMap.set(node, {
+                  backgroundColor: backgroundColor.toString(),
+                  fontColor,
+              });
+          }
+          return colorMap.get(node);
+      };
+  };
+
+  const StaticContext = G({});
+  const drawChart = (parentNode, data, width, height) => {
+      const availableSizeProperties = getAvailableSizeOptions(data.options);
+      console.time("layout create");
+      const layout = treemap()
+          .size([width, height])
+          .paddingOuter(PADDING)
+          .paddingTop(TOP_PADDING)
+          .paddingInner(PADDING)
+          .round(true)
+          .tile(treemapResquarify);
+      console.timeEnd("layout create");
+      console.time("rawHierarchy create");
+      const rawHierarchy = hierarchy(data.tree);
+      console.timeEnd("rawHierarchy create");
+      const nodeSizesCache = new Map();
+      const nodeIdsCache = new Map();
+      const getModuleSize = (node, sizeKey) => { var _a, _b; return (_b = (_a = nodeSizesCache.get(node)) === null || _a === void 0 ? void 0 : _a[sizeKey]) !== null && _b !== void 0 ? _b : 0; };
+      console.time("rawHierarchy eachAfter cache");
+      rawHierarchy.eachAfter((node) => {
+          var _a;
+          const nodeData = node.data;
+          nodeIdsCache.set(nodeData, {
+              nodeUid: generateUniqueId("node"),
+              clipUid: generateUniqueId("clip"),
+          });
+          const sizes = { renderedLength: 0, gzipLength: 0, brotliLength: 0 };
+          if (isModuleTree(nodeData)) {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = nodeData.children.reduce((acc, child) => getModuleSize(child, sizeKey) + acc, 0);
+              }
+          }
+          else {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = (_a = data.nodeParts[nodeData.uid][sizeKey]) !== null && _a !== void 0 ? _a : 0;
+              }
+          }
+          nodeSizesCache.set(nodeData, sizes);
+      });
+      console.timeEnd("rawHierarchy eachAfter cache");
+      const getModuleIds = (node) => nodeIdsCache.get(node);
+      console.time("color");
+      const getModuleColor = createRainbowColor(rawHierarchy);
+      console.timeEnd("color");
+      D(o$1(StaticContext.Provider, { value: {
+              data,
+              availableSizeProperties,
+              width,
+              height,
+              getModuleSize,
+              getModuleIds,
+              getModuleColor,
+              rawHierarchy,
+              layout,
+          }, children: o$1(Main, {}) }), parentNode);
+  };
+
+  exports.StaticContext = StaticContext;
+  exports.default = drawChart;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+  return exports;
+
+})({});
+
+  /*-->*/
+  </script>
+  <script>
+    /*<!--*/
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"metamask-sdk.js","children":[{"uid":"5277-5592","name":"\u0000commonjsHelpers.js"},{"name":"\u0000","children":[{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"eciesjs","children":[{"name":"dist","children":[{"uid":"5277-5594","name":"index.js?commonjs-exports"},{"name":"keys","children":[{"uid":"5277-5596","name":"index.js?commonjs-exports"},{"uid":"5277-5598","name":"PrivateKey.js?commonjs-exports"},{"uid":"5277-5730","name":"PublicKey.js?commonjs-exports"}]},{"uid":"5277-5722","name":"utils.js?commonjs-exports"},{"uid":"5277-5724","name":"consts.js?commonjs-exports"}]},{"name":"node_modules/secp256k1/index.js?commonjs-module","uid":"5277-5602"}]},{"name":"node-gyp-build/index.js?commonjs-module","uid":"5277-5604"},{"name":"elliptic","children":[{"name":"lib","children":[{"uid":"5277-5616","name":"elliptic.js?commonjs-exports"},{"name":"elliptic","children":[{"uid":"5277-5620","name":"utils.js?commonjs-exports"},{"name":"curve/index.js?commonjs-exports","uid":"5277-5638"},{"uid":"5277-5658","name":"curves.js?commonjs-exports"}]}]},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-5622"}]},{"name":"minimalistic-crypto-utils/lib/utils.js?commonjs-exports","uid":"5277-5628"},{"name":"brorand/index.js?commonjs-module","uid":"5277-5634"},{"name":"inherits","children":[{"uid":"5277-5642","name":"inherits.js?commonjs-module"},{"uid":"5277-5644","name":"inherits_browser.js?commonjs-module"}]},{"name":"hash.js/lib","children":[{"uid":"5277-5660","name":"hash.js?commonjs-exports"},{"name":"hash","children":[{"uid":"5277-5662","name":"utils.js?commonjs-exports"},{"uid":"5277-5666","name":"common.js?commonjs-exports"},{"uid":"5277-5670","name":"sha.js?commonjs-exports"},{"name":"sha/common.js?commonjs-exports","uid":"5277-5672"},{"uid":"5277-5688","name":"ripemd.js?commonjs-exports"}]}]},{"name":"eventemitter2/lib/eventemitter2.js?commonjs-module","uid":"5277-5740"},{"name":"debug/src","children":[{"uid":"5277-5768","name":"index.js?commonjs-module"},{"uid":"5277-5770","name":"browser.js?commonjs-module"},{"uid":"5277-5778","name":"node.js?commonjs-module"}]},{"name":"engine.io-client/node_modules/ws/lib","children":[{"uid":"5277-5800","name":"buffer-util.js?commonjs-module"},{"uid":"5277-5816","name":"validation.js?commonjs-module"}]},{"name":"bufferutil/index.js?commonjs-module","uid":"5277-5804"},{"name":"utf-8-validate/index.js?commonjs-module","uid":"5277-5818"},{"name":"cross-fetch","children":[{"name":"dist/node-ponyfill.js?commonjs-module","uid":"5277-5868"},{"name":"node_modules/node-fetch/lib/index.mjs?commonjs-proxy","uid":"5277-5900"}]},{"name":"whatwg-url/lib","children":[{"uid":"5277-5870","name":"public-api.js?commonjs-exports"},{"uid":"5277-5872","name":"URL.js?commonjs-module"},{"uid":"5277-5876","name":"utils.js?commonjs-module"},{"uid":"5277-5880","name":"URL-impl.js?commonjs-exports"},{"uid":"5277-5882","name":"url-state-machine.js?commonjs-module"}]},{"name":"tr46/index.js?commonjs-exports","uid":"5277-5884"},{"name":"@metamask","children":[{"name":"providers/dist","children":[{"uid":"5277-5908","name":"index.js?commonjs-exports"},{"uid":"5277-5910","name":"BaseProvider.js?commonjs-exports"},{"uid":"5277-5968","name":"messages.js?commonjs-exports"},{"uid":"5277-5972","name":"utils.js?commonjs-exports"},{"name":"middleware/createRpcWarningMiddleware.js?commonjs-exports","uid":"5277-5974"},{"name":"extension-provider/createExternalExtensionProvider.js?commonjs-exports","uid":"5277-5982"},{"uid":"5277-5992","name":"MetaMaskInpageProvider.js?commonjs-exports"},{"uid":"5277-5994","name":"siteMetadata.js?commonjs-exports"},{"uid":"5277-5998","name":"StreamProvider.js?commonjs-exports"},{"uid":"5277-6088","name":"initializeInpageProvider.js?commonjs-exports"},{"uid":"5277-6090","name":"shimWeb3.js?commonjs-exports"}]},{"name":"safe-event-emitter/index.js?commonjs-exports","uid":"5277-5912"},{"name":"object-multiplex/dist","children":[{"uid":"5277-6000","name":"ObjectMultiplex.js?commonjs-exports"},{"uid":"5277-6052","name":"Substream.js?commonjs-exports"}]}]},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-5916","name":"index.js?commonjs-exports"},{"uid":"5277-5918","name":"classes.js?commonjs-exports"},{"uid":"5277-5924","name":"utils.js?commonjs-exports"},{"uid":"5277-5926","name":"error-constants.js?commonjs-exports"},{"uid":"5277-5932","name":"errors.js?commonjs-exports"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-5940","name":"index.js?commonjs-exports"},{"uid":"5277-5942","name":"idRemapMiddleware.js?commonjs-exports"},{"uid":"5277-5944","name":"getUniqueId.js?commonjs-exports"},{"uid":"5277-5950","name":"createAsyncMiddleware.js?commonjs-exports"},{"uid":"5277-5954","name":"createScaffoldMiddleware.js?commonjs-exports"},{"uid":"5277-5958","name":"JsonRpcEngine.js?commonjs-exports"},{"uid":"5277-5962","name":"mergeMiddleware.js?commonjs-exports"}]},{"name":"extension-port-stream/dist/index.js?commonjs-exports","uid":"5277-5984"},{"name":"detect-browser/es/index.js?commonjs-proxy","uid":"5277-5990"},{"name":"readable-stream","children":[{"uid":"5277-6002","name":"readable.js?commonjs-module"},{"name":"node_modules","children":[{"name":"safe-buffer/index.js?commonjs-module","uid":"5277-6012"},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-6032"}]},{"name":"lib/internal/streams/BufferList.js?commonjs-module","uid":"5277-6020"}]},{"name":"process-nextick-args/index.js?commonjs-module","uid":"5277-6004"},{"name":"core-util-is/lib/util.js?commonjs-exports","uid":"5277-6016"},{"name":"once/once.js?commonjs-module","uid":"5277-6044"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-6062","name":"index.js?commonjs-exports"},{"uid":"5277-6064","name":"createEngineStream.js?commonjs-exports"},{"uid":"5277-6068","name":"createStreamMiddleware.js?commonjs-exports"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","uid":"5277-6070"}]},{"name":"react","children":[{"uid":"5277-6316","name":"index.js?commonjs-module"},{"name":"cjs","children":[{"uid":"5277-6318","name":"react.production.min.js?commonjs-exports"},{"uid":"5277-6322","name":"react.development.js?commonjs-module"}]}]},{"name":"react-i18next/node_modules/@babel/runtime/helpers/extends.js?commonjs-module","uid":"5277-6328"}]},{"name":"node_modules","children":[{"name":"cross-fetch/dist/node-ponyfill.js?commonjs-module","uid":"5277-6178"},{"name":"node-fetch/lib/index.mjs?commonjs-proxy","uid":"5277-6182"}]}]},{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"futoin-hkdf/hkdf.js","uid":"5277-5600"},{"name":"node-gyp-build","children":[{"uid":"5277-5608","name":"node-gyp-build.js"},{"uid":"5277-5610","name":"index.js"}]},{"name":"eciesjs","children":[{"name":"node_modules/secp256k1","children":[{"name":"lib","children":[{"uid":"5277-5612","name":"index.js"},{"uid":"5277-5716","name":"elliptic.js"}]},{"uid":"5277-5614","name":"bindings.js"},{"uid":"5277-5718","name":"elliptic.js"},{"uid":"5277-5720","name":"index.js"}]},{"name":"dist","children":[{"uid":"5277-5726","name":"consts.js"},{"uid":"5277-5728","name":"utils.js"},{"name":"keys","children":[{"uid":"5277-5732","name":"PublicKey.js"},{"uid":"5277-5734","name":"PrivateKey.js"},{"uid":"5277-5736","name":"index.js"}]},{"uid":"5277-5738","name":"index.js"}]}]},{"name":"elliptic","children":[{"uid":"5277-5618","name":"package.json"},{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-5624"},{"name":"lib","children":[{"name":"elliptic","children":[{"uid":"5277-5632","name":"utils.js"},{"name":"curve","children":[{"uid":"5277-5640","name":"base.js"},{"uid":"5277-5650","name":"short.js"},{"uid":"5277-5652","name":"mont.js"},{"uid":"5277-5654","name":"edwards.js"},{"uid":"5277-5656","name":"index.js"}]},{"name":"precomputed/secp256k1.js","uid":"5277-5696"},{"uid":"5277-5698","name":"curves.js"},{"name":"ec","children":[{"uid":"5277-5702","name":"key.js"},{"uid":"5277-5704","name":"signature.js"},{"uid":"5277-5706","name":"index.js"}]},{"name":"eddsa","children":[{"uid":"5277-5708","name":"key.js"},{"uid":"5277-5710","name":"signature.js"},{"uid":"5277-5712","name":"index.js"}]}]},{"uid":"5277-5714","name":"elliptic.js"}]}]},{"name":"minimalistic-assert/index.js","uid":"5277-5626"},{"name":"minimalistic-crypto-utils/lib/utils.js","uid":"5277-5630"},{"name":"brorand/index.js","uid":"5277-5636"},{"name":"inherits","children":[{"uid":"5277-5646","name":"inherits_browser.js"},{"uid":"5277-5648","name":"inherits.js"}]},{"name":"hash.js/lib","children":[{"name":"hash","children":[{"uid":"5277-5664","name":"utils.js"},{"uid":"5277-5668","name":"common.js"},{"name":"sha","children":[{"uid":"5277-5674","name":"common.js"},{"uid":"5277-5676","name":"1.js"},{"uid":"5277-5678","name":"256.js"},{"uid":"5277-5680","name":"224.js"},{"uid":"5277-5682","name":"512.js"},{"uid":"5277-5684","name":"384.js"}]},{"uid":"5277-5686","name":"sha.js"},{"uid":"5277-5690","name":"ripemd.js"},{"uid":"5277-5692","name":"hmac.js"}]},{"uid":"5277-5694","name":"hash.js"}]},{"name":"hmac-drbg/lib/hmac-drbg.js","uid":"5277-5700"},{"name":"eventemitter2/lib/eventemitter2.js","uid":"5277-5742"},{"name":"uuid/dist/esm-node","children":[{"uid":"5277-5744","name":"rng.js"},{"uid":"5277-5746","name":"regex.js"},{"uid":"5277-5748","name":"validate.js"},{"uid":"5277-5750","name":"stringify.js"},{"uid":"5277-5752","name":"v4.js"}]},{"name":"engine.io-parser/build/esm","children":[{"uid":"5277-5754","name":"commons.js"},{"uid":"5277-5756","name":"encodePacket.js"},{"uid":"5277-5758","name":"decodePacket.js"},{"uid":"5277-5760","name":"index.js"}]},{"name":"@socket.io/component-emitter/index.mjs","uid":"5277-5762"},{"name":"engine.io-client","children":[{"name":"build/esm-debug","children":[{"uid":"5277-5764","name":"globalThis.js"},{"uid":"5277-5766","name":"util.js"},{"name":"contrib","children":[{"uid":"5277-5788","name":"parseqs.js"},{"uid":"5277-5792","name":"yeast.js"},{"uid":"5277-5846","name":"parseuri.js"}]},{"uid":"5277-5790","name":"transport.js"},{"name":"transports","children":[{"uid":"5277-5796","name":"xmlhttprequest.js"},{"uid":"5277-5798","name":"polling.js"},{"uid":"5277-5838","name":"websocket-constructor.js"},{"uid":"5277-5840","name":"websocket.js"},{"uid":"5277-5842","name":"webtransport.js"},{"uid":"5277-5844","name":"index.js"}]},{"uid":"5277-5848","name":"socket.js"}]},{"name":"node_modules/ws","children":[{"name":"lib","children":[{"uid":"5277-5802","name":"constants.js"},{"uid":"5277-5810","name":"buffer-util.js"},{"uid":"5277-5812","name":"limiter.js"},{"uid":"5277-5814","name":"permessage-deflate.js"},{"uid":"5277-5824","name":"validation.js"},{"uid":"5277-5826","name":"receiver.js"},{"uid":"5277-5828","name":"sender.js"},{"uid":"5277-5830","name":"event-target.js"},{"uid":"5277-5832","name":"extension.js"},{"uid":"5277-5834","name":"websocket.js"}]},{"uid":"5277-5836","name":"wrapper.mjs"}]}]},{"name":"debug","children":[{"name":"node_modules/ms/index.js","uid":"5277-5772"},{"name":"src","children":[{"uid":"5277-5774","name":"common.js"},{"uid":"5277-5776","name":"browser.js"},{"uid":"5277-5784","name":"node.js"},{"uid":"5277-5786","name":"index.js"}]}]},{"name":"has-flag/index.js","uid":"5277-5780"},{"name":"supports-color/index.js","uid":"5277-5782"},{"name":"xmlhttprequest-ssl/lib/XMLHttpRequest.js","uid":"5277-5794"},{"name":"bufferutil","children":[{"uid":"5277-5806","name":"fallback.js"},{"uid":"5277-5808","name":"index.js"}]},{"name":"utf-8-validate","children":[{"uid":"5277-5820","name":"fallback.js"},{"uid":"5277-5822","name":"index.js"}]},{"name":"socket.io-client/build/esm-debug","children":[{"uid":"5277-5850","name":"url.js"},{"uid":"5277-5858","name":"on.js"},{"uid":"5277-5860","name":"socket.js"},{"name":"contrib/backo2.js","uid":"5277-5862"},{"uid":"5277-5864","name":"manager.js"},{"uid":"5277-5866","name":"index.js"}]},{"name":"socket.io-parser/build/esm-debug","children":[{"uid":"5277-5852","name":"is-binary.js"},{"uid":"5277-5854","name":"binary.js"},{"uid":"5277-5856","name":"index.js"}]},{"name":"whatwg-url","children":[{"name":"node_modules/webidl-conversions/lib/index.js","uid":"5277-5874"},{"name":"lib","children":[{"uid":"5277-5878","name":"utils.js"},{"uid":"5277-5890","name":"url-state-machine.js"},{"uid":"5277-5892","name":"URL-impl.js"},{"uid":"5277-5894","name":"URL.js"},{"uid":"5277-5896","name":"public-api.js"}]}]},{"name":"tr46","children":[{"name":"lib/mappingTable.json","uid":"5277-5886"},{"uid":"5277-5888","name":"index.js"}]},{"name":"cross-fetch","children":[{"name":"node_modules/node-fetch/lib/index.mjs","uid":"5277-5898"},{"name":"dist/node-ponyfill.js","uid":"5277-5902"}]},{"name":"@metamask","children":[{"name":"safe-event-emitter/index.js","uid":"5277-5914"},{"name":"providers","children":[{"name":"node_modules/fast-deep-equal/index.js","uid":"5277-5938"},{"name":"dist","children":[{"uid":"5277-5970","name":"messages.js"},{"name":"middleware/createRpcWarningMiddleware.js","uid":"5277-5976"},{"uid":"5277-5978","name":"utils.js"},{"uid":"5277-5980","name":"BaseProvider.js"},{"uid":"5277-5996","name":"siteMetadata.js"},{"uid":"5277-6080","name":"StreamProvider.js"},{"uid":"5277-6082","name":"MetaMaskInpageProvider.js"},{"name":"extension-provider","children":[{"uid":"5277-6084","name":"external-extension-config.json"},{"uid":"5277-6086","name":"createExternalExtensionProvider.js"}]},{"uid":"5277-6092","name":"shimWeb3.js"},{"uid":"5277-6094","name":"initializeInpageProvider.js"},{"uid":"5277-6096","name":"index.js"}]}]},{"name":"object-multiplex/dist","children":[{"uid":"5277-6054","name":"Substream.js"},{"uid":"5277-6056","name":"ObjectMultiplex.js"},{"uid":"5277-6058","name":"index.js"}]},{"name":"onboarding/dist/metamask-onboarding.es.js","uid":"5277-6254"}]},{"name":"fast-safe-stringify/index.js","uid":"5277-5920"},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-5922","name":"classes.js"},{"uid":"5277-5928","name":"error-constants.js"},{"uid":"5277-5930","name":"utils.js"},{"uid":"5277-5934","name":"errors.js"},{"uid":"5277-5936","name":"index.js"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-5946","name":"getUniqueId.js"},{"uid":"5277-5948","name":"idRemapMiddleware.js"},{"uid":"5277-5952","name":"createAsyncMiddleware.js"},{"uid":"5277-5956","name":"createScaffoldMiddleware.js"},{"uid":"5277-5960","name":"JsonRpcEngine.js"},{"uid":"5277-5964","name":"mergeMiddleware.js"},{"uid":"5277-5966","name":"index.js"}]},{"name":"extension-port-stream/dist/index.js","uid":"5277-5986"},{"name":"detect-browser/es/index.js","uid":"5277-5988"},{"name":"process-nextick-args/index.js","uid":"5277-6006"},{"name":"readable-stream","children":[{"name":"node_modules","children":[{"name":"isarray/index.js","uid":"5277-6008"},{"name":"safe-buffer/index.js","uid":"5277-6014"},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-6034"}]},{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-6010","name":"stream.js"},{"uid":"5277-6022","name":"BufferList.js"},{"uid":"5277-6024","name":"destroy.js"}]},{"uid":"5277-6028","name":"_stream_writable.js"},{"uid":"5277-6030","name":"_stream_duplex.js"},{"uid":"5277-6036","name":"_stream_readable.js"},{"uid":"5277-6038","name":"_stream_transform.js"},{"uid":"5277-6040","name":"_stream_passthrough.js"}]},{"uid":"5277-6042","name":"readable.js"}]},{"name":"core-util-is/lib/util.js","uid":"5277-6018"},{"name":"util-deprecate/node.js","uid":"5277-6026"},{"name":"wrappy/wrappy.js","uid":"5277-6046"},{"name":"once/once.js","uid":"5277-6048"},{"name":"end-of-stream/index.js","uid":"5277-6050"},{"name":"is-stream/index.js","uid":"5277-6060"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-6066","name":"createEngineStream.js"},{"uid":"5277-6074","name":"createStreamMiddleware.js"},{"uid":"5277-6076","name":"index.js"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js","uid":"5277-6072"}]},{"name":"pump/index.js","uid":"5277-6078"},{"name":"i18next","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-6108","name":"typeof.js"},{"uid":"5277-6110","name":"classCallCheck.js"},{"uid":"5277-6112","name":"toPrimitive.js"},{"uid":"5277-6114","name":"toPropertyKey.js"},{"uid":"5277-6116","name":"createClass.js"},{"uid":"5277-6118","name":"assertThisInitialized.js"},{"uid":"5277-6120","name":"setPrototypeOf.js"},{"uid":"5277-6122","name":"inherits.js"},{"uid":"5277-6124","name":"possibleConstructorReturn.js"},{"uid":"5277-6126","name":"getPrototypeOf.js"},{"uid":"5277-6128","name":"defineProperty.js"},{"uid":"5277-6130","name":"arrayWithHoles.js"},{"uid":"5277-6132","name":"iterableToArray.js"},{"uid":"5277-6134","name":"arrayLikeToArray.js"},{"uid":"5277-6136","name":"unsupportedIterableToArray.js"},{"uid":"5277-6138","name":"nonIterableRest.js"},{"uid":"5277-6140","name":"toArray.js"}]},{"name":"dist/esm/i18next.js","uid":"5277-6142"}]},{"name":"bowser/src","children":[{"uid":"5277-6210","name":"constants.js"},{"uid":"5277-6212","name":"utils.js"},{"uid":"5277-6214","name":"parser-browsers.js"},{"uid":"5277-6216","name":"parser-os.js"},{"uid":"5277-6218","name":"parser-platforms.js"},{"uid":"5277-6220","name":"parser-engines.js"},{"uid":"5277-6222","name":"parser.js"},{"uid":"5277-6224","name":"bowser.js"}]},{"name":"i18next-browser-languagedetector","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-6304","name":"classCallCheck.js"},{"uid":"5277-6306","name":"typeof.js"},{"uid":"5277-6308","name":"toPrimitive.js"},{"uid":"5277-6310","name":"toPropertyKey.js"},{"uid":"5277-6312","name":"createClass.js"}]},{"name":"dist/esm/i18nextBrowserLanguageDetector.js","uid":"5277-6314"}]},{"name":"react","children":[{"name":"cjs","children":[{"uid":"5277-6320","name":"react.production.min.js"},{"uid":"5277-6324","name":"react.development.js"}]},{"uid":"5277-6326","name":"index.js"}]},{"name":"react-i18next","children":[{"name":"node_modules/@babel/runtime/helpers/extends.js","uid":"5277-6330"},{"name":"dist/es","children":[{"uid":"5277-6332","name":"unescape.js"},{"uid":"5277-6334","name":"defaults.js"},{"uid":"5277-6336","name":"initReactI18next.js"},{"uid":"5277-6338","name":"context.js"}]}]}]},{"uid":"5277-5606","name":"\u0000commonjs-dynamic-modules"},{"name":"-communication-layer/dist/node/es/metamask-sdk-communication-layer.js","uid":"5277-5904"},{"uid":"5277-5906","name":"\u0000tslib.js"},{"name":"src","children":[{"name":"services","children":[{"name":"SDKProvider","children":[{"name":"ChainManager/handleChainChanged.ts","uid":"5277-6098"},{"name":"ConnectionManager/handleDisconnect.ts","uid":"5277-6100"},{"name":"InitializationManager","children":[{"uid":"5277-6102","name":"initializeState.ts"},{"uid":"5277-6104","name":"initializeStateAsync.ts"}]}]},{"name":"MetaMaskSDK","children":[{"name":"ConnectionManager","children":[{"uid":"5277-6144","name":"connect.ts"},{"uid":"5277-6146","name":"resume.ts"},{"uid":"5277-6152","name":"terminate.ts"},{"uid":"5277-6360","name":"connectAndSign.ts"}]},{"name":"ProviderManager/connectWithExtensionProvider.ts","uid":"5277-6154"},{"name":"InitializerManager","children":[{"uid":"5277-6158","name":"handleAutoAndExtensionConnections.ts"},{"uid":"5277-6160","name":"initEventListeners.ts"},{"uid":"5277-6192","name":"initializeProviderAndEventListeners.ts"},{"uid":"5277-6194","name":"setupAnalytics.ts"},{"uid":"5277-6200","name":"setupDappMetadata.ts"},{"uid":"5277-6208","name":"setupExtensionPreferences.ts"},{"uid":"5277-6248","name":"setupPlatformManager.ts"},{"uid":"5277-6292","name":"setupRemoteConnectionAndInstaller.ts"},{"uid":"5277-6298","name":"setupStorage.ts"},{"uid":"5277-6300","name":"setupInfuraProvider.ts"},{"uid":"5277-6302","name":"setupReadOnlyRPCProviders.ts"},{"uid":"5277-6354","name":"initializeI18next.ts"},{"uid":"5277-6356","name":"performSDKInitialization.ts"},{"uid":"5277-6358","name":"initializeMetaMaskSDK.ts"}]}]},{"uid":"5277-6156","name":"Analytics.ts"},{"name":"RemoteCommunicationPostMessageStream","children":[{"uid":"5277-6164","name":"onMessage.ts"},{"uid":"5277-6168","name":"extractMethod.ts"},{"uid":"5277-6170","name":"write.ts"}]},{"uid":"5277-6166","name":"Ethereum.ts"},{"name":"rpc-requests/RPCRequestHandler.ts","uid":"5277-6186"},{"name":"PlatfformManager","children":[{"uid":"5277-6228","name":"disableWakeLock.ts"},{"uid":"5277-6230","name":"enableWakeLock.ts"},{"uid":"5277-6232","name":"getPlatformType.ts"},{"uid":"5277-6234","name":"isMetaMaskInstalled.ts"},{"uid":"5277-6236","name":"openDeeplink.ts"}]},{"name":"MetaMaskInstaller","children":[{"uid":"5277-6250","name":"checkInstallation.ts"},{"uid":"5277-6252","name":"redirectToProperInstall.ts"},{"uid":"5277-6256","name":"startDesktopOnboarding.ts"},{"uid":"5277-6258","name":"startInstaller.ts"}]},{"name":"RemoteConnection","children":[{"name":"ConnectionInitializer/initializeConnector.ts","uid":"5277-6270"},{"name":"ConnectionManager","children":[{"uid":"5277-6272","name":"connectWithDeeplink.ts"},{"uid":"5277-6276","name":"connectWithModalInstaller.ts"},{"uid":"5277-6284","name":"startConnection.ts"}]},{"name":"ModalManager","children":[{"uid":"5277-6274","name":"showInstallModal.ts"},{"uid":"5277-6278","name":"onOTPModalDisconnect.ts"},{"uid":"5277-6280","name":"waitForOTPAnswer.ts"},{"uid":"5277-6282","name":"reconnectWithModalOTP.ts"},{"uid":"5277-6288","name":"showActiveModal.ts"}]},{"name":"EventListeners/setupListeners.ts","uid":"5277-6286"},{"uid":"5277-6290","name":"RemoteConnection.ts"}]}]},{"name":"provider","children":[{"uid":"5277-6106","name":"SDKProvider.ts"},{"uid":"5277-6190","name":"initializeMobileProvider.ts"},{"uid":"5277-6202","name":"wrapExtensionProvider.ts"}]},{"uid":"5277-6148","name":"config.ts"},{"name":"types","children":[{"uid":"5277-6150","name":"ProviderUpdateType.ts"},{"uid":"5277-6226","name":"WakeLockStatus.ts"}]},{"uid":"5277-6162","name":"constants.ts"},{"name":"PostMessageStream","children":[{"uid":"5277-6172","name":"RemoteCommunicationPostMessageStream.ts"},{"uid":"5277-6174","name":"getPostMessageStream.ts"}]},{"name":"utils","children":[{"uid":"5277-6176","name":"wait.ts"},{"uid":"5277-6196","name":"extractFavicon.ts"},{"uid":"5277-6198","name":"getBase64FromUrl.ts"},{"uid":"5277-6204","name":"eip6963RequestProvider.ts"},{"uid":"5277-6206","name":"get-browser-extension.ts"},{"uid":"5277-6238","name":"hasNativeWakeLockSupport.ts"},{"uid":"5277-6240","name":"isOldIOS.ts"}]},{"name":"Platform","children":[{"uid":"5277-6242","name":"Media.ts"},{"uid":"5277-6244","name":"WakeLockManager.ts"},{"uid":"5277-6246","name":"PlatfformManager.ts"},{"uid":"5277-6260","name":"MetaMaskInstaller.ts"}]},{"name":"ui/InstallModal","children":[{"uid":"5277-6262","name":"InstallModal-nodejs.ts"},{"uid":"5277-6264","name":"installModal.ts"},{"uid":"5277-6266","name":"pendingModal-nodejs.ts"},{"uid":"5277-6268","name":"pendingModal.ts"}]},{"name":"storage-manager","children":[{"uid":"5277-6294","name":"StorageManagerNode.ts"},{"uid":"5277-6296","name":"getStorageManager.ts"}]},{"name":"locales","children":[{"uid":"5277-6340","name":"en.json"},{"uid":"5277-6342","name":"es.json"},{"uid":"5277-6344","name":"fr.json"},{"uid":"5277-6346","name":"he.json"},{"uid":"5277-6348","name":"it.json"},{"uid":"5277-6350","name":"pt.json"},{"uid":"5277-6352","name":"tr.json"}]},{"uid":"5277-6362","name":"sdk.ts"},{"uid":"5277-6364","name":"index.ts"}]},{"name":"node_modules","children":[{"name":"node-fetch/lib/index.mjs","uid":"5277-6180"},{"name":"cross-fetch/dist/node-ponyfill.js","uid":"5277-6184"}]},{"uid":"5277-6188","name":"package.json"}]}],"isRoot":true},"nodeParts":{"5277-5592":{"renderedLength":943,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5591"},"5277-5594":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5593"},"5277-5596":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5595"},"5277-5598":{"renderedLength":22,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5597"},"5277-5600":{"renderedLength":5322,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5599"},"5277-5602":{"renderedLength":32,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5601"},"5277-5604":{"renderedLength":35,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5603"},"5277-5606":{"renderedLength":252,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5605"},"5277-5608":{"renderedLength":6454,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5607"},"5277-5610":{"renderedLength":449,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5609"},"5277-5612":{"renderedLength":10925,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5611"},"5277-5614":{"renderedLength":256,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5613"},"5277-5616":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5615"},"5277-5618":{"renderedLength":1616,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5617"},"5277-5620":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5619"},"5277-5622":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5621"},"5277-5624":{"renderedLength":93705,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5623"},"5277-5626":{"renderedLength":493,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5625"},"5277-5628":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5627"},"5277-5630":{"renderedLength":1407,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5629"},"5277-5632":{"renderedLength":2699,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5631"},"5277-5634":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5633"},"5277-5636":{"renderedLength":1722,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5635"},"5277-5638":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5637"},"5277-5640":{"renderedLength":9613,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5639"},"5277-5642":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5641"},"5277-5644":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5643"},"5277-5646":{"renderedLength":1016,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5645"},"5277-5648":{"renderedLength":416,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5647"},"5277-5650":{"renderedLength":23870,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5649"},"5277-5652":{"renderedLength":4821,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5651"},"5277-5654":{"renderedLength":11401,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5653"},"5277-5656":{"renderedLength":316,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5655"},"5277-5658":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5657"},"5277-5660":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5659"},"5277-5662":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5661"},"5277-5664":{"renderedLength":6883,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5663"},"5277-5666":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5665"},"5277-5668":{"renderedLength":2512,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5667"},"5277-5670":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5669"},"5277-5672":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5671"},"5277-5674":{"renderedLength":1079,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5673"},"5277-5676":{"renderedLength":1706,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5675"},"5277-5678":{"renderedLength":3062,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5677"},"5277-5680":{"renderedLength":790,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5679"},"5277-5682":{"renderedLength":8711,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5681"},"5277-5684":{"renderedLength":894,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5683"},"5277-5686":{"renderedLength":256,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5685"},"5277-5688":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5687"},"5277-5690":{"renderedLength":3792,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5689"},"5277-5692":{"renderedLength":1275,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5691"},"5277-5694":{"renderedLength":583,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5693"},"5277-5696":{"renderedLength":33475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5695"},"5277-5698":{"renderedLength":6956,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5697"},"5277-5700":{"renderedLength":3190,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5699"},"5277-5702":{"renderedLength":3321,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5701"},"5277-5704":{"renderedLength":3560,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5703"},"5277-5706":{"renderedLength":6509,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5705"},"5277-5708":{"renderedLength":2667,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5707"},"5277-5710":{"renderedLength":1891,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5709"},"5277-5712":{"renderedLength":3688,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5711"},"5277-5714":{"renderedLength":494,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5713"},"5277-5716":{"renderedLength":11369,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5715"},"5277-5718":{"renderedLength":205,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5717"},"5277-5720":{"renderedLength":154,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5719"},"5277-5722":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5721"},"5277-5724":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5723"},"5277-5726":{"renderedLength":475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5725"},"5277-5728":{"renderedLength":1814,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5727"},"5277-5730":{"renderedLength":21,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5729"},"5277-5732":{"renderedLength":1764,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5731"},"5277-5734":{"renderedLength":1637,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5733"},"5277-5736":{"renderedLength":647,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5735"},"5277-5738":{"renderedLength":1704,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5737"},"5277-5740":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5739"},"5277-5742":{"renderedLength":45902,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5741"},"5277-5744":{"renderedLength":279,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5743"},"5277-5746":{"renderedLength":130,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5745"},"5277-5748":{"renderedLength":82,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5747"},"5277-5750":{"renderedLength":1330,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5749"},"5277-5752":{"renderedLength":459,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5751"},"5277-5754":{"renderedLength":478,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5753"},"5277-5756":{"renderedLength":1140,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5755"},"5277-5758":{"renderedLength":1676,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5757"},"5277-5760":{"renderedLength":1594,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5759"},"5277-5762":{"renderedLength":3303,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5761"},"5277-5764":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5763"},"5277-5766":{"renderedLength":1599,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5765"},"5277-5768":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5767"},"5277-5770":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5769"},"5277-5772":{"renderedLength":3275,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5771"},"5277-5774":{"renderedLength":6653,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5773"},"5277-5776":{"renderedLength":6716,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5775"},"5277-5778":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5777"},"5277-5780":{"renderedLength":466,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5779"},"5277-5782":{"renderedLength":3364,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5781"},"5277-5784":{"renderedLength":5339,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5783"},"5277-5786":{"renderedLength":394,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5785"},"5277-5788":{"renderedLength":798,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5787"},"5277-5790":{"renderedLength":3444,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5789"},"5277-5792":{"renderedLength":922,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5791"},"5277-5794":{"renderedLength":19369,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5793"},"5277-5796":{"renderedLength":2295,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5795"},"5277-5798":{"renderedLength":11799,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5797"},"5277-5800":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5799"},"5277-5802":{"renderedLength":343,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5801"},"5277-5804":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5803"},"5277-5806":{"renderedLength":1083,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5805"},"5277-5808":{"renderedLength":301,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5807"},"5277-5810":{"renderedLength":3115,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5809"},"5277-5812":{"renderedLength":1034,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5811"},"5277-5814":{"renderedLength":14025,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5813"},"5277-5816":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5815"},"5277-5818":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5817"},"5277-5820":{"renderedLength":1821,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5819"},"5277-5822":{"renderedLength":315,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5821"},"5277-5824":{"renderedLength":3300,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5823"},"5277-5826":{"renderedLength":14562,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5825"},"5277-5828":{"renderedLength":12606,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5827"},"5277-5830":{"renderedLength":7382,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5829"},"5277-5832":{"renderedLength":6183,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5831"},"5277-5834":{"renderedLength":33888,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5833"},"5277-5836":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5835"},"5277-5838":{"renderedLength":142,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5837"},"5277-5840":{"renderedLength":5026,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5839"},"5277-5842":{"renderedLength":3628,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5841"},"5277-5844":{"renderedLength":86,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5843"},"5277-5846":{"renderedLength":2438,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5845"},"5277-5848":{"renderedLength":20988,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5847"},"5277-5850":{"renderedLength":1820,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5849"},"5277-5852":{"renderedLength":1561,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5851"},"5277-5854":{"renderedLength":2685,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5853"},"5277-5856":{"renderedLength":9971,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5855"},"5277-5858":{"renderedLength":115,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5857"},"5277-5860":{"renderedLength":24984,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5859"},"5277-5862":{"renderedLength":1376,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5861"},"5277-5864":{"renderedLength":10872,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5863"},"5277-5866":{"renderedLength":1272,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5865"},"5277-5868":{"renderedLength":35,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5867"},"5277-5870":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5869"},"5277-5872":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5871"},"5277-5874":{"renderedLength":5035,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5873"},"5277-5876":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5875"},"5277-5878":{"renderedLength":633,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5877"},"5277-5880":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5879"},"5277-5882":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5881"},"5277-5884":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5883"},"5277-5886":{"renderedLength":500482,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5885"},"5277-5888":{"renderedLength":7472,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5887"},"5277-5890":{"renderedLength":34720,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5889"},"5277-5892":{"renderedLength":3781,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5891"},"5277-5894":{"renderedLength":4387,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5893"},"5277-5896":{"renderedLength":557,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5895"},"5277-5898":{"renderedLength":45728,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5897"},"5277-5900":{"renderedLength":61,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5899"},"5277-5902":{"renderedLength":841,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5901"},"5277-5904":{"renderedLength":46067,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5903"},"5277-5906":{"renderedLength":2755,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5905"},"5277-5908":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5907"},"5277-5910":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5909"},"5277-5912":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5911"},"5277-5914":{"renderedLength":2124,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5913"},"5277-5916":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5915"},"5277-5918":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5917"},"5277-5920":{"renderedLength":5882,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5919"},"5277-5922":{"renderedLength":2294,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5921"},"5277-5924":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5923"},"5277-5926":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5925"},"5277-5928":{"renderedLength":2564,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5927"},"5277-5930":{"renderedLength":4140,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5929"},"5277-5932":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5931"},"5277-5934":{"renderedLength":5728,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5933"},"5277-5936":{"renderedLength":1165,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5935"},"5277-5938":{"renderedLength":1278,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5937"},"5277-5940":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5939"},"5277-5942":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5941"},"5277-5944":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5943"},"5277-5946":{"renderedLength":389,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5945"},"5277-5948":{"renderedLength":572,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5947"},"5277-5950":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5949"},"5277-5952":{"renderedLength":2629,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5951"},"5277-5954":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5953"},"5277-5956":{"renderedLength":730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5955"},"5277-5958":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5957"},"5277-5960":{"renderedLength":9544,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5959"},"5277-5962":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5961"},"5277-5964":{"renderedLength":416,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5963"},"5277-5966":{"renderedLength":929,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5965"},"5277-5968":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5967"},"5277-5970":{"renderedLength":3481,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5969"},"5277-5972":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5971"},"5277-5974":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5973"},"5277-5976":{"renderedLength":1401,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5975"},"5277-5978":{"renderedLength":3138,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5977"},"5277-5980":{"renderedLength":12503,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5979"},"5277-5982":{"renderedLength":43,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5981"},"5277-5984":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5983"},"5277-5986":{"renderedLength":2364,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5985"},"5277-5988":{"renderedLength":7672,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5987"},"5277-5990":{"renderedLength":58,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5989"},"5277-5992":{"renderedLength":32,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5991"},"5277-5994":{"renderedLength":22,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5993"},"5277-5996":{"renderedLength":2663,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5995"},"5277-5998":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5997"},"5277-6000":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-5999"},"5277-6002":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6001"},"5277-6004":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6003"},"5277-6006":{"renderedLength":1354,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6005"},"5277-6008":{"renderedLength":280,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6007"},"5277-6010":{"renderedLength":162,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6009"},"5277-6012":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6011"},"5277-6014":{"renderedLength":1890,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6013"},"5277-6016":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6015"},"5277-6018":{"renderedLength":3199,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6017"},"5277-6020":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6019"},"5277-6022":{"renderedLength":2331,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6021"},"5277-6024":{"renderedLength":2378,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6023"},"5277-6026":{"renderedLength":243,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6025"},"5277-6028":{"renderedLength":19561,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6027"},"5277-6030":{"renderedLength":2903,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6029"},"5277-6032":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6031"},"5277-6034":{"renderedLength":8749,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6033"},"5277-6036":{"renderedLength":31246,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6035"},"5277-6038":{"renderedLength":4571,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6037"},"5277-6040":{"renderedLength":715,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6039"},"5277-6042":{"renderedLength":850,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6041"},"5277-6044":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6043"},"5277-6046":{"renderedLength":917,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6045"},"5277-6048":{"renderedLength":984,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6047"},"5277-6050":{"renderedLength":2692,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6049"},"5277-6052":{"renderedLength":21,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6051"},"5277-6054":{"renderedLength":921,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6053"},"5277-6056":{"renderedLength":3119,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6055"},"5277-6058":{"renderedLength":92,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6057"},"5277-6060":{"renderedLength":661,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6059"},"5277-6062":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6061"},"5277-6064":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6063"},"5277-6066":{"renderedLength":1180,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6065"},"5277-6068":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6067"},"5277-6070":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6069"},"5277-6072":{"renderedLength":2078,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6071"},"5277-6074":{"renderedLength":3926,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6073"},"5277-6076":{"renderedLength":552,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6075"},"5277-6078":{"renderedLength":2246,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6077"},"5277-6080":{"renderedLength":6959,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6079"},"5277-6082":{"renderedLength":11887,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6081"},"5277-6084":{"renderedLength":165,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6083"},"5277-6086":{"renderedLength":2050,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6085"},"5277-6088":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6087"},"5277-6090":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6089"},"5277-6092":{"renderedLength":2567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6091"},"5277-6094":{"renderedLength":2141,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6093"},"5277-6096":{"renderedLength":1874,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6095"},"5277-6098":{"renderedLength":1852,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6097"},"5277-6100":{"renderedLength":2372,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6099"},"5277-6102":{"renderedLength":1080,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6101"},"5277-6104":{"renderedLength":4108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6103"},"5277-6106":{"renderedLength":2178,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6105"},"5277-6108":{"renderedLength":341,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6107"},"5277-6110":{"renderedLength":163,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6109"},"5277-6112":{"renderedLength":409,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6111"},"5277-6114":{"renderedLength":135,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6113"},"5277-6116":{"renderedLength":667,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6115"},"5277-6118":{"renderedLength":176,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6117"},"5277-6120":{"renderedLength":214,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6119"},"5277-6122":{"renderedLength":500,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6121"},"5277-6124":{"renderedLength":306,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6123"},"5277-6126":{"renderedLength":222,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6125"},"5277-6128":{"renderedLength":284,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6127"},"5277-6130":{"renderedLength":71,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6129"},"5277-6132":{"renderedLength":160,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6131"},"5277-6134":{"renderedLength":185,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6133"},"5277-6136":{"renderedLength":428,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6135"},"5277-6138":{"renderedLength":195,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6137"},"5277-6140":{"renderedLength":140,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6139"},"5277-6142":{"renderedLength":104975,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6141"},"5277-6144":{"renderedLength":1218,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6143"},"5277-6146":{"renderedLength":1090,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6145"},"5277-6148":{"renderedLength":876,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6147"},"5277-6150":{"renderedLength":314,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6149"},"5277-6152":{"renderedLength":2057,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6151"},"5277-6154":{"renderedLength":2444,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6153"},"5277-6156":{"renderedLength":1537,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6155"},"5277-6158":{"renderedLength":3108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6157"},"5277-6160":{"renderedLength":1095,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6159"},"5277-6162":{"renderedLength":726,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6161"},"5277-6164":{"renderedLength":1282,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6163"},"5277-6166":{"renderedLength":2490,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6165"},"5277-6168":{"renderedLength":453,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6167"},"5277-6170":{"renderedLength":5525,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6169"},"5277-6172":{"renderedLength":1145,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6171"},"5277-6174":{"renderedLength":628,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6173"},"5277-6176":{"renderedLength":151,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6175"},"5277-6178":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6177"},"5277-6180":{"renderedLength":45170,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6179"},"5277-6182":{"renderedLength":57,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6181"},"5277-6184":{"renderedLength":838,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6183"},"5277-6186":{"renderedLength":1226,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6185"},"5277-6188":{"renderedLength":4730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6187"},"5277-6190":{"renderedLength":12152,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6189"},"5277-6192":{"renderedLength":1455,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6191"},"5277-6194":{"renderedLength":1299,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6193"},"5277-6196":{"renderedLength":529,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6195"},"5277-6198":{"renderedLength":418,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6197"},"5277-6200":{"renderedLength":1340,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6199"},"5277-6202":{"renderedLength":1458,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6201"},"5277-6204":{"renderedLength":1159,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6203"},"5277-6206":{"renderedLength":1746,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6205"},"5277-6208":{"renderedLength":3273,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6207"},"5277-6210":{"renderedLength":2604,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6209"},"5277-6212":{"renderedLength":8363,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6211"},"5277-6214":{"renderedLength":15995,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6213"},"5277-6216":{"renderedLength":3938,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6215"},"5277-6218":{"renderedLength":4490,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6217"},"5277-6220":{"renderedLength":2142,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6219"},"5277-6222":{"renderedLength":12442,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6221"},"5277-6224":{"renderedLength":1682,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6223"},"5277-6226":{"renderedLength":245,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6225"},"5277-6228":{"renderedLength":288,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6227"},"5277-6230":{"renderedLength":830,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6229"},"5277-6232":{"renderedLength":578,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6231"},"5277-6234":{"renderedLength":557,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6233"},"5277-6236":{"renderedLength":1143,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6235"},"5277-6238":{"renderedLength":96,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6237"},"5277-6240":{"renderedLength":461,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6239"},"5277-6242":{"renderedLength":12518,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6241"},"5277-6244":{"renderedLength":6127,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6243"},"5277-6246":{"renderedLength":3346,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6245"},"5277-6248":{"renderedLength":1100,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6247"},"5277-6250":{"renderedLength":1210,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6249"},"5277-6252":{"renderedLength":2662,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6251"},"5277-6254":{"renderedLength":11318,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6253"},"5277-6256":{"renderedLength":972,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6255"},"5277-6258":{"renderedLength":1278,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6257"},"5277-6260":{"renderedLength":1179,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6259"},"5277-6262":{"renderedLength":362,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6261"},"5277-6264":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6263"},"5277-6266":{"renderedLength":487,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6265"},"5277-6268":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6267"},"5277-6270":{"renderedLength":1726,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6269"},"5277-6272":{"renderedLength":838,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6271"},"5277-6274":{"renderedLength":1033,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6273"},"5277-6276":{"renderedLength":2083,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6275"},"5277-6278":{"renderedLength":320,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6277"},"5277-6280":{"renderedLength":272,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6279"},"5277-6282":{"renderedLength":2862,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6281"},"5277-6284":{"renderedLength":2567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6283"},"5277-6286":{"renderedLength":6578,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6285"},"5277-6288":{"renderedLength":803,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6287"},"5277-6290":{"renderedLength":3821,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6289"},"5277-6292":{"renderedLength":3045,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6291"},"5277-6294":{"renderedLength":1942,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6293"},"5277-6296":{"renderedLength":566,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6295"},"5277-6298":{"renderedLength":1088,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6297"},"5277-6300":{"renderedLength":3835,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6299"},"5277-6302":{"renderedLength":524,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6301"},"5277-6304":{"renderedLength":161,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6303"},"5277-6306":{"renderedLength":335,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6305"},"5277-6308":{"renderedLength":403,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6307"},"5277-6310":{"renderedLength":129,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6309"},"5277-6312":{"renderedLength":657,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6311"},"5277-6314":{"renderedLength":12139,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6313"},"5277-6316":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6315"},"5277-6318":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6317"},"5277-6320":{"renderedLength":7617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6319"},"5277-6322":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6321"},"5277-6324":{"renderedLength":92422,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6323"},"5277-6326":{"renderedLength":185,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6325"},"5277-6328":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6327"},"5277-6330":{"renderedLength":653,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6329"},"5277-6332":{"renderedLength":615,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6331"},"5277-6334":{"renderedLength":447,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6333"},"5277-6336":{"renderedLength":113,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6335"},"5277-6338":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6337"},"5277-6340":{"renderedLength":1706,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6339"},"5277-6342":{"renderedLength":1903,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6341"},"5277-6344":{"renderedLength":1936,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6343"},"5277-6346":{"renderedLength":2219,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6345"},"5277-6348":{"renderedLength":1881,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6347"},"5277-6350":{"renderedLength":1825,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6349"},"5277-6352":{"renderedLength":1814,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6351"},"5277-6354":{"renderedLength":2617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6353"},"5277-6356":{"renderedLength":3368,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6355"},"5277-6358":{"renderedLength":1487,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6357"},"5277-6360":{"renderedLength":1256,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6359"},"5277-6362":{"renderedLength":5859,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6361"},"5277-6364":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-6363"}},"nodeMetas":{"5277-5591":{"id":"\u0000commonjsHelpers.js","moduleParts":{"metamask-sdk.js":"5277-5592"},"imported":[],"importedBy":[{"uid":"5277-5737"},{"uid":"5277-5741"},{"uid":"5277-5901"},{"uid":"5277-6095"},{"uid":"5277-5785"},{"uid":"5277-5899"},{"uid":"5277-5935"},{"uid":"5277-5735"},{"uid":"5277-5727"},{"uid":"5277-5725"},{"uid":"5277-5775"},{"uid":"5277-5783"},{"uid":"5277-5979"},{"uid":"5277-6085"},{"uid":"5277-6093"},{"uid":"5277-6081"},{"uid":"5277-6091"},{"uid":"5277-6079"},{"uid":"5277-5773"},{"uid":"5277-5781"},{"uid":"5277-5895"},{"uid":"5277-5989"},{"uid":"5277-5921"},{"uid":"5277-5929"},{"uid":"5277-5933"},{"uid":"5277-5927"},{"uid":"5277-5733"},{"uid":"5277-5731"},{"uid":"5277-5719"},{"uid":"5277-5771"},{"uid":"5277-5779"},{"uid":"5277-5913"},{"uid":"5277-5937"},{"uid":"5277-5965"},{"uid":"5277-5969"},{"uid":"5277-5977"},{"uid":"5277-5985"},{"uid":"5277-5987"},{"uid":"5277-5995"},{"uid":"5277-6057"},{"uid":"5277-6059"},{"uid":"5277-6075"},{"uid":"5277-6077"},{"uid":"5277-6183"},{"uid":"5277-5613"},{"uid":"5277-5717"},{"uid":"5277-6441"},{"uid":"5277-5825"},{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-6442"},{"uid":"5277-5893"},{"uid":"5277-5889"},{"uid":"5277-5919"},{"uid":"5277-6181"},{"uid":"5277-6325"},{"uid":"5277-6329"},{"uid":"5277-5599"},{"uid":"5277-5609"},{"uid":"5277-5611"},{"uid":"5277-5715"},{"uid":"5277-5793"},{"uid":"5277-5947"},{"uid":"5277-5951"},{"uid":"5277-5955"},{"uid":"5277-5945"},{"uid":"5277-5959"},{"uid":"5277-5963"},{"uid":"5277-5975"},{"uid":"5277-6055"},{"uid":"5277-6065"},{"uid":"5277-6073"},{"uid":"5277-6047"},{"uid":"5277-6049"},{"uid":"5277-6319"},{"uid":"5277-6323"},{"uid":"5277-6483"},{"uid":"5277-5607"},{"uid":"5277-5713"},{"uid":"5277-5813"},{"uid":"5277-5801"},{"uid":"5277-5809"},{"uid":"5277-5823"},{"uid":"5277-5829"},{"uid":"5277-5831"},{"uid":"5277-6488"},{"uid":"5277-5873"},{"uid":"5277-5877"},{"uid":"5277-5891"},{"uid":"5277-5887"},{"uid":"5277-5631"},{"uid":"5277-5635"},{"uid":"5277-5655"},{"uid":"5277-5697"},{"uid":"5277-5705"},{"uid":"5277-5711"},{"uid":"5277-5807"},{"uid":"5277-5821"},{"uid":"5277-6041"},{"uid":"5277-6053"},{"uid":"5277-6071"},{"uid":"5277-6045"},{"uid":"5277-5623"},{"uid":"5277-5625"},{"uid":"5277-5629"},{"uid":"5277-5639"},{"uid":"5277-5649"},{"uid":"5277-5651"},{"uid":"5277-5653"},{"uid":"5277-5693"},{"uid":"5277-5695"},{"uid":"5277-5699"},{"uid":"5277-5701"},{"uid":"5277-5703"},{"uid":"5277-5707"},{"uid":"5277-5709"},{"uid":"5277-5811"},{"uid":"5277-5805"},{"uid":"5277-5819"},{"uid":"5277-6035"},{"uid":"5277-6027"},{"uid":"5277-6029"},{"uid":"5277-6037"},{"uid":"5277-6039"},{"uid":"5277-5647"},{"uid":"5277-5663"},{"uid":"5277-5667"},{"uid":"5277-5685"},{"uid":"5277-5689"},{"uid":"5277-5691"},{"uid":"5277-6005"},{"uid":"5277-6007"},{"uid":"5277-6009"},{"uid":"5277-6013"},{"uid":"5277-6017"},{"uid":"5277-6021"},{"uid":"5277-6023"},{"uid":"5277-6033"},{"uid":"5277-6025"},{"uid":"5277-5645"},{"uid":"5277-5675"},{"uid":"5277-5679"},{"uid":"5277-5677"},{"uid":"5277-5683"},{"uid":"5277-5681"},{"uid":"5277-5673"}]},"5277-5593":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5594"},"imported":[],"importedBy":[{"uid":"5277-5737"}]},"5277-5595":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5596"},"imported":[],"importedBy":[{"uid":"5277-5735"}]},"5277-5597":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5598"},"imported":[],"importedBy":[{"uid":"5277-5733"}]},"5277-5599":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js","moduleParts":{"metamask-sdk.js":"5277-5600"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6484"},{"uid":"5277-6396"}],"importedBy":[{"uid":"5277-6440"}]},"5277-5601":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5602"},"imported":[],"importedBy":[{"uid":"5277-5719"}]},"5277-5603":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/node-gyp-build/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5604"},"imported":[],"importedBy":[{"uid":"5277-5609"}]},"5277-5605":{"id":"\u0000commonjs-dynamic-modules","moduleParts":{"metamask-sdk.js":"5277-5606"},"imported":[],"importedBy":[{"uid":"5277-5607"}]},"5277-5607":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/node-gyp-build/node-gyp-build.js","moduleParts":{"metamask-sdk.js":"5277-5608"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5605"},{"uid":"5277-6458"},{"uid":"5277-6494"},{"uid":"5277-6422"}],"importedBy":[{"uid":"5277-5609"}]},"5277-5609":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/node-gyp-build/index.js","moduleParts":{"metamask-sdk.js":"5277-5610"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5603"},{"uid":"5277-5607"}],"importedBy":[{"uid":"5277-5613"},{"uid":"5277-5807"},{"uid":"5277-5821"}]},"5277-5611":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/index.js","moduleParts":{"metamask-sdk.js":"5277-5612"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5613"},{"uid":"5277-5717"}]},"5277-5613":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/bindings.js","moduleParts":{"metamask-sdk.js":"5277-5614"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5609"},{"uid":"5277-5611"}],"importedBy":[{"uid":"5277-5719"}]},"5277-5615":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5616"},"imported":[],"importedBy":[{"uid":"5277-5713"}]},"5277-5617":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json","moduleParts":{"metamask-sdk.js":"5277-5618"},"imported":[],"importedBy":[{"uid":"5277-6495"}]},"5277-5619":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5620"},"imported":[],"importedBy":[{"uid":"5277-5631"}]},"5277-5621":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5622"},"imported":[],"importedBy":[{"uid":"5277-5623"}]},"5277-5623":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-5624"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5621"}],"importedBy":[{"uid":"5277-5631"},{"uid":"5277-5705"},{"uid":"5277-5639"},{"uid":"5277-5649"},{"uid":"5277-5651"},{"uid":"5277-5653"},{"uid":"5277-5701"},{"uid":"5277-5703"},{"uid":"5277-5709"}]},"5277-5625":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-assert/index.js","moduleParts":{"metamask-sdk.js":"5277-5626"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5631"},{"uid":"5277-5699"},{"uid":"5277-5663"},{"uid":"5277-5667"},{"uid":"5277-5691"},{"uid":"5277-5677"},{"uid":"5277-5681"}]},"5277-5627":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5628"},"imported":[],"importedBy":[{"uid":"5277-5629"}]},"5277-5629":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js","moduleParts":{"metamask-sdk.js":"5277-5630"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5627"}],"importedBy":[{"uid":"5277-5631"},{"uid":"5277-5699"}]},"5277-5631":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js","moduleParts":{"metamask-sdk.js":"5277-5632"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5619"},{"uid":"5277-5623"},{"uid":"5277-5625"},{"uid":"5277-5629"}],"importedBy":[{"uid":"5277-5713"},{"uid":"5277-5697"},{"uid":"5277-5705"},{"uid":"5277-5711"},{"uid":"5277-5639"},{"uid":"5277-5649"},{"uid":"5277-5651"},{"uid":"5277-5653"},{"uid":"5277-5701"},{"uid":"5277-5703"},{"uid":"5277-5707"},{"uid":"5277-5709"}]},"5277-5633":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5634"},"imported":[],"importedBy":[{"uid":"5277-5635"}]},"5277-5635":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js","moduleParts":{"metamask-sdk.js":"5277-5636"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5633"}],"importedBy":[{"uid":"5277-5713"},{"uid":"5277-5705"}]},"5277-5637":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5638"},"imported":[],"importedBy":[{"uid":"5277-5655"}]},"5277-5639":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/base.js","moduleParts":{"metamask-sdk.js":"5277-5640"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5623"},{"uid":"5277-5631"}],"importedBy":[{"uid":"5277-5655"},{"uid":"5277-5649"},{"uid":"5277-5651"},{"uid":"5277-5653"}]},"5277-5641":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5642"},"imported":[],"importedBy":[{"uid":"5277-5647"}]},"5277-5643":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5644"},"imported":[],"importedBy":[{"uid":"5277-5645"}]},"5277-5645":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js","moduleParts":{"metamask-sdk.js":"5277-5646"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5643"}],"importedBy":[{"uid":"5277-5647"}]},"5277-5647":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits.js","moduleParts":{"metamask-sdk.js":"5277-5648"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5641"},{"uid":"5277-5645"}],"importedBy":[{"uid":"5277-5649"},{"uid":"5277-5651"},{"uid":"5277-5653"},{"uid":"5277-6035"},{"uid":"5277-6027"},{"uid":"5277-6029"},{"uid":"5277-6037"},{"uid":"5277-6039"},{"uid":"5277-5663"}]},"5277-5649":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/short.js","moduleParts":{"metamask-sdk.js":"5277-5650"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5631"},{"uid":"5277-5623"},{"uid":"5277-5647"},{"uid":"5277-5639"}],"importedBy":[{"uid":"5277-5655"}]},"5277-5651":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/mont.js","moduleParts":{"metamask-sdk.js":"5277-5652"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5623"},{"uid":"5277-5647"},{"uid":"5277-5639"},{"uid":"5277-5631"}],"importedBy":[{"uid":"5277-5655"}]},"5277-5653":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/edwards.js","moduleParts":{"metamask-sdk.js":"5277-5654"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5631"},{"uid":"5277-5623"},{"uid":"5277-5647"},{"uid":"5277-5639"}],"importedBy":[{"uid":"5277-5655"}]},"5277-5655":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js","moduleParts":{"metamask-sdk.js":"5277-5656"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5637"},{"uid":"5277-5639"},{"uid":"5277-5649"},{"uid":"5277-5651"},{"uid":"5277-5653"}],"importedBy":[{"uid":"5277-5713"},{"uid":"5277-5697"}]},"5277-5657":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5658"},"imported":[],"importedBy":[{"uid":"5277-5697"}]},"5277-5659":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5660"},"imported":[],"importedBy":[{"uid":"5277-5693"}]},"5277-5661":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5662"},"imported":[],"importedBy":[{"uid":"5277-5663"}]},"5277-5663":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js","moduleParts":{"metamask-sdk.js":"5277-5664"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5661"},{"uid":"5277-5625"},{"uid":"5277-5647"}],"importedBy":[{"uid":"5277-5693"},{"uid":"5277-5667"},{"uid":"5277-5689"},{"uid":"5277-5691"},{"uid":"5277-5675"},{"uid":"5277-5679"},{"uid":"5277-5677"},{"uid":"5277-5683"},{"uid":"5277-5681"},{"uid":"5277-5673"}]},"5277-5665":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5666"},"imported":[],"importedBy":[{"uid":"5277-5667"}]},"5277-5667":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js","moduleParts":{"metamask-sdk.js":"5277-5668"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5665"},{"uid":"5277-5663"},{"uid":"5277-5625"}],"importedBy":[{"uid":"5277-5693"},{"uid":"5277-5689"},{"uid":"5277-5675"},{"uid":"5277-5677"},{"uid":"5277-5681"}]},"5277-5669":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5670"},"imported":[],"importedBy":[{"uid":"5277-5685"}]},"5277-5671":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5672"},"imported":[],"importedBy":[{"uid":"5277-5673"}]},"5277-5673":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js","moduleParts":{"metamask-sdk.js":"5277-5674"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5671"},{"uid":"5277-5663"}],"importedBy":[{"uid":"5277-5675"},{"uid":"5277-5677"}]},"5277-5675":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/1.js","moduleParts":{"metamask-sdk.js":"5277-5676"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5663"},{"uid":"5277-5667"},{"uid":"5277-5673"}],"importedBy":[{"uid":"5277-5685"}]},"5277-5677":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/256.js","moduleParts":{"metamask-sdk.js":"5277-5678"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5663"},{"uid":"5277-5667"},{"uid":"5277-5673"},{"uid":"5277-5625"}],"importedBy":[{"uid":"5277-5685"},{"uid":"5277-5679"}]},"5277-5679":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/224.js","moduleParts":{"metamask-sdk.js":"5277-5680"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5663"},{"uid":"5277-5677"}],"importedBy":[{"uid":"5277-5685"}]},"5277-5681":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/512.js","moduleParts":{"metamask-sdk.js":"5277-5682"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5663"},{"uid":"5277-5667"},{"uid":"5277-5625"}],"importedBy":[{"uid":"5277-5685"},{"uid":"5277-5683"}]},"5277-5683":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/384.js","moduleParts":{"metamask-sdk.js":"5277-5684"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5663"},{"uid":"5277-5681"}],"importedBy":[{"uid":"5277-5685"}]},"5277-5685":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js","moduleParts":{"metamask-sdk.js":"5277-5686"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5669"},{"uid":"5277-5675"},{"uid":"5277-5679"},{"uid":"5277-5677"},{"uid":"5277-5683"},{"uid":"5277-5681"}],"importedBy":[{"uid":"5277-5693"}]},"5277-5687":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5688"},"imported":[],"importedBy":[{"uid":"5277-5689"}]},"5277-5689":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js","moduleParts":{"metamask-sdk.js":"5277-5690"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5687"},{"uid":"5277-5663"},{"uid":"5277-5667"}],"importedBy":[{"uid":"5277-5693"}]},"5277-5691":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/hmac.js","moduleParts":{"metamask-sdk.js":"5277-5692"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5663"},{"uid":"5277-5625"}],"importedBy":[{"uid":"5277-5693"}]},"5277-5693":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js","moduleParts":{"metamask-sdk.js":"5277-5694"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5659"},{"uid":"5277-5663"},{"uid":"5277-5667"},{"uid":"5277-5685"},{"uid":"5277-5689"},{"uid":"5277-5691"}],"importedBy":[{"uid":"5277-5697"},{"uid":"5277-5711"},{"uid":"5277-5699"}]},"5277-5695":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/precomputed/secp256k1.js","moduleParts":{"metamask-sdk.js":"5277-5696"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5697"}]},"5277-5697":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js","moduleParts":{"metamask-sdk.js":"5277-5698"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5657"},{"uid":"5277-5693"},{"uid":"5277-5655"},{"uid":"5277-5631"},{"uid":"5277-5695"}],"importedBy":[{"uid":"5277-5713"},{"uid":"5277-5705"},{"uid":"5277-5711"}]},"5277-5699":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hmac-drbg/lib/hmac-drbg.js","moduleParts":{"metamask-sdk.js":"5277-5700"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5693"},{"uid":"5277-5629"},{"uid":"5277-5625"}],"importedBy":[{"uid":"5277-5705"}]},"5277-5701":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/key.js","moduleParts":{"metamask-sdk.js":"5277-5702"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5623"},{"uid":"5277-5631"}],"importedBy":[{"uid":"5277-5705"}]},"5277-5703":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/signature.js","moduleParts":{"metamask-sdk.js":"5277-5704"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5623"},{"uid":"5277-5631"}],"importedBy":[{"uid":"5277-5705"}]},"5277-5705":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/index.js","moduleParts":{"metamask-sdk.js":"5277-5706"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5623"},{"uid":"5277-5699"},{"uid":"5277-5631"},{"uid":"5277-5697"},{"uid":"5277-5635"},{"uid":"5277-5701"},{"uid":"5277-5703"}],"importedBy":[{"uid":"5277-5713"}]},"5277-5707":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/key.js","moduleParts":{"metamask-sdk.js":"5277-5708"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5631"}],"importedBy":[{"uid":"5277-5711"}]},"5277-5709":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/signature.js","moduleParts":{"metamask-sdk.js":"5277-5710"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5623"},{"uid":"5277-5631"}],"importedBy":[{"uid":"5277-5711"}]},"5277-5711":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/index.js","moduleParts":{"metamask-sdk.js":"5277-5712"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5693"},{"uid":"5277-5697"},{"uid":"5277-5631"},{"uid":"5277-5707"},{"uid":"5277-5709"}],"importedBy":[{"uid":"5277-5713"}]},"5277-5713":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-5714"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5615"},{"uid":"5277-6495"},{"uid":"5277-5631"},{"uid":"5277-5635"},{"uid":"5277-5655"},{"uid":"5277-5697"},{"uid":"5277-5705"},{"uid":"5277-5711"}],"importedBy":[{"uid":"5277-5715"}]},"5277-5715":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-5716"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5713"}],"importedBy":[{"uid":"5277-5717"}]},"5277-5717":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-5718"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5611"},{"uid":"5277-5715"}],"importedBy":[{"uid":"5277-5719"}]},"5277-5719":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/index.js","moduleParts":{"metamask-sdk.js":"5277-5720"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5601"},{"uid":"5277-5613"},{"uid":"5277-5717"}],"importedBy":[{"uid":"5277-6397"}]},"5277-5721":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5722"},"imported":[],"importedBy":[{"uid":"5277-5727"}]},"5277-5723":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5724"},"imported":[],"importedBy":[{"uid":"5277-5725"}]},"5277-5725":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js","moduleParts":{"metamask-sdk.js":"5277-5726"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5723"}],"importedBy":[{"uid":"5277-6371"}]},"5277-5727":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-5728"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5721"},{"uid":"5277-6396"},{"uid":"5277-6397"},{"uid":"5277-6371"}],"importedBy":[{"uid":"5277-6370"}]},"5277-5729":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5730"},"imported":[],"importedBy":[{"uid":"5277-5731"}]},"5277-5731":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js","moduleParts":{"metamask-sdk.js":"5277-5732"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5729"},{"uid":"5277-6440"},{"uid":"5277-6397"},{"uid":"5277-6370"},{"uid":"5277-6371"}],"importedBy":[{"uid":"5277-6395"}]},"5277-5733":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js","moduleParts":{"metamask-sdk.js":"5277-5734"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5597"},{"uid":"5277-6440"},{"uid":"5277-6397"},{"uid":"5277-6370"},{"uid":"5277-6395"}],"importedBy":[{"uid":"5277-6394"}]},"5277-5735":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js","moduleParts":{"metamask-sdk.js":"5277-5736"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5595"},{"uid":"5277-6394"},{"uid":"5277-6395"}],"importedBy":[{"uid":"5277-6369"}]},"5277-5737":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-5738"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5593"},{"uid":"5277-6369"},{"uid":"5277-6370"},{"uid":"5277-6371"}],"importedBy":[{"uid":"5277-5903"}]},"5277-5739":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5740"},"imported":[],"importedBy":[{"uid":"5277-5741"}]},"5277-5741":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js","moduleParts":{"metamask-sdk.js":"5277-5742"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5739"}],"importedBy":[{"uid":"5277-5903"},{"uid":"5277-6361"}]},"5277-5743":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/rng.js","moduleParts":{"metamask-sdk.js":"5277-5744"},"imported":[{"uid":"5277-6398"}],"importedBy":[{"uid":"5277-6372"},{"uid":"5277-5751"}]},"5277-5745":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/regex.js","moduleParts":{"metamask-sdk.js":"5277-5746"},"imported":[],"importedBy":[{"uid":"5277-5747"}]},"5277-5747":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/validate.js","moduleParts":{"metamask-sdk.js":"5277-5748"},"imported":[{"uid":"5277-5745"}],"importedBy":[{"uid":"5277-6366"},{"uid":"5277-6376"},{"uid":"5277-5749"},{"uid":"5277-6377"}]},"5277-5749":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/stringify.js","moduleParts":{"metamask-sdk.js":"5277-5750"},"imported":[{"uid":"5277-5747"}],"importedBy":[{"uid":"5277-6366"},{"uid":"5277-6372"},{"uid":"5277-5751"},{"uid":"5277-6384"}]},"5277-5751":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/v4.js","moduleParts":{"metamask-sdk.js":"5277-5752"},"imported":[{"uid":"5277-5743"},{"uid":"5277-5749"}],"importedBy":[{"uid":"5277-6366"}]},"5277-5753":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/commons.js","moduleParts":{"metamask-sdk.js":"5277-5754"},"imported":[],"importedBy":[{"uid":"5277-5755"},{"uid":"5277-5757"}]},"5277-5755":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/encodePacket.js","moduleParts":{"metamask-sdk.js":"5277-5756"},"imported":[{"uid":"5277-5753"}],"importedBy":[{"uid":"5277-5759"}]},"5277-5757":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/decodePacket.js","moduleParts":{"metamask-sdk.js":"5277-5758"},"imported":[{"uid":"5277-5753"}],"importedBy":[{"uid":"5277-5759"}]},"5277-5759":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-5760"},"imported":[{"uid":"5277-5755"},{"uid":"5277-5757"}],"importedBy":[{"uid":"5277-5847"},{"uid":"5277-5789"},{"uid":"5277-5797"},{"uid":"5277-5839"},{"uid":"5277-5841"}]},"5277-5761":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@socket.io/component-emitter/index.mjs","moduleParts":{"metamask-sdk.js":"5277-5762"},"imported":[],"importedBy":[{"uid":"5277-5863"},{"uid":"5277-5859"},{"uid":"5277-5855"},{"uid":"5277-5847"},{"uid":"5277-5789"},{"uid":"5277-5797"}]},"5277-5763":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/globalThis.js","moduleParts":{"metamask-sdk.js":"5277-5764"},"imported":[],"importedBy":[{"uid":"5277-5765"},{"uid":"5277-5797"}]},"5277-5765":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/util.js","moduleParts":{"metamask-sdk.js":"5277-5766"},"imported":[{"uid":"5277-5763"}],"importedBy":[{"uid":"5277-6387"},{"uid":"5277-5847"},{"uid":"5277-5789"},{"uid":"5277-5797"},{"uid":"5277-5839"}]},"5277-5767":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5768"},"imported":[],"importedBy":[{"uid":"5277-5785"}]},"5277-5769":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5770"},"imported":[],"importedBy":[{"uid":"5277-5775"}]},"5277-5771":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/node_modules/ms/index.js","moduleParts":{"metamask-sdk.js":"5277-5772"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5773"}]},"5277-5773":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/common.js","moduleParts":{"metamask-sdk.js":"5277-5774"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5771"}],"importedBy":[{"uid":"5277-5775"},{"uid":"5277-5783"}]},"5277-5775":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/browser.js","moduleParts":{"metamask-sdk.js":"5277-5776"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5769"},{"uid":"5277-5773"}],"importedBy":[{"uid":"5277-5785"}]},"5277-5777":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/node.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5778"},"imported":[],"importedBy":[{"uid":"5277-5783"}]},"5277-5779":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/has-flag/index.js","moduleParts":{"metamask-sdk.js":"5277-5780"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5781"}]},"5277-5781":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/supports-color/index.js","moduleParts":{"metamask-sdk.js":"5277-5782"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6422"},{"uid":"5277-6399"},{"uid":"5277-5779"}],"importedBy":[{"uid":"5277-5783"}]},"5277-5783":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/node.js","moduleParts":{"metamask-sdk.js":"5277-5784"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5777"},{"uid":"5277-6399"},{"uid":"5277-6400"},{"uid":"5277-5781"},{"uid":"5277-5773"}],"importedBy":[{"uid":"5277-5785"}]},"5277-5785":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/index.js","moduleParts":{"metamask-sdk.js":"5277-5786"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5767"},{"uid":"5277-5775"},{"uid":"5277-5783"}],"importedBy":[{"uid":"5277-5865"},{"uid":"5277-5849"},{"uid":"5277-5863"},{"uid":"5277-5859"},{"uid":"5277-5855"},{"uid":"5277-5847"},{"uid":"5277-5789"},{"uid":"5277-5797"},{"uid":"5277-5839"},{"uid":"5277-5841"}]},"5277-5787":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/contrib/parseqs.js","moduleParts":{"metamask-sdk.js":"5277-5788"},"imported":[],"importedBy":[{"uid":"5277-5847"},{"uid":"5277-5789"}]},"5277-5789":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transport.js","moduleParts":{"metamask-sdk.js":"5277-5790"},"imported":[{"uid":"5277-5759"},{"uid":"5277-5761"},{"uid":"5277-5765"},{"uid":"5277-5785"},{"uid":"5277-5787"}],"importedBy":[{"uid":"5277-6387"},{"uid":"5277-5797"},{"uid":"5277-5839"},{"uid":"5277-5841"}]},"5277-5791":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/contrib/yeast.js","moduleParts":{"metamask-sdk.js":"5277-5792"},"imported":[],"importedBy":[{"uid":"5277-5797"},{"uid":"5277-5839"}]},"5277-5793":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/xmlhttprequest-ssl/lib/XMLHttpRequest.js","moduleParts":{"metamask-sdk.js":"5277-5794"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6458"},{"uid":"5277-6470"},{"uid":"5277-6485"},{"uid":"5277-6469"},{"uid":"5277-6468"}],"importedBy":[{"uid":"5277-5795"}]},"5277-5795":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/xmlhttprequest.js","moduleParts":{"metamask-sdk.js":"5277-5796"},"imported":[{"uid":"5277-5793"}],"importedBy":[{"uid":"5277-5797"}]},"5277-5797":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/polling.js","moduleParts":{"metamask-sdk.js":"5277-5798"},"imported":[{"uid":"5277-5789"},{"uid":"5277-5785"},{"uid":"5277-5791"},{"uid":"5277-5759"},{"uid":"5277-5795"},{"uid":"5277-5761"},{"uid":"5277-5765"},{"uid":"5277-5763"}],"importedBy":[{"uid":"5277-5843"}]},"5277-5799":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/buffer-util.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5800"},"imported":[],"importedBy":[{"uid":"5277-5809"}]},"5277-5801":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/constants.js","moduleParts":{"metamask-sdk.js":"5277-5802"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6463"}]},"5277-5803":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bufferutil/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5804"},"imported":[],"importedBy":[{"uid":"5277-5807"}]},"5277-5805":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bufferutil/fallback.js","moduleParts":{"metamask-sdk.js":"5277-5806"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5807"}]},"5277-5807":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bufferutil/index.js","moduleParts":{"metamask-sdk.js":"5277-5808"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5803"},{"uid":"5277-5609"},{"uid":"5277-5805"}],"importedBy":[{"uid":"5277-5809"}]},"5277-5809":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/buffer-util.js","moduleParts":{"metamask-sdk.js":"5277-5810"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5799"},{"uid":"5277-6463"},{"uid":"5277-5807"}],"importedBy":[{"uid":"5277-6464"}]},"5277-5811":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/limiter.js","moduleParts":{"metamask-sdk.js":"5277-5812"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6498"}]},"5277-5813":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/permessage-deflate.js","moduleParts":{"metamask-sdk.js":"5277-5814"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6497"},{"uid":"5277-6464"},{"uid":"5277-6498"},{"uid":"5277-6463"}],"importedBy":[{"uid":"5277-6462"}]},"5277-5815":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/validation.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5816"},"imported":[],"importedBy":[{"uid":"5277-5823"}]},"5277-5817":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/utf-8-validate/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5818"},"imported":[],"importedBy":[{"uid":"5277-5821"}]},"5277-5819":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/utf-8-validate/fallback.js","moduleParts":{"metamask-sdk.js":"5277-5820"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5821"}]},"5277-5821":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/utf-8-validate/index.js","moduleParts":{"metamask-sdk.js":"5277-5822"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5817"},{"uid":"5277-5609"},{"uid":"5277-5819"}],"importedBy":[{"uid":"5277-5823"}]},"5277-5823":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/validation.js","moduleParts":{"metamask-sdk.js":"5277-5824"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5815"},{"uid":"5277-5821"}],"importedBy":[{"uid":"5277-6465"}]},"5277-5825":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/receiver.js","moduleParts":{"metamask-sdk.js":"5277-5826"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6452"},{"uid":"5277-6462"},{"uid":"5277-6463"},{"uid":"5277-6464"},{"uid":"5277-6465"}],"importedBy":[{"uid":"5277-5835"},{"uid":"5277-6471"}]},"5277-5827":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/sender.js","moduleParts":{"metamask-sdk.js":"5277-5828"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6466"},{"uid":"5277-6467"},{"uid":"5277-6396"},{"uid":"5277-6462"},{"uid":"5277-6463"},{"uid":"5277-6465"},{"uid":"5277-6464"}],"importedBy":[{"uid":"5277-5835"},{"uid":"5277-6472"}]},"5277-5829":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/event-target.js","moduleParts":{"metamask-sdk.js":"5277-5830"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6463"}],"importedBy":[{"uid":"5277-6473"}]},"5277-5831":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/extension.js","moduleParts":{"metamask-sdk.js":"5277-5832"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6465"}],"importedBy":[{"uid":"5277-6474"}]},"5277-5833":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/websocket.js","moduleParts":{"metamask-sdk.js":"5277-5834"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6444"},{"uid":"5277-6468"},{"uid":"5277-6469"},{"uid":"5277-6466"},{"uid":"5277-6467"},{"uid":"5277-6396"},{"uid":"5277-6452"},{"uid":"5277-6470"},{"uid":"5277-6462"},{"uid":"5277-6471"},{"uid":"5277-6472"},{"uid":"5277-6463"},{"uid":"5277-6473"},{"uid":"5277-6474"},{"uid":"5277-6464"}],"importedBy":[{"uid":"5277-5835"},{"uid":"5277-6476"}]},"5277-5835":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/wrapper.mjs","moduleParts":{"metamask-sdk.js":"5277-5836"},"imported":[{"uid":"5277-6441"},{"uid":"5277-5825"},{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-6442"}],"importedBy":[{"uid":"5277-5837"}]},"5277-5837":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/websocket-constructor.js","moduleParts":{"metamask-sdk.js":"5277-5838"},"imported":[{"uid":"5277-5835"}],"importedBy":[{"uid":"5277-6387"},{"uid":"5277-5839"},{"uid":"5277-5841"}]},"5277-5839":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/websocket.js","moduleParts":{"metamask-sdk.js":"5277-5840"},"imported":[{"uid":"5277-5789"},{"uid":"5277-5791"},{"uid":"5277-5765"},{"uid":"5277-5837"},{"uid":"5277-5785"},{"uid":"5277-5759"}],"importedBy":[{"uid":"5277-5843"}]},"5277-5841":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/webtransport.js","moduleParts":{"metamask-sdk.js":"5277-5842"},"imported":[{"uid":"5277-5789"},{"uid":"5277-5837"},{"uid":"5277-5759"},{"uid":"5277-5785"}],"importedBy":[{"uid":"5277-5843"}]},"5277-5843":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/index.js","moduleParts":{"metamask-sdk.js":"5277-5844"},"imported":[{"uid":"5277-5797"},{"uid":"5277-5839"},{"uid":"5277-5841"}],"importedBy":[{"uid":"5277-6387"},{"uid":"5277-5847"}]},"5277-5845":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/contrib/parseuri.js","moduleParts":{"metamask-sdk.js":"5277-5846"},"imported":[],"importedBy":[{"uid":"5277-6387"},{"uid":"5277-5847"}]},"5277-5847":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/socket.js","moduleParts":{"metamask-sdk.js":"5277-5848"},"imported":[{"uid":"5277-5843"},{"uid":"5277-5765"},{"uid":"5277-5787"},{"uid":"5277-5845"},{"uid":"5277-5785"},{"uid":"5277-5761"},{"uid":"5277-5759"}],"importedBy":[{"uid":"5277-6387"}]},"5277-5849":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/url.js","moduleParts":{"metamask-sdk.js":"5277-5850"},"imported":[{"uid":"5277-6387"},{"uid":"5277-5785"}],"importedBy":[{"uid":"5277-5865"}]},"5277-5851":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm-debug/is-binary.js","moduleParts":{"metamask-sdk.js":"5277-5852"},"imported":[],"importedBy":[{"uid":"5277-5855"},{"uid":"5277-5853"}]},"5277-5853":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm-debug/binary.js","moduleParts":{"metamask-sdk.js":"5277-5854"},"imported":[{"uid":"5277-5851"}],"importedBy":[{"uid":"5277-5855"}]},"5277-5855":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm-debug/index.js","moduleParts":{"metamask-sdk.js":"5277-5856"},"imported":[{"uid":"5277-5761"},{"uid":"5277-5853"},{"uid":"5277-5851"},{"uid":"5277-5785"}],"importedBy":[{"uid":"5277-5865"},{"uid":"5277-5863"},{"uid":"5277-5859"}]},"5277-5857":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/on.js","moduleParts":{"metamask-sdk.js":"5277-5858"},"imported":[],"importedBy":[{"uid":"5277-5863"},{"uid":"5277-5859"}]},"5277-5859":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/socket.js","moduleParts":{"metamask-sdk.js":"5277-5860"},"imported":[{"uid":"5277-5855"},{"uid":"5277-5857"},{"uid":"5277-5761"},{"uid":"5277-5785"}],"importedBy":[{"uid":"5277-5865"},{"uid":"5277-5863"}]},"5277-5861":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/contrib/backo2.js","moduleParts":{"metamask-sdk.js":"5277-5862"},"imported":[],"importedBy":[{"uid":"5277-5863"}]},"5277-5863":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/manager.js","moduleParts":{"metamask-sdk.js":"5277-5864"},"imported":[{"uid":"5277-6387"},{"uid":"5277-5859"},{"uid":"5277-5855"},{"uid":"5277-5857"},{"uid":"5277-5861"},{"uid":"5277-5761"},{"uid":"5277-5785"}],"importedBy":[{"uid":"5277-5865"}]},"5277-5865":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/index.js","moduleParts":{"metamask-sdk.js":"5277-5866"},"imported":[{"uid":"5277-5849"},{"uid":"5277-5863"},{"uid":"5277-5859"},{"uid":"5277-5785"},{"uid":"5277-5855"}],"importedBy":[{"uid":"5277-5903"}]},"5277-5867":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/node-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5868"},"imported":[],"importedBy":[{"uid":"5277-5901"}]},"5277-5869":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/public-api.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5870"},"imported":[],"importedBy":[{"uid":"5277-5895"}]},"5277-5871":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/URL.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5872"},"imported":[],"importedBy":[{"uid":"5277-5893"}]},"5277-5873":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/node_modules/webidl-conversions/lib/index.js","moduleParts":{"metamask-sdk.js":"5277-5874"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6477"}]},"5277-5875":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/utils.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5876"},"imported":[],"importedBy":[{"uid":"5277-5877"}]},"5277-5877":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/utils.js","moduleParts":{"metamask-sdk.js":"5277-5878"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5875"}],"importedBy":[{"uid":"5277-6478"}]},"5277-5879":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/URL-impl.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5880"},"imported":[],"importedBy":[{"uid":"5277-5891"}]},"5277-5881":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/url-state-machine.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-5882"},"imported":[],"importedBy":[{"uid":"5277-5889"}]},"5277-5883":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/tr46/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5884"},"imported":[],"importedBy":[{"uid":"5277-5887"}]},"5277-5885":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/tr46/lib/mappingTable.json","moduleParts":{"metamask-sdk.js":"5277-5886"},"imported":[],"importedBy":[{"uid":"5277-6499"}]},"5277-5887":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/tr46/index.js","moduleParts":{"metamask-sdk.js":"5277-5888"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5883"},{"uid":"5277-6480"},{"uid":"5277-6499"}],"importedBy":[{"uid":"5277-6481"}]},"5277-5889":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/url-state-machine.js","moduleParts":{"metamask-sdk.js":"5277-5890"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5881"},{"uid":"5277-6480"},{"uid":"5277-6481"}],"importedBy":[{"uid":"5277-6424"}]},"5277-5891":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/URL-impl.js","moduleParts":{"metamask-sdk.js":"5277-5892"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5879"},{"uid":"5277-6424"}],"importedBy":[{"uid":"5277-6479"}]},"5277-5893":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/URL.js","moduleParts":{"metamask-sdk.js":"5277-5894"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5871"},{"uid":"5277-6477"},{"uid":"5277-6478"},{"uid":"5277-6479"}],"importedBy":[{"uid":"5277-6423"}]},"5277-5895":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/public-api.js","moduleParts":{"metamask-sdk.js":"5277-5896"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5869"},{"uid":"5277-6423"},{"uid":"5277-6424"}],"importedBy":[{"uid":"5277-5897"},{"uid":"5277-6179"}]},"5277-5897":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/node_modules/node-fetch/lib/index.mjs","moduleParts":{"metamask-sdk.js":"5277-5898"},"imported":[{"uid":"5277-6401"},{"uid":"5277-6402"},{"uid":"5277-6403"},{"uid":"5277-5895"},{"uid":"5277-6404"},{"uid":"5277-6405"}],"importedBy":[{"uid":"5277-5899"}]},"5277-5899":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/node_modules/node-fetch/lib/index.mjs?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-5900"},"imported":[{"uid":"5277-5897"},{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5901"}]},"5277-5901":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/node-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-5902"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5867"},{"uid":"5277-5899"}],"importedBy":[{"uid":"5277-5903"}]},"5277-5903":{"id":"-communication-layer/dist/node/es/metamask-sdk-communication-layer.js","moduleParts":{"metamask-sdk.js":"5277-5904"},"imported":[{"uid":"5277-6365"},{"uid":"5277-5737"},{"uid":"5277-5741"},{"uid":"5277-6366"},{"uid":"5277-5865"},{"uid":"5277-5901"}],"importedBy":[{"uid":"5277-6363"},{"uid":"5277-6151"},{"uid":"5277-6157"},{"uid":"5277-6159"},{"uid":"5277-6191"},{"uid":"5277-6355"},{"uid":"5277-6193"},{"uid":"5277-6207"},{"uid":"5277-6291"},{"uid":"5277-6155"},{"uid":"5277-6189"},{"uid":"5277-6245"},{"uid":"5277-6153"},{"uid":"5277-6231"},{"uid":"5277-6251"},{"uid":"5277-6171"},{"uid":"5277-6269"},{"uid":"5277-6275"},{"uid":"5277-6285"}]},"5277-5905":{"id":"\u0000tslib.js","moduleParts":{"metamask-sdk.js":"5277-5906"},"imported":[],"importedBy":[{"uid":"5277-6105"},{"uid":"5277-6361"},{"uid":"5277-6103"},{"uid":"5277-6359"},{"uid":"5277-6143"},{"uid":"5277-6145"},{"uid":"5277-6157"},{"uid":"5277-6357"},{"uid":"5277-6191"},{"uid":"5277-6355"},{"uid":"5277-6193"},{"uid":"5277-6199"},{"uid":"5277-6207"},{"uid":"5277-6247"},{"uid":"5277-6291"},{"uid":"5277-6297"},{"uid":"5277-6155"},{"uid":"5277-6189"},{"uid":"5277-6299"},{"uid":"5277-6301"},{"uid":"5277-6353"},{"uid":"5277-6197"},{"uid":"5277-6205"},{"uid":"5277-6259"},{"uid":"5277-6153"},{"uid":"5277-6185"},{"uid":"5277-6201"},{"uid":"5277-6243"},{"uid":"5277-6249"},{"uid":"5277-6251"},{"uid":"5277-6255"},{"uid":"5277-6257"},{"uid":"5277-6289"},{"uid":"5277-6293"},{"uid":"5277-6171"},{"uid":"5277-6169"},{"uid":"5277-6271"},{"uid":"5277-6275"},{"uid":"5277-6461"},{"uid":"5277-6283"},{"uid":"5277-6285"},{"uid":"5277-6281"},{"uid":"5277-6279"}]},"5277-5907":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5908"},"imported":[],"importedBy":[{"uid":"5277-6095"}]},"5277-5909":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5910"},"imported":[],"importedBy":[{"uid":"5277-5979"}]},"5277-5911":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5912"},"imported":[],"importedBy":[{"uid":"5277-5913"}]},"5277-5913":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-5914"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5911"},{"uid":"5277-6444"}],"importedBy":[{"uid":"5277-6406"}]},"5277-5915":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5916"},"imported":[],"importedBy":[{"uid":"5277-5935"}]},"5277-5917":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5918"},"imported":[],"importedBy":[{"uid":"5277-5921"}]},"5277-5919":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js","moduleParts":{"metamask-sdk.js":"5277-5920"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6425"}]},"5277-5921":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js","moduleParts":{"metamask-sdk.js":"5277-5922"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5917"},{"uid":"5277-6425"}],"importedBy":[{"uid":"5277-6388"}]},"5277-5923":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5924"},"imported":[],"importedBy":[{"uid":"5277-5929"}]},"5277-5925":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5926"},"imported":[],"importedBy":[{"uid":"5277-5927"}]},"5277-5927":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js","moduleParts":{"metamask-sdk.js":"5277-5928"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5925"}],"importedBy":[{"uid":"5277-6391"}]},"5277-5929":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-5930"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5923"},{"uid":"5277-6391"},{"uid":"5277-6388"}],"importedBy":[{"uid":"5277-6389"}]},"5277-5931":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5932"},"imported":[],"importedBy":[{"uid":"5277-5933"}]},"5277-5933":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js","moduleParts":{"metamask-sdk.js":"5277-5934"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5931"},{"uid":"5277-6388"},{"uid":"5277-6389"},{"uid":"5277-6391"}],"importedBy":[{"uid":"5277-6390"}]},"5277-5935":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-5936"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5915"},{"uid":"5277-6388"},{"uid":"5277-6389"},{"uid":"5277-6390"},{"uid":"5277-6391"}],"importedBy":[{"uid":"5277-6099"},{"uid":"5277-6407"}]},"5277-5937":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js","moduleParts":{"metamask-sdk.js":"5277-5938"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6408"}]},"5277-5939":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5940"},"imported":[],"importedBy":[{"uid":"5277-5965"}]},"5277-5941":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5942"},"imported":[],"importedBy":[{"uid":"5277-5947"}]},"5277-5943":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5944"},"imported":[],"importedBy":[{"uid":"5277-5945"}]},"5277-5945":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js","moduleParts":{"metamask-sdk.js":"5277-5946"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5943"}],"importedBy":[{"uid":"5277-6448"}]},"5277-5947":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-5948"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5941"},{"uid":"5277-6448"}],"importedBy":[{"uid":"5277-6445"}]},"5277-5949":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5950"},"imported":[],"importedBy":[{"uid":"5277-5951"}]},"5277-5951":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-5952"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5949"}],"importedBy":[{"uid":"5277-6446"}]},"5277-5953":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5954"},"imported":[],"importedBy":[{"uid":"5277-5955"}]},"5277-5955":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-5956"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5953"}],"importedBy":[{"uid":"5277-6447"}]},"5277-5957":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5958"},"imported":[],"importedBy":[{"uid":"5277-5959"}]},"5277-5959":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js","moduleParts":{"metamask-sdk.js":"5277-5960"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5957"},{"uid":"5277-6406"},{"uid":"5277-6407"}],"importedBy":[{"uid":"5277-6449"}]},"5277-5961":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5962"},"imported":[],"importedBy":[{"uid":"5277-5963"}]},"5277-5963":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-5964"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5961"},{"uid":"5277-6449"}],"importedBy":[{"uid":"5277-6450"}]},"5277-5965":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-5966"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5939"},{"uid":"5277-6445"},{"uid":"5277-6446"},{"uid":"5277-6447"},{"uid":"5277-6448"},{"uid":"5277-6449"},{"uid":"5277-6450"}],"importedBy":[{"uid":"5277-6409"}]},"5277-5967":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5968"},"imported":[],"importedBy":[{"uid":"5277-5969"}]},"5277-5969":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js","moduleParts":{"metamask-sdk.js":"5277-5970"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5967"}],"importedBy":[{"uid":"5277-6410"}]},"5277-5971":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5972"},"imported":[],"importedBy":[{"uid":"5277-5977"}]},"5277-5973":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5974"},"imported":[],"importedBy":[{"uid":"5277-5975"}]},"5277-5975":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-5976"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5973"},{"uid":"5277-6410"}],"importedBy":[{"uid":"5277-6451"}]},"5277-5977":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-5978"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5971"},{"uid":"5277-6409"},{"uid":"5277-6407"},{"uid":"5277-6451"}],"importedBy":[{"uid":"5277-6411"}]},"5277-5979":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js","moduleParts":{"metamask-sdk.js":"5277-5980"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5909"},{"uid":"5277-6406"},{"uid":"5277-6407"},{"uid":"5277-6408"},{"uid":"5277-6409"},{"uid":"5277-6410"},{"uid":"5277-6411"}],"importedBy":[{"uid":"5277-6378"}]},"5277-5981":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5982"},"imported":[],"importedBy":[{"uid":"5277-6085"}]},"5277-5983":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5984"},"imported":[],"importedBy":[{"uid":"5277-5985"}]},"5277-5985":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-5986"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5983"},{"uid":"5277-6452"}],"importedBy":[{"uid":"5277-6412"}]},"5277-5987":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/es/index.js","moduleParts":{"metamask-sdk.js":"5277-5988"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-5989"}]},"5277-5989":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/es/index.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-5990"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5987"}],"importedBy":[{"uid":"5277-6085"}]},"5277-5991":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5992"},"imported":[],"importedBy":[{"uid":"5277-6081"}]},"5277-5993":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5994"},"imported":[],"importedBy":[{"uid":"5277-5995"}]},"5277-5995":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js","moduleParts":{"metamask-sdk.js":"5277-5996"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5993"},{"uid":"5277-6410"},{"uid":"5277-6411"}],"importedBy":[{"uid":"5277-6414"}]},"5277-5997":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-5998"},"imported":[],"importedBy":[{"uid":"5277-6079"}]},"5277-5999":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6000"},"imported":[],"importedBy":[{"uid":"5277-6055"}]},"5277-6001":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6002"},"imported":[],"importedBy":[{"uid":"5277-6041"}]},"5277-6003":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6004"},"imported":[],"importedBy":[{"uid":"5277-6005"}]},"5277-6005":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js","moduleParts":{"metamask-sdk.js":"5277-6006"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6003"}],"importedBy":[{"uid":"5277-6035"},{"uid":"5277-6027"},{"uid":"5277-6029"},{"uid":"5277-6023"}]},"5277-6007":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/isarray/index.js","moduleParts":{"metamask-sdk.js":"5277-6008"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6035"}]},"5277-6009":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/stream.js","moduleParts":{"metamask-sdk.js":"5277-6010"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6452"}],"importedBy":[{"uid":"5277-6035"},{"uid":"5277-6027"}]},"5277-6011":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6012"},"imported":[],"importedBy":[{"uid":"5277-6013"}]},"5277-6013":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js","moduleParts":{"metamask-sdk.js":"5277-6014"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6011"},{"uid":"5277-6484"}],"importedBy":[{"uid":"5277-6035"},{"uid":"5277-6027"},{"uid":"5277-6021"},{"uid":"5277-6033"}]},"5277-6015":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6016"},"imported":[],"importedBy":[{"uid":"5277-6017"}]},"5277-6017":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js","moduleParts":{"metamask-sdk.js":"5277-6018"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6015"},{"uid":"5277-6484"}],"importedBy":[{"uid":"5277-6035"},{"uid":"5277-6027"},{"uid":"5277-6029"},{"uid":"5277-6037"},{"uid":"5277-6039"}]},"5277-6019":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6020"},"imported":[],"importedBy":[{"uid":"5277-6021"}]},"5277-6021":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js","moduleParts":{"metamask-sdk.js":"5277-6022"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6019"},{"uid":"5277-6013"},{"uid":"5277-6400"}],"importedBy":[{"uid":"5277-6035"}]},"5277-6023":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-6024"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6005"}],"importedBy":[{"uid":"5277-6035"},{"uid":"5277-6027"}]},"5277-6025":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/util-deprecate/node.js","moduleParts":{"metamask-sdk.js":"5277-6026"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6400"}],"importedBy":[{"uid":"5277-6027"}]},"5277-6027":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-6028"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6005"},{"uid":"5277-6017"},{"uid":"5277-5647"},{"uid":"5277-6025"},{"uid":"5277-6009"},{"uid":"5277-6013"},{"uid":"5277-6023"},{"uid":"5277-6029"}],"importedBy":[{"uid":"5277-6041"},{"uid":"5277-6029"}]},"5277-6029":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-6030"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6005"},{"uid":"5277-6017"},{"uid":"5277-5647"},{"uid":"5277-6035"},{"uid":"5277-6027"}],"importedBy":[{"uid":"5277-6041"},{"uid":"5277-6035"},{"uid":"5277-6027"},{"uid":"5277-6037"}]},"5277-6031":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6032"},"imported":[],"importedBy":[{"uid":"5277-6033"}]},"5277-6033":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-6034"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6031"},{"uid":"5277-6013"}],"importedBy":[{"uid":"5277-6035"}]},"5277-6035":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-6036"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6005"},{"uid":"5277-6007"},{"uid":"5277-6444"},{"uid":"5277-6009"},{"uid":"5277-6013"},{"uid":"5277-6017"},{"uid":"5277-5647"},{"uid":"5277-6400"},{"uid":"5277-6021"},{"uid":"5277-6023"},{"uid":"5277-6029"},{"uid":"5277-6033"}],"importedBy":[{"uid":"5277-6041"},{"uid":"5277-6029"}]},"5277-6037":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-6038"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6029"},{"uid":"5277-6017"},{"uid":"5277-5647"}],"importedBy":[{"uid":"5277-6041"},{"uid":"5277-6039"}]},"5277-6039":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-6040"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6037"},{"uid":"5277-6017"},{"uid":"5277-5647"}],"importedBy":[{"uid":"5277-6041"}]},"5277-6041":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable.js","moduleParts":{"metamask-sdk.js":"5277-6042"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6001"},{"uid":"5277-6452"},{"uid":"5277-6035"},{"uid":"5277-6027"},{"uid":"5277-6029"},{"uid":"5277-6037"},{"uid":"5277-6039"}],"importedBy":[{"uid":"5277-6490"}]},"5277-6043":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6044"},"imported":[],"importedBy":[{"uid":"5277-6047"}]},"5277-6045":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js","moduleParts":{"metamask-sdk.js":"5277-6046"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6493"}]},"5277-6047":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js","moduleParts":{"metamask-sdk.js":"5277-6048"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6043"},{"uid":"5277-6493"}],"importedBy":[{"uid":"5277-6456"}]},"5277-6049":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-6050"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6456"}],"importedBy":[{"uid":"5277-6457"}]},"5277-6051":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6052"},"imported":[],"importedBy":[{"uid":"5277-6053"}]},"5277-6053":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js","moduleParts":{"metamask-sdk.js":"5277-6054"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6051"},{"uid":"5277-6490"}],"importedBy":[{"uid":"5277-6491"}]},"5277-6055":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js","moduleParts":{"metamask-sdk.js":"5277-6056"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5999"},{"uid":"5277-6490"},{"uid":"5277-6457"},{"uid":"5277-6456"},{"uid":"5277-6491"}],"importedBy":[{"uid":"5277-6453"}]},"5277-6057":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-6058"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6453"}],"importedBy":[{"uid":"5277-6415"}]},"5277-6059":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-6060"},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6416"}]},"5277-6061":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6062"},"imported":[],"importedBy":[{"uid":"5277-6075"}]},"5277-6063":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6064"},"imported":[],"importedBy":[{"uid":"5277-6065"}]},"5277-6065":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js","moduleParts":{"metamask-sdk.js":"5277-6066"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6063"},{"uid":"5277-6490"}],"importedBy":[{"uid":"5277-6454"}]},"5277-6067":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6068"},"imported":[],"importedBy":[{"uid":"5277-6073"}]},"5277-6069":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6070"},"imported":[],"importedBy":[{"uid":"5277-6071"}]},"5277-6071":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-6072"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6069"},{"uid":"5277-6444"}],"importedBy":[{"uid":"5277-6492"}]},"5277-6073":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-6074"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6067"},{"uid":"5277-6492"},{"uid":"5277-6490"}],"importedBy":[{"uid":"5277-6455"}]},"5277-6075":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-6076"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6061"},{"uid":"5277-6454"},{"uid":"5277-6455"}],"importedBy":[{"uid":"5277-6417"}]},"5277-6077":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js","moduleParts":{"metamask-sdk.js":"5277-6078"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6456"},{"uid":"5277-6457"},{"uid":"5277-6458"}],"importedBy":[{"uid":"5277-6418"}]},"5277-6079":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js","moduleParts":{"metamask-sdk.js":"5277-6080"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5997"},{"uid":"5277-6415"},{"uid":"5277-6416"},{"uid":"5277-6417"},{"uid":"5277-6418"},{"uid":"5277-6410"},{"uid":"5277-6411"},{"uid":"5277-6378"}],"importedBy":[{"uid":"5277-6383"}]},"5277-6081":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-6082"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5991"},{"uid":"5277-6407"},{"uid":"5277-6414"},{"uid":"5277-6410"},{"uid":"5277-6411"},{"uid":"5277-6383"}],"importedBy":[{"uid":"5277-6381"}]},"5277-6083":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json","moduleParts":{"metamask-sdk.js":"5277-6084"},"imported":[],"importedBy":[{"uid":"5277-6413"}]},"5277-6085":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js","moduleParts":{"metamask-sdk.js":"5277-6086"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5981"},{"uid":"5277-6412"},{"uid":"5277-5989"},{"uid":"5277-6381"},{"uid":"5277-6383"},{"uid":"5277-6411"},{"uid":"5277-6413"}],"importedBy":[{"uid":"5277-6379"}]},"5277-6087":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6088"},"imported":[],"importedBy":[{"uid":"5277-6093"}]},"5277-6089":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6090"},"imported":[],"importedBy":[{"uid":"5277-6091"}]},"5277-6091":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js","moduleParts":{"metamask-sdk.js":"5277-6092"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6089"}],"importedBy":[{"uid":"5277-6382"}]},"5277-6093":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-6094"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6087"},{"uid":"5277-6381"},{"uid":"5277-6382"}],"importedBy":[{"uid":"5277-6380"}]},"5277-6095":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-6096"},"imported":[{"uid":"5277-5591"},{"uid":"5277-5907"},{"uid":"5277-6378"},{"uid":"5277-6379"},{"uid":"5277-6380"},{"uid":"5277-6381"},{"uid":"5277-6382"},{"uid":"5277-6383"}],"importedBy":[{"uid":"5277-6105"},{"uid":"5277-6165"}]},"5277-6097":{"id":"/src/services/SDKProvider/ChainManager/handleChainChanged.ts","moduleParts":{"metamask-sdk.js":"5277-6098"},"imported":[],"importedBy":[{"uid":"5277-6105"}]},"5277-6099":{"id":"/src/services/SDKProvider/ConnectionManager/handleDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-6100"},"imported":[{"uid":"5277-5935"}],"importedBy":[{"uid":"5277-6105"}]},"5277-6101":{"id":"/src/services/SDKProvider/InitializationManager/initializeState.ts","moduleParts":{"metamask-sdk.js":"5277-6102"},"imported":[],"importedBy":[{"uid":"5277-6105"}]},"5277-6103":{"id":"/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts","moduleParts":{"metamask-sdk.js":"5277-6104"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6105"}]},"5277-6105":{"id":"/src/provider/SDKProvider.ts","moduleParts":{"metamask-sdk.js":"5277-6106"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6095"},{"uid":"5277-6097"},{"uid":"5277-6099"},{"uid":"5277-6101"},{"uid":"5277-6103"}],"importedBy":[{"uid":"5277-6363"},{"uid":"5277-6165"}]},"5277-6107":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-6108"},"imported":[],"importedBy":[{"uid":"5277-6141"},{"uid":"5277-6123"},{"uid":"5277-6113"},{"uid":"5277-6111"}]},"5277-6109":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-6110"},"imported":[],"importedBy":[{"uid":"5277-6141"}]},"5277-6111":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-6112"},"imported":[{"uid":"5277-6107"}],"importedBy":[{"uid":"5277-6113"}]},"5277-6113":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-6114"},"imported":[{"uid":"5277-6107"},{"uid":"5277-6111"}],"importedBy":[{"uid":"5277-6115"},{"uid":"5277-6127"}]},"5277-6115":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-6116"},"imported":[{"uid":"5277-6113"}],"importedBy":[{"uid":"5277-6141"}]},"5277-6117":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js","moduleParts":{"metamask-sdk.js":"5277-6118"},"imported":[],"importedBy":[{"uid":"5277-6141"},{"uid":"5277-6123"}]},"5277-6119":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-6120"},"imported":[],"importedBy":[{"uid":"5277-6121"}]},"5277-6121":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/inherits.js","moduleParts":{"metamask-sdk.js":"5277-6122"},"imported":[{"uid":"5277-6119"}],"importedBy":[{"uid":"5277-6141"}]},"5277-6123":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js","moduleParts":{"metamask-sdk.js":"5277-6124"},"imported":[{"uid":"5277-6107"},{"uid":"5277-6117"}],"importedBy":[{"uid":"5277-6141"}]},"5277-6125":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/getPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-6126"},"imported":[],"importedBy":[{"uid":"5277-6141"}]},"5277-6127":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/defineProperty.js","moduleParts":{"metamask-sdk.js":"5277-6128"},"imported":[{"uid":"5277-6113"}],"importedBy":[{"uid":"5277-6141"}]},"5277-6129":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js","moduleParts":{"metamask-sdk.js":"5277-6130"},"imported":[],"importedBy":[{"uid":"5277-6139"}]},"5277-6131":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/iterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-6132"},"imported":[],"importedBy":[{"uid":"5277-6139"}]},"5277-6133":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js","moduleParts":{"metamask-sdk.js":"5277-6134"},"imported":[],"importedBy":[{"uid":"5277-6135"}]},"5277-6135":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-6136"},"imported":[{"uid":"5277-6133"}],"importedBy":[{"uid":"5277-6139"}]},"5277-6137":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js","moduleParts":{"metamask-sdk.js":"5277-6138"},"imported":[],"importedBy":[{"uid":"5277-6139"}]},"5277-6139":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toArray.js","moduleParts":{"metamask-sdk.js":"5277-6140"},"imported":[{"uid":"5277-6129"},{"uid":"5277-6131"},{"uid":"5277-6135"},{"uid":"5277-6137"}],"importedBy":[{"uid":"5277-6141"}]},"5277-6141":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/dist/esm/i18next.js","moduleParts":{"metamask-sdk.js":"5277-6142"},"imported":[{"uid":"5277-6107"},{"uid":"5277-6109"},{"uid":"5277-6115"},{"uid":"5277-6117"},{"uid":"5277-6121"},{"uid":"5277-6123"},{"uid":"5277-6125"},{"uid":"5277-6127"},{"uid":"5277-6139"}],"importedBy":[{"uid":"5277-6361"}]},"5277-6143":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connect.ts","moduleParts":{"metamask-sdk.js":"5277-6144"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6367"}]},"5277-6145":{"id":"/src/services/MetaMaskSDK/ConnectionManager/resume.ts","moduleParts":{"metamask-sdk.js":"5277-6146"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6367"}]},"5277-6147":{"id":"/src/config.ts","moduleParts":{"metamask-sdk.js":"5277-6148"},"imported":[],"importedBy":[{"uid":"5277-6359"},{"uid":"5277-6151"},{"uid":"5277-6157"},{"uid":"5277-6207"},{"uid":"5277-6189"},{"uid":"5277-6153"},{"uid":"5277-6201"},{"uid":"5277-6293"},{"uid":"5277-6169"}]},"5277-6149":{"id":"/src/types/ProviderUpdateType.ts","moduleParts":{"metamask-sdk.js":"5277-6150"},"imported":[],"importedBy":[{"uid":"5277-6363"},{"uid":"5277-6151"},{"uid":"5277-6355"},{"uid":"5277-6189"},{"uid":"5277-6153"}]},"5277-6151":{"id":"/src/services/MetaMaskSDK/ConnectionManager/terminate.ts","moduleParts":{"metamask-sdk.js":"5277-6152"},"imported":[{"uid":"5277-5903"},{"uid":"5277-6147"},{"uid":"5277-6149"}],"importedBy":[{"uid":"5277-6367"}]},"5277-6153":{"id":"/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-6154"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6147"},{"uid":"5277-6149"}],"importedBy":[{"uid":"5277-6392"}]},"5277-6155":{"id":"/src/services/Analytics.ts","moduleParts":{"metamask-sdk.js":"5277-6156"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"}],"importedBy":[{"uid":"5277-6157"},{"uid":"5277-6193"}]},"5277-6157":{"id":"/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts","moduleParts":{"metamask-sdk.js":"5277-6158"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6147"},{"uid":"5277-6392"},{"uid":"5277-6155"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6159":{"id":"/src/services/MetaMaskSDK/InitializerManager/initEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-6160"},"imported":[{"uid":"5277-5903"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6191"}]},"5277-6161":{"id":"/src/constants.ts","moduleParts":{"metamask-sdk.js":"5277-6162"},"imported":[],"importedBy":[{"uid":"5277-6189"},{"uid":"5277-6203"},{"uid":"5277-6163"},{"uid":"5277-6169"},{"uid":"5277-6271"},{"uid":"5277-6275"},{"uid":"5277-6283"},{"uid":"5277-6281"}]},"5277-6163":{"id":"/src/services/RemoteCommunicationPostMessageStream/onMessage.ts","moduleParts":{"metamask-sdk.js":"5277-6164"},"imported":[{"uid":"5277-6365"},{"uid":"5277-6161"}],"importedBy":[{"uid":"5277-6171"}]},"5277-6165":{"id":"/src/services/Ethereum.ts","moduleParts":{"metamask-sdk.js":"5277-6166"},"imported":[{"uid":"5277-6095"},{"uid":"5277-6105"}],"importedBy":[{"uid":"5277-6207"},{"uid":"5277-6189"},{"uid":"5277-6233"},{"uid":"5277-6255"},{"uid":"5277-6289"},{"uid":"5277-6169"},{"uid":"5277-6461"},{"uid":"5277-6283"},{"uid":"5277-6285"},{"uid":"5277-6281"}]},"5277-6167":{"id":"/src/services/RemoteCommunicationPostMessageStream/extractMethod.ts","moduleParts":{"metamask-sdk.js":"5277-6168"},"imported":[{"uid":"5277-6365"}],"importedBy":[{"uid":"5277-6169"}]},"5277-6169":{"id":"/src/services/RemoteCommunicationPostMessageStream/write.ts","moduleParts":{"metamask-sdk.js":"5277-6170"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6147"},{"uid":"5277-6161"},{"uid":"5277-6165"},{"uid":"5277-6167"}],"importedBy":[{"uid":"5277-6171"}]},"5277-6171":{"id":"/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-6172"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6401"},{"uid":"5277-5903"},{"uid":"5277-6163"},{"uid":"5277-6169"}],"importedBy":[{"uid":"5277-6173"}]},"5277-6173":{"id":"/src/PostMessageStream/getPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-6174"},"imported":[{"uid":"5277-6171"}],"importedBy":[{"uid":"5277-6189"}]},"5277-6175":{"id":"/src/utils/wait.ts","moduleParts":{"metamask-sdk.js":"5277-6176"},"imported":[],"importedBy":[{"uid":"5277-6189"},{"uid":"5277-6257"}]},"5277-6177":{"id":"\u0000/node_modules/cross-fetch/dist/node-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6178"},"imported":[],"importedBy":[{"uid":"5277-6183"}]},"5277-6179":{"id":"/node_modules/node-fetch/lib/index.mjs","moduleParts":{"metamask-sdk.js":"5277-6180"},"imported":[{"uid":"5277-6401"},{"uid":"5277-6402"},{"uid":"5277-6403"},{"uid":"5277-5895"},{"uid":"5277-6404"},{"uid":"5277-6405"}],"importedBy":[{"uid":"5277-6181"}]},"5277-6181":{"id":"\u0000/node_modules/node-fetch/lib/index.mjs?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-6182"},"imported":[{"uid":"5277-6179"},{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6183"}]},"5277-6183":{"id":"/node_modules/cross-fetch/dist/node-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-6184"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6177"},{"uid":"5277-6181"}],"importedBy":[{"uid":"5277-6185"}]},"5277-6185":{"id":"/src/services/rpc-requests/RPCRequestHandler.ts","moduleParts":{"metamask-sdk.js":"5277-6186"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6183"}],"importedBy":[{"uid":"5277-6189"}]},"5277-6187":{"id":"/package.json","moduleParts":{"metamask-sdk.js":"5277-6188"},"imported":[],"importedBy":[{"uid":"5277-6189"},{"uid":"5277-6269"}]},"5277-6189":{"id":"/src/provider/initializeMobileProvider.ts","moduleParts":{"metamask-sdk.js":"5277-6190"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6173"},{"uid":"5277-6147"},{"uid":"5277-6161"},{"uid":"5277-6165"},{"uid":"5277-6149"},{"uid":"5277-6175"},{"uid":"5277-6185"},{"uid":"5277-6187"}],"importedBy":[{"uid":"5277-6191"}]},"5277-6191":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeProviderAndEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-6192"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6189"},{"uid":"5277-6159"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6193":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.ts","moduleParts":{"metamask-sdk.js":"5277-6194"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6155"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6195":{"id":"/src/utils/extractFavicon.ts","moduleParts":{"metamask-sdk.js":"5277-6196"},"imported":[],"importedBy":[{"uid":"5277-6199"}]},"5277-6197":{"id":"/src/utils/getBase64FromUrl.ts","moduleParts":{"metamask-sdk.js":"5277-6198"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6199"}]},"5277-6199":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.ts","moduleParts":{"metamask-sdk.js":"5277-6200"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6195"},{"uid":"5277-6197"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6201":{"id":"/src/provider/wrapExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-6202"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6147"}],"importedBy":[{"uid":"5277-6205"}]},"5277-6203":{"id":"/src/utils/eip6963RequestProvider.ts","moduleParts":{"metamask-sdk.js":"5277-6204"},"imported":[{"uid":"5277-6161"}],"importedBy":[{"uid":"5277-6205"}]},"5277-6205":{"id":"/src/utils/get-browser-extension.ts","moduleParts":{"metamask-sdk.js":"5277-6206"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6201"},{"uid":"5277-6203"}],"importedBy":[{"uid":"5277-6207"}]},"5277-6207":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts","moduleParts":{"metamask-sdk.js":"5277-6208"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6147"},{"uid":"5277-6205"},{"uid":"5277-6165"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6209":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/constants.js","moduleParts":{"metamask-sdk.js":"5277-6210"},"imported":[],"importedBy":[{"uid":"5277-6223"},{"uid":"5277-6215"},{"uid":"5277-6217"},{"uid":"5277-6219"},{"uid":"5277-6211"}]},"5277-6211":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/utils.js","moduleParts":{"metamask-sdk.js":"5277-6212"},"imported":[{"uid":"5277-6209"}],"importedBy":[{"uid":"5277-6221"},{"uid":"5277-6213"},{"uid":"5277-6215"},{"uid":"5277-6217"},{"uid":"5277-6219"}]},"5277-6213":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/parser-browsers.js","moduleParts":{"metamask-sdk.js":"5277-6214"},"imported":[{"uid":"5277-6211"}],"importedBy":[{"uid":"5277-6221"}]},"5277-6215":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/parser-os.js","moduleParts":{"metamask-sdk.js":"5277-6216"},"imported":[{"uid":"5277-6211"},{"uid":"5277-6209"}],"importedBy":[{"uid":"5277-6221"}]},"5277-6217":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/parser-platforms.js","moduleParts":{"metamask-sdk.js":"5277-6218"},"imported":[{"uid":"5277-6211"},{"uid":"5277-6209"}],"importedBy":[{"uid":"5277-6221"}]},"5277-6219":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/parser-engines.js","moduleParts":{"metamask-sdk.js":"5277-6220"},"imported":[{"uid":"5277-6211"},{"uid":"5277-6209"}],"importedBy":[{"uid":"5277-6221"}]},"5277-6221":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/parser.js","moduleParts":{"metamask-sdk.js":"5277-6222"},"imported":[{"uid":"5277-6213"},{"uid":"5277-6215"},{"uid":"5277-6217"},{"uid":"5277-6219"},{"uid":"5277-6211"}],"importedBy":[{"uid":"5277-6223"}]},"5277-6223":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/src/bowser.js","moduleParts":{"metamask-sdk.js":"5277-6224"},"imported":[{"uid":"5277-6221"},{"uid":"5277-6209"}],"importedBy":[{"uid":"5277-6245"},{"uid":"5277-6253"}]},"5277-6225":{"id":"/src/types/WakeLockStatus.ts","moduleParts":{"metamask-sdk.js":"5277-6226"},"imported":[],"importedBy":[{"uid":"5277-6245"},{"uid":"5277-6227"},{"uid":"5277-6229"}]},"5277-6227":{"id":"/src/services/PlatfformManager/disableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-6228"},"imported":[{"uid":"5277-6225"}],"importedBy":[{"uid":"5277-6245"}]},"5277-6229":{"id":"/src/services/PlatfformManager/enableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-6230"},"imported":[{"uid":"5277-6245"},{"uid":"5277-6225"}],"importedBy":[{"uid":"5277-6245"}]},"5277-6231":{"id":"/src/services/PlatfformManager/getPlatformType.ts","moduleParts":{"metamask-sdk.js":"5277-6232"},"imported":[{"uid":"5277-5903"}],"importedBy":[{"uid":"5277-6245"}]},"5277-6233":{"id":"/src/services/PlatfformManager/isMetaMaskInstalled.ts","moduleParts":{"metamask-sdk.js":"5277-6234"},"imported":[{"uid":"5277-6165"}],"importedBy":[{"uid":"5277-6245"}]},"5277-6235":{"id":"/src/services/PlatfformManager/openDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-6236"},"imported":[{"uid":"5277-6245"}],"importedBy":[{"uid":"5277-6245"}]},"5277-6237":{"id":"/src/utils/hasNativeWakeLockSupport.ts","moduleParts":{"metamask-sdk.js":"5277-6238"},"imported":[],"importedBy":[{"uid":"5277-6243"}]},"5277-6239":{"id":"/src/utils/isOldIOS.ts","moduleParts":{"metamask-sdk.js":"5277-6240"},"imported":[],"importedBy":[{"uid":"5277-6243"}]},"5277-6241":{"id":"/src/Platform/Media.ts","moduleParts":{"metamask-sdk.js":"5277-6242"},"imported":[],"importedBy":[{"uid":"5277-6243"}]},"5277-6243":{"id":"/src/Platform/WakeLockManager.ts","moduleParts":{"metamask-sdk.js":"5277-6244"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6237"},{"uid":"5277-6239"},{"uid":"5277-6241"}],"importedBy":[{"uid":"5277-6245"}]},"5277-6245":{"id":"/src/Platform/PlatfformManager.ts","moduleParts":{"metamask-sdk.js":"5277-6246"},"imported":[{"uid":"5277-5903"},{"uid":"5277-6223"},{"uid":"5277-6227"},{"uid":"5277-6229"},{"uid":"5277-6231"},{"uid":"5277-6233"},{"uid":"5277-6235"},{"uid":"5277-6225"},{"uid":"5277-6243"}],"importedBy":[{"uid":"5277-6247"},{"uid":"5277-6229"},{"uid":"5277-6235"}]},"5277-6247":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupPlatformManager.ts","moduleParts":{"metamask-sdk.js":"5277-6248"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6245"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6249":{"id":"/src/services/MetaMaskInstaller/checkInstallation.ts","moduleParts":{"metamask-sdk.js":"5277-6250"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6259"}]},"5277-6251":{"id":"/src/services/MetaMaskInstaller/redirectToProperInstall.ts","moduleParts":{"metamask-sdk.js":"5277-6252"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"}],"importedBy":[{"uid":"5277-6259"}]},"5277-6253":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/onboarding/dist/metamask-onboarding.es.js","moduleParts":{"metamask-sdk.js":"5277-6254"},"imported":[{"uid":"5277-6223"}],"importedBy":[{"uid":"5277-6255"}]},"5277-6255":{"id":"/src/services/MetaMaskInstaller/startDesktopOnboarding.ts","moduleParts":{"metamask-sdk.js":"5277-6256"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6253"},{"uid":"5277-6165"}],"importedBy":[{"uid":"5277-6259"}]},"5277-6257":{"id":"/src/services/MetaMaskInstaller/startInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-6258"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6175"}],"importedBy":[{"uid":"5277-6259"}]},"5277-6259":{"id":"/src/Platform/MetaMaskInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-6260"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6249"},{"uid":"5277-6251"},{"uid":"5277-6255"},{"uid":"5277-6257"}],"importedBy":[{"uid":"5277-6291"}]},"5277-6261":{"id":"/src/ui/InstallModal/InstallModal-nodejs.ts","moduleParts":{"metamask-sdk.js":"5277-6262"},"imported":[],"importedBy":[{"uid":"5277-6263"}]},"5277-6263":{"id":"/src/ui/InstallModal/installModal.ts","moduleParts":{"metamask-sdk.js":"5277-6264"},"imported":[{"uid":"5277-6261"}],"importedBy":[{"uid":"5277-6289"}]},"5277-6265":{"id":"/src/ui/InstallModal/pendingModal-nodejs.ts","moduleParts":{"metamask-sdk.js":"5277-6266"},"imported":[],"importedBy":[{"uid":"5277-6267"}]},"5277-6267":{"id":"/src/ui/InstallModal/pendingModal.ts","moduleParts":{"metamask-sdk.js":"5277-6268"},"imported":[{"uid":"5277-6265"}],"importedBy":[{"uid":"5277-6289"}]},"5277-6269":{"id":"/src/services/RemoteConnection/ConnectionInitializer/initializeConnector.ts","moduleParts":{"metamask-sdk.js":"5277-6270"},"imported":[{"uid":"5277-5903"},{"uid":"5277-6187"}],"importedBy":[{"uid":"5277-6435"}]},"5277-6271":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-6272"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6161"}],"importedBy":[{"uid":"5277-6436"},{"uid":"5277-6283"}]},"5277-6273":{"id":"/src/services/RemoteConnection/ModalManager/showInstallModal.ts","moduleParts":{"metamask-sdk.js":"5277-6274"},"imported":[],"importedBy":[{"uid":"5277-6438"},{"uid":"5277-6275"}]},"5277-6275":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithModalInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-6276"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6273"},{"uid":"5277-6161"}],"importedBy":[{"uid":"5277-6436"},{"uid":"5277-6283"}]},"5277-6277":{"id":"/src/services/RemoteConnection/ModalManager/onOTPModalDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-6278"},"imported":[],"importedBy":[{"uid":"5277-6281"}]},"5277-6279":{"id":"/src/services/RemoteConnection/ModalManager/waitForOTPAnswer.ts","moduleParts":{"metamask-sdk.js":"5277-6280"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6281"}]},"5277-6281":{"id":"/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts","moduleParts":{"metamask-sdk.js":"5277-6282"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6165"},{"uid":"5277-6161"},{"uid":"5277-6277"},{"uid":"5277-6279"}],"importedBy":[{"uid":"5277-6438"},{"uid":"5277-6283"}]},"5277-6283":{"id":"/src/services/RemoteConnection/ConnectionManager/startConnection.ts","moduleParts":{"metamask-sdk.js":"5277-6284"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6161"},{"uid":"5277-6165"},{"uid":"5277-6281"},{"uid":"5277-6271"},{"uid":"5277-6275"}],"importedBy":[{"uid":"5277-6436"}]},"5277-6285":{"id":"/src/services/RemoteConnection/EventListeners/setupListeners.ts","moduleParts":{"metamask-sdk.js":"5277-6286"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6165"}],"importedBy":[{"uid":"5277-6437"}]},"5277-6287":{"id":"/src/services/RemoteConnection/ModalManager/showActiveModal.ts","moduleParts":{"metamask-sdk.js":"5277-6288"},"imported":[],"importedBy":[{"uid":"5277-6438"}]},"5277-6289":{"id":"/src/services/RemoteConnection/RemoteConnection.ts","moduleParts":{"metamask-sdk.js":"5277-6290"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6263"},{"uid":"5277-6267"},{"uid":"5277-6165"},{"uid":"5277-6435"},{"uid":"5277-6436"},{"uid":"5277-6437"},{"uid":"5277-6438"}],"importedBy":[{"uid":"5277-6393"}]},"5277-6291":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-6292"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6259"},{"uid":"5277-6393"},{"uid":"5277-6392"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6293":{"id":"/src/storage-manager/StorageManagerNode.ts","moduleParts":{"metamask-sdk.js":"5277-6294"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6439"},{"uid":"5277-6147"}],"importedBy":[{"uid":"5277-6295"}]},"5277-6295":{"id":"/src/storage-manager/getStorageManager.ts","moduleParts":{"metamask-sdk.js":"5277-6296"},"imported":[{"uid":"5277-6293"}],"importedBy":[{"uid":"5277-6297"}]},"5277-6297":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupStorage.ts","moduleParts":{"metamask-sdk.js":"5277-6298"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6295"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6355"}]},"5277-6299":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupInfuraProvider.ts","moduleParts":{"metamask-sdk.js":"5277-6300"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6355"}]},"5277-6301":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupReadOnlyRPCProviders.ts","moduleParts":{"metamask-sdk.js":"5277-6302"},"imported":[{"uid":"5277-5905"}],"importedBy":[{"uid":"5277-6355"}]},"5277-6303":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-6304"},"imported":[],"importedBy":[{"uid":"5277-6313"}]},"5277-6305":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-6306"},"imported":[],"importedBy":[{"uid":"5277-6309"},{"uid":"5277-6307"}]},"5277-6307":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-6308"},"imported":[{"uid":"5277-6305"}],"importedBy":[{"uid":"5277-6309"}]},"5277-6309":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-6310"},"imported":[{"uid":"5277-6305"},{"uid":"5277-6307"}],"importedBy":[{"uid":"5277-6311"}]},"5277-6311":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-6312"},"imported":[{"uid":"5277-6309"}],"importedBy":[{"uid":"5277-6313"}]},"5277-6313":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/dist/esm/i18nextBrowserLanguageDetector.js","moduleParts":{"metamask-sdk.js":"5277-6314"},"imported":[{"uid":"5277-6303"},{"uid":"5277-6311"}],"importedBy":[{"uid":"5277-6353"}]},"5277-6315":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6316"},"imported":[],"importedBy":[{"uid":"5277-6325"}]},"5277-6317":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-6318"},"imported":[],"importedBy":[{"uid":"5277-6319"}]},"5277-6319":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js","moduleParts":{"metamask-sdk.js":"5277-6320"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6317"}],"importedBy":[{"uid":"5277-6325"}]},"5277-6321":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6322"},"imported":[],"importedBy":[{"uid":"5277-6323"}]},"5277-6323":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js","moduleParts":{"metamask-sdk.js":"5277-6324"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6321"}],"importedBy":[{"uid":"5277-6325"}]},"5277-6325":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js","moduleParts":{"metamask-sdk.js":"5277-6326"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6315"},{"uid":"5277-6319"},{"uid":"5277-6323"}],"importedBy":[{"uid":"5277-6426"},{"uid":"5277-6427"},{"uid":"5277-6428"},{"uid":"5277-6429"},{"uid":"5277-6431"},{"uid":"5277-6432"},{"uid":"5277-6433"},{"uid":"5277-6337"}]},"5277-6327":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/node_modules/@babel/runtime/helpers/extends.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-6328"},"imported":[],"importedBy":[{"uid":"5277-6329"}]},"5277-6329":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/node_modules/@babel/runtime/helpers/extends.js","moduleParts":{"metamask-sdk.js":"5277-6330"},"imported":[{"uid":"5277-5591"},{"uid":"5277-6327"}],"importedBy":[{"uid":"5277-6427"}]},"5277-6331":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/unescape.js","moduleParts":{"metamask-sdk.js":"5277-6332"},"imported":[],"importedBy":[{"uid":"5277-6333"}]},"5277-6333":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/defaults.js","moduleParts":{"metamask-sdk.js":"5277-6334"},"imported":[{"uid":"5277-6331"}],"importedBy":[{"uid":"5277-6419"},{"uid":"5277-6427"},{"uid":"5277-6335"},{"uid":"5277-6337"}]},"5277-6335":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/initReactI18next.js","moduleParts":{"metamask-sdk.js":"5277-6336"},"imported":[{"uid":"5277-6333"},{"uid":"5277-6434"}],"importedBy":[{"uid":"5277-6419"},{"uid":"5277-6337"}]},"5277-6337":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/context.js","moduleParts":{"metamask-sdk.js":"5277-6338"},"imported":[{"uid":"5277-6325"},{"uid":"5277-6333"},{"uid":"5277-6434"},{"uid":"5277-6335"}],"importedBy":[{"uid":"5277-6419"},{"uid":"5277-6426"},{"uid":"5277-6428"},{"uid":"5277-6431"},{"uid":"5277-6432"},{"uid":"5277-6433"}]},"5277-6339":{"id":"/src/locales/en.json","moduleParts":{"metamask-sdk.js":"5277-6340"},"imported":[],"importedBy":[{"uid":"5277-6353"}]},"5277-6341":{"id":"/src/locales/es.json","moduleParts":{"metamask-sdk.js":"5277-6342"},"imported":[],"importedBy":[{"uid":"5277-6353"}]},"5277-6343":{"id":"/src/locales/fr.json","moduleParts":{"metamask-sdk.js":"5277-6344"},"imported":[],"importedBy":[{"uid":"5277-6353"}]},"5277-6345":{"id":"/src/locales/he.json","moduleParts":{"metamask-sdk.js":"5277-6346"},"imported":[],"importedBy":[{"uid":"5277-6353"}]},"5277-6347":{"id":"/src/locales/it.json","moduleParts":{"metamask-sdk.js":"5277-6348"},"imported":[],"importedBy":[{"uid":"5277-6353"}]},"5277-6349":{"id":"/src/locales/pt.json","moduleParts":{"metamask-sdk.js":"5277-6350"},"imported":[],"importedBy":[{"uid":"5277-6353"}]},"5277-6351":{"id":"/src/locales/tr.json","moduleParts":{"metamask-sdk.js":"5277-6352"},"imported":[],"importedBy":[{"uid":"5277-6353"}]},"5277-6353":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeI18next.ts","moduleParts":{"metamask-sdk.js":"5277-6354"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6313"},{"uid":"5277-6419"},{"uid":"5277-6339"},{"uid":"5277-6341"},{"uid":"5277-6343"},{"uid":"5277-6345"},{"uid":"5277-6347"},{"uid":"5277-6349"},{"uid":"5277-6351"}],"importedBy":[{"uid":"5277-6355"}]},"5277-6355":{"id":"/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts","moduleParts":{"metamask-sdk.js":"5277-6356"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5903"},{"uid":"5277-6149"},{"uid":"5277-6157"},{"uid":"5277-6191"},{"uid":"5277-6193"},{"uid":"5277-6199"},{"uid":"5277-6207"},{"uid":"5277-6247"},{"uid":"5277-6291"},{"uid":"5277-6297"},{"uid":"5277-6299"},{"uid":"5277-6301"},{"uid":"5277-6353"}],"importedBy":[{"uid":"5277-6368"},{"uid":"5277-6357"}]},"5277-6357":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeMetaMaskSDK.ts","moduleParts":{"metamask-sdk.js":"5277-6358"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6355"}],"importedBy":[{"uid":"5277-6368"}]},"5277-6359":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connectAndSign.ts","moduleParts":{"metamask-sdk.js":"5277-6360"},"imported":[{"uid":"5277-5905"},{"uid":"5277-6147"}],"importedBy":[{"uid":"5277-6361"}]},"5277-6361":{"id":"/src/sdk.ts","moduleParts":{"metamask-sdk.js":"5277-6362"},"imported":[{"uid":"5277-5905"},{"uid":"5277-5741"},{"uid":"5277-6141"},{"uid":"5277-6367"},{"uid":"5277-6368"},{"uid":"5277-6359"}],"importedBy":[{"uid":"5277-6363"}]},"5277-6363":{"id":"/src/index.ts","moduleParts":{"metamask-sdk.js":"5277-6364"},"imported":[{"uid":"5277-5903"},{"uid":"5277-6105"},{"uid":"5277-6361"},{"uid":"5277-6149"}],"importedBy":[],"isEntry":true},"5277-6365":{"id":"buffer","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-5903"},{"uid":"5277-6163"},{"uid":"5277-6167"},{"uid":"5277-6484"}],"isExternal":true},"5277-6366":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/index.js","moduleParts":{},"imported":[{"uid":"5277-6372"},{"uid":"5277-6373"},{"uid":"5277-5751"},{"uid":"5277-6374"},{"uid":"5277-6375"},{"uid":"5277-6376"},{"uid":"5277-5747"},{"uid":"5277-5749"},{"uid":"5277-6377"}],"importedBy":[{"uid":"5277-5903"}]},"5277-6367":{"id":"/src/services/MetaMaskSDK/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-6143"},{"uid":"5277-6145"},{"uid":"5277-6151"}],"importedBy":[{"uid":"5277-6361"}]},"5277-6368":{"id":"/src/services/MetaMaskSDK/InitializerManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-6157"},{"uid":"5277-6159"},{"uid":"5277-6357"},{"uid":"5277-6191"},{"uid":"5277-6355"},{"uid":"5277-6193"},{"uid":"5277-6199"},{"uid":"5277-6207"},{"uid":"5277-6247"},{"uid":"5277-6291"},{"uid":"5277-6297"}],"importedBy":[{"uid":"5277-6361"}]},"5277-6369":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5735"}],"importedBy":[{"uid":"5277-5737"}]},"5277-6370":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5727"}],"importedBy":[{"uid":"5277-5737"},{"uid":"5277-5733"},{"uid":"5277-5731"}]},"5277-6371":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5725"}],"importedBy":[{"uid":"5277-5737"},{"uid":"5277-5727"},{"uid":"5277-5731"}]},"5277-6372":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/v1.js","moduleParts":{},"imported":[{"uid":"5277-5743"},{"uid":"5277-5749"}],"importedBy":[{"uid":"5277-6366"}]},"5277-6373":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/v3.js","moduleParts":{},"imported":[{"uid":"5277-6384"},{"uid":"5277-6385"}],"importedBy":[{"uid":"5277-6366"}]},"5277-6374":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/v5.js","moduleParts":{},"imported":[{"uid":"5277-6384"},{"uid":"5277-6386"}],"importedBy":[{"uid":"5277-6366"}]},"5277-6375":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/nil.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6366"}]},"5277-6376":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/version.js","moduleParts":{},"imported":[{"uid":"5277-5747"}],"importedBy":[{"uid":"5277-6366"}]},"5277-6377":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/parse.js","moduleParts":{},"imported":[{"uid":"5277-5747"}],"importedBy":[{"uid":"5277-6366"},{"uid":"5277-6384"}]},"5277-6378":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5979"}],"importedBy":[{"uid":"5277-6095"},{"uid":"5277-6079"}]},"5277-6379":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6085"}],"importedBy":[{"uid":"5277-6095"}]},"5277-6380":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6093"}],"importedBy":[{"uid":"5277-6095"}]},"5277-6381":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6081"}],"importedBy":[{"uid":"5277-6095"},{"uid":"5277-6085"},{"uid":"5277-6093"}]},"5277-6382":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6091"}],"importedBy":[{"uid":"5277-6095"},{"uid":"5277-6093"}]},"5277-6383":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6079"}],"importedBy":[{"uid":"5277-6095"},{"uid":"5277-6085"},{"uid":"5277-6081"}]},"5277-6384":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/v35.js","moduleParts":{},"imported":[{"uid":"5277-5749"},{"uid":"5277-6377"}],"importedBy":[{"uid":"5277-6373"},{"uid":"5277-6374"}]},"5277-6385":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/md5.js","moduleParts":{},"imported":[{"uid":"5277-6398"}],"importedBy":[{"uid":"5277-6373"}]},"5277-6386":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-node/sha1.js","moduleParts":{},"imported":[{"uid":"5277-6398"}],"importedBy":[{"uid":"5277-6374"}]},"5277-6387":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/index.js","moduleParts":{},"imported":[{"uid":"5277-5847"},{"uid":"5277-5789"},{"uid":"5277-5843"},{"uid":"5277-5765"},{"uid":"5277-5845"},{"uid":"5277-5837"}],"importedBy":[{"uid":"5277-5849"},{"uid":"5277-5863"}]},"5277-6388":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5921"}],"importedBy":[{"uid":"5277-5935"},{"uid":"5277-5929"},{"uid":"5277-5933"}]},"5277-6389":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5929"}],"importedBy":[{"uid":"5277-5935"},{"uid":"5277-5933"}]},"5277-6390":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5933"}],"importedBy":[{"uid":"5277-5935"}]},"5277-6391":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5927"}],"importedBy":[{"uid":"5277-5935"},{"uid":"5277-5929"},{"uid":"5277-5933"}]},"5277-6392":{"id":"/src/services/MetaMaskSDK/ProviderManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-6153"}],"importedBy":[{"uid":"5277-6157"},{"uid":"5277-6291"}]},"5277-6393":{"id":"/src/services/RemoteConnection/index.ts","moduleParts":{},"imported":[{"uid":"5277-6289"}],"importedBy":[{"uid":"5277-6291"}]},"5277-6394":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5733"}],"importedBy":[{"uid":"5277-5735"}]},"5277-6395":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5731"}],"importedBy":[{"uid":"5277-5735"},{"uid":"5277-5733"}]},"5277-6396":{"id":"\u0000crypto?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6398"}],"importedBy":[{"uid":"5277-5727"},{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-6442"},{"uid":"5277-5599"}]},"5277-6397":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5719"}],"importedBy":[{"uid":"5277-5727"},{"uid":"5277-5733"},{"uid":"5277-5731"}]},"5277-6398":{"id":"crypto","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-5743"},{"uid":"5277-6385"},{"uid":"5277-6386"},{"uid":"5277-6396"}],"isExternal":true},"5277-6399":{"id":"\u0000tty?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6420"}],"importedBy":[{"uid":"5277-5783"},{"uid":"5277-5781"}]},"5277-6400":{"id":"\u0000util?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6421"}],"importedBy":[{"uid":"5277-5783"},{"uid":"5277-6035"},{"uid":"5277-6021"},{"uid":"5277-6025"}]},"5277-6401":{"id":"stream","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-5897"},{"uid":"5277-6171"},{"uid":"5277-6452"},{"uid":"5277-6179"}],"isExternal":true},"5277-6402":{"id":"http","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-5897"},{"uid":"5277-6469"},{"uid":"5277-6179"}],"isExternal":true},"5277-6403":{"id":"url","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-5897"},{"uid":"5277-6470"},{"uid":"5277-6179"}],"isExternal":true},"5277-6404":{"id":"https","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-5897"},{"uid":"5277-6468"},{"uid":"5277-6179"}],"isExternal":true},"5277-6405":{"id":"zlib","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-5897"},{"uid":"5277-6179"},{"uid":"5277-6497"}],"isExternal":true},"5277-6406":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5913"}],"importedBy":[{"uid":"5277-5979"},{"uid":"5277-5959"}]},"5277-6407":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5935"}],"importedBy":[{"uid":"5277-5979"},{"uid":"5277-6081"},{"uid":"5277-5977"},{"uid":"5277-5959"}]},"5277-6408":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5937"}],"importedBy":[{"uid":"5277-5979"}]},"5277-6409":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5965"}],"importedBy":[{"uid":"5277-5979"},{"uid":"5277-5977"}]},"5277-6410":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5969"}],"importedBy":[{"uid":"5277-5979"},{"uid":"5277-6081"},{"uid":"5277-6079"},{"uid":"5277-5995"},{"uid":"5277-5975"}]},"5277-6411":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5977"}],"importedBy":[{"uid":"5277-5979"},{"uid":"5277-6085"},{"uid":"5277-6081"},{"uid":"5277-6079"},{"uid":"5277-5995"}]},"5277-6412":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5985"}],"importedBy":[{"uid":"5277-6085"}]},"5277-6413":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6083"}],"importedBy":[{"uid":"5277-6085"}]},"5277-6414":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5995"}],"importedBy":[{"uid":"5277-6081"}]},"5277-6415":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6057"}],"importedBy":[{"uid":"5277-6079"}]},"5277-6416":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6059"}],"importedBy":[{"uid":"5277-6079"}]},"5277-6417":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6075"}],"importedBy":[{"uid":"5277-6079"}]},"5277-6418":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6077"}],"importedBy":[{"uid":"5277-6079"}]},"5277-6419":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/index.js","moduleParts":{},"imported":[{"uid":"5277-6426"},{"uid":"5277-6427"},{"uid":"5277-6428"},{"uid":"5277-6429"},{"uid":"5277-6430"},{"uid":"5277-6431"},{"uid":"5277-6432"},{"uid":"5277-6433"},{"uid":"5277-6335"},{"uid":"5277-6333"},{"uid":"5277-6434"},{"uid":"5277-6337"}],"importedBy":[{"uid":"5277-6353"}]},"5277-6420":{"id":"tty","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6399"}],"isExternal":true},"5277-6421":{"id":"util","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6400"}],"isExternal":true},"5277-6422":{"id":"\u0000os?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6443"}],"importedBy":[{"uid":"5277-5781"},{"uid":"5277-5607"}]},"5277-6423":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/URL.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5893"}],"importedBy":[{"uid":"5277-5895"}]},"5277-6424":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/url-state-machine.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5889"}],"importedBy":[{"uid":"5277-5895"},{"uid":"5277-5891"}]},"5277-6425":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5919"}],"importedBy":[{"uid":"5277-5921"}]},"5277-6426":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Trans.js","moduleParts":{},"imported":[{"uid":"5277-6325"},{"uid":"5277-6427"},{"uid":"5277-6337"}],"importedBy":[{"uid":"5277-6419"}]},"5277-6427":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/TransWithoutContext.js","moduleParts":{},"imported":[{"uid":"5277-6329"},{"uid":"5277-6325"},{"uid":"5277-6459"},{"uid":"5277-6460"},{"uid":"5277-6333"},{"uid":"5277-6434"}],"importedBy":[{"uid":"5277-6419"},{"uid":"5277-6426"}]},"5277-6428":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useTranslation.js","moduleParts":{},"imported":[{"uid":"5277-6325"},{"uid":"5277-6337"},{"uid":"5277-6460"}],"importedBy":[{"uid":"5277-6419"},{"uid":"5277-6429"},{"uid":"5277-6430"}]},"5277-6429":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withTranslation.js","moduleParts":{},"imported":[{"uid":"5277-6325"},{"uid":"5277-6428"},{"uid":"5277-6460"}],"importedBy":[{"uid":"5277-6419"}]},"5277-6430":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Translation.js","moduleParts":{},"imported":[{"uid":"5277-6428"}],"importedBy":[{"uid":"5277-6419"}]},"5277-6431":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/I18nextProvider.js","moduleParts":{},"imported":[{"uid":"5277-6325"},{"uid":"5277-6337"}],"importedBy":[{"uid":"5277-6419"}]},"5277-6432":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withSSR.js","moduleParts":{},"imported":[{"uid":"5277-6325"},{"uid":"5277-6433"},{"uid":"5277-6337"},{"uid":"5277-6460"}],"importedBy":[{"uid":"5277-6419"}]},"5277-6433":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useSSR.js","moduleParts":{},"imported":[{"uid":"5277-6325"},{"uid":"5277-6337"}],"importedBy":[{"uid":"5277-6419"},{"uid":"5277-6432"}]},"5277-6434":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/i18nInstance.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6419"},{"uid":"5277-6427"},{"uid":"5277-6335"},{"uid":"5277-6337"}]},"5277-6435":{"id":"/src/services/RemoteConnection/ConnectionInitializer/index.ts","moduleParts":{},"imported":[{"uid":"5277-6269"}],"importedBy":[{"uid":"5277-6289"}]},"5277-6436":{"id":"/src/services/RemoteConnection/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-6271"},{"uid":"5277-6275"},{"uid":"5277-6461"},{"uid":"5277-6283"}],"importedBy":[{"uid":"5277-6289"}]},"5277-6437":{"id":"/src/services/RemoteConnection/EventListeners/index.ts","moduleParts":{},"imported":[{"uid":"5277-6285"}],"importedBy":[{"uid":"5277-6289"}]},"5277-6438":{"id":"/src/services/RemoteConnection/ModalManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-6281"},{"uid":"5277-6287"},{"uid":"5277-6273"}],"importedBy":[{"uid":"5277-6289"}]},"5277-6439":{"id":"fs","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6293"},{"uid":"5277-6458"}],"isExternal":true},"5277-6440":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5599"}],"importedBy":[{"uid":"5277-5733"},{"uid":"5277-5731"}]},"5277-6441":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/stream.js","moduleParts":{},"imported":[{"uid":"5277-5591"},{"uid":"5277-6452"}],"importedBy":[{"uid":"5277-5835"}]},"5277-6442":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/websocket-server.js","moduleParts":{},"imported":[{"uid":"5277-5591"},{"uid":"5277-6444"},{"uid":"5277-6469"},{"uid":"5277-6468"},{"uid":"5277-6466"},{"uid":"5277-6467"},{"uid":"5277-6396"},{"uid":"5277-6474"},{"uid":"5277-6462"},{"uid":"5277-6475"},{"uid":"5277-6476"},{"uid":"5277-6463"}],"importedBy":[{"uid":"5277-5835"}]},"5277-6443":{"id":"os","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6422"}],"isExternal":true},"5277-6444":{"id":"\u0000events?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6482"}],"importedBy":[{"uid":"5277-5913"},{"uid":"5277-5833"},{"uid":"5277-6442"},{"uid":"5277-6071"},{"uid":"5277-6035"}]},"5277-6445":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5947"}],"importedBy":[{"uid":"5277-5965"}]},"5277-6446":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5951"}],"importedBy":[{"uid":"5277-5965"}]},"5277-6447":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5955"}],"importedBy":[{"uid":"5277-5965"}]},"5277-6448":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5945"}],"importedBy":[{"uid":"5277-5965"},{"uid":"5277-5947"}]},"5277-6449":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5959"}],"importedBy":[{"uid":"5277-5965"},{"uid":"5277-5963"}]},"5277-6450":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5963"}],"importedBy":[{"uid":"5277-5965"}]},"5277-6451":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5975"}],"importedBy":[{"uid":"5277-5977"}]},"5277-6452":{"id":"\u0000stream?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6401"}],"importedBy":[{"uid":"5277-5985"},{"uid":"5277-6441"},{"uid":"5277-5825"},{"uid":"5277-5833"},{"uid":"5277-6041"},{"uid":"5277-6009"}]},"5277-6453":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6055"}],"importedBy":[{"uid":"5277-6057"}]},"5277-6454":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6065"}],"importedBy":[{"uid":"5277-6075"}]},"5277-6455":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6073"}],"importedBy":[{"uid":"5277-6075"}]},"5277-6456":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6047"}],"importedBy":[{"uid":"5277-6077"},{"uid":"5277-6055"},{"uid":"5277-6049"}]},"5277-6457":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6049"}],"importedBy":[{"uid":"5277-6077"},{"uid":"5277-6055"}]},"5277-6458":{"id":"\u0000fs?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6439"}],"importedBy":[{"uid":"5277-6077"},{"uid":"5277-5793"},{"uid":"5277-5607"}]},"5277-6459":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/html-parse-stringify/dist/html-parse-stringify.module.js","moduleParts":{},"imported":[{"uid":"5277-6483"}],"importedBy":[{"uid":"5277-6427"}]},"5277-6460":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/utils.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6427"},{"uid":"5277-6428"},{"uid":"5277-6429"},{"uid":"5277-6432"}]},"5277-6461":{"id":"/src/services/RemoteConnection/ConnectionManager/handleDisconnect.ts","moduleParts":{},"imported":[{"uid":"5277-5905"},{"uid":"5277-6165"}],"importedBy":[{"uid":"5277-6436"}]},"5277-6462":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/permessage-deflate.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5813"}],"importedBy":[{"uid":"5277-5825"},{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-6442"}]},"5277-6463":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/constants.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5801"}],"importedBy":[{"uid":"5277-5825"},{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-6442"},{"uid":"5277-5813"},{"uid":"5277-5809"},{"uid":"5277-5829"}]},"5277-6464":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/buffer-util.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5809"}],"importedBy":[{"uid":"5277-5825"},{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-5813"}]},"5277-6465":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/validation.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5823"}],"importedBy":[{"uid":"5277-5825"},{"uid":"5277-5827"},{"uid":"5277-5831"},{"uid":"5277-6488"}]},"5277-6466":{"id":"\u0000net?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6486"}],"importedBy":[{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-6442"}]},"5277-6467":{"id":"\u0000tls?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6487"}],"importedBy":[{"uid":"5277-5827"},{"uid":"5277-5833"},{"uid":"5277-6442"}]},"5277-6468":{"id":"\u0000https?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6404"}],"importedBy":[{"uid":"5277-5833"},{"uid":"5277-6442"},{"uid":"5277-5793"}]},"5277-6469":{"id":"\u0000http?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6402"}],"importedBy":[{"uid":"5277-5833"},{"uid":"5277-6442"},{"uid":"5277-5793"}]},"5277-6470":{"id":"\u0000url?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6403"}],"importedBy":[{"uid":"5277-5833"},{"uid":"5277-5793"}]},"5277-6471":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/receiver.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5825"}],"importedBy":[{"uid":"5277-5833"}]},"5277-6472":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/sender.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5827"}],"importedBy":[{"uid":"5277-5833"}]},"5277-6473":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/event-target.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5829"}],"importedBy":[{"uid":"5277-5833"}]},"5277-6474":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/extension.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5831"}],"importedBy":[{"uid":"5277-5833"},{"uid":"5277-6442"}]},"5277-6475":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/subprotocol.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6488"}],"importedBy":[{"uid":"5277-6442"}]},"5277-6476":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/websocket.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5833"}],"importedBy":[{"uid":"5277-6442"}]},"5277-6477":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/node_modules/webidl-conversions/lib/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5873"}],"importedBy":[{"uid":"5277-5893"}]},"5277-6478":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5877"}],"importedBy":[{"uid":"5277-5893"}]},"5277-6479":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/whatwg-url/lib/URL-impl.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5891"}],"importedBy":[{"uid":"5277-5893"}]},"5277-6480":{"id":"\u0000punycode?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6489"}],"importedBy":[{"uid":"5277-5889"},{"uid":"5277-5887"}]},"5277-6481":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/tr46/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5887"}],"importedBy":[{"uid":"5277-5889"}]},"5277-6482":{"id":"events","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6444"}],"isExternal":true},"5277-6483":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/void-elements/index.js","moduleParts":{},"imported":[{"uid":"5277-5591"}],"importedBy":[{"uid":"5277-6459"}]},"5277-6484":{"id":"\u0000buffer?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6365"}],"importedBy":[{"uid":"5277-5599"},{"uid":"5277-6013"},{"uid":"5277-6017"}]},"5277-6485":{"id":"\u0000child_process?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6496"}],"importedBy":[{"uid":"5277-5793"}]},"5277-6486":{"id":"net","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6466"}],"isExternal":true},"5277-6487":{"id":"tls","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6467"}],"isExternal":true},"5277-6488":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/subprotocol.js","moduleParts":{},"imported":[{"uid":"5277-5591"},{"uid":"5277-6465"}],"importedBy":[{"uid":"5277-6475"}]},"5277-6489":{"id":"punycode","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6480"}],"isExternal":true},"5277-6490":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6041"}],"importedBy":[{"uid":"5277-6055"},{"uid":"5277-6065"},{"uid":"5277-6073"},{"uid":"5277-6053"}]},"5277-6491":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6053"}],"importedBy":[{"uid":"5277-6055"}]},"5277-6492":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6071"}],"importedBy":[{"uid":"5277-6073"}]},"5277-6493":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-6045"}],"importedBy":[{"uid":"5277-6047"}]},"5277-6494":{"id":"\u0000path?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6500"}],"importedBy":[{"uid":"5277-5607"}]},"5277-6495":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5617"}],"importedBy":[{"uid":"5277-5713"}]},"5277-6496":{"id":"child_process","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6485"}],"isExternal":true},"5277-6497":{"id":"\u0000zlib?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-6405"}],"importedBy":[{"uid":"5277-5813"}]},"5277-6498":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/node_modules/ws/lib/limiter.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5811"}],"importedBy":[{"uid":"5277-5813"}]},"5277-6499":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/tr46/lib/mappingTable.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-5885"}],"importedBy":[{"uid":"5277-5887"}]},"5277-6500":{"id":"path","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-6494"}],"isExternal":true}},"env":{"rollup":"3.29.4"},"options":{"gzip":false,"brotli":false,"sourcemap":false}};
+
+    const run = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      const chartNode = document.querySelector("main");
+      drawChart.default(chartNode, data, width, height);
+    };
+
+    window.addEventListener('resize', run);
+
+    document.addEventListener('DOMContentLoaded', run);
+    /*-->*/
+  </script>
+</body>
+</html>
+

--- a/packages/sdk/bundle_stats/react-native-stats-0.11.0.html
+++ b/packages/sdk/bundle_stats/react-native-stats-0.11.0.html
@@ -1,0 +1,4838 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <title>Rollup Visualizer</title>
+  <style>
+:root {
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --background-color: #2b2d42;
+  --text-color: #edf2f4;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+html {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: var(--font-family);
+}
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+svg {
+  vertical-align: middle;
+  width: 100%;
+  height: 100%;
+  max-height: 100vh;
+}
+
+main {
+  flex-grow: 1;
+  height: 100vh;
+  padding: 20px;
+}
+
+.tooltip {
+  position: absolute;
+  z-index: 1070;
+  border: 2px solid;
+  border-radius: 5px;
+  padding: 5px;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.tooltip-hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  font-size: 0.7rem;
+  align-items: center;
+  margin: 0 50px;
+  height: 20px;
+}
+
+.size-selectors {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.size-selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+}
+.size-selector input {
+  margin: 0 0.3rem 0 0;
+}
+
+.filters {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.module-filters {
+  display: flex;
+  flex-grow: 1;
+}
+
+.module-filter {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+.module-filter input {
+  flex: 1;
+  height: 1rem;
+  padding: 0.01rem;
+  font-size: 0.7rem;
+  margin-left: 0.3rem;
+}
+.module-filter + .module-filter {
+  margin-left: 0.5rem;
+}
+  </style>
+</head>
+<body>
+  <main></main>
+  <script>
+  /*<!--*/
+var drawChart = (function (exports) {
+  'use strict';
+
+  var n,l$1,u$1,t$1,o$2,r$1,f$1,e$1,c$1={},s$1=[],a$1=/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,v$1=Array.isArray;function h$1(n,l){for(var u in l)n[u]=l[u];return n}function p$1(n){var l=n.parentNode;l&&l.removeChild(n);}function y$1(l,u,i){var t,o,r,f={};for(r in u)"key"==r?t=u[r]:"ref"==r?o=u[r]:f[r]=u[r];if(arguments.length>2&&(f.children=arguments.length>3?n.call(arguments,2):i),"function"==typeof l&&null!=l.defaultProps)for(r in l.defaultProps)void 0===f[r]&&(f[r]=l.defaultProps[r]);return d$1(l,f,t,o,null)}function d$1(n,i,t,o,r){var f={type:n,props:i,key:t,ref:o,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:null==r?++u$1:r};return null==r&&null!=l$1.vnode&&l$1.vnode(f),f}function k$1(n){return n.children}function b$1(n,l){this.props=n,this.context=l;}function g$1(n,l){if(null==l)return n.__?g$1(n.__,n.__.__k.indexOf(n)+1):null;for(var u;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e)return u.__e;return "function"==typeof n.type?g$1(n):null}function m$1(n){var l,u;if(null!=(n=n.__)&&null!=n.__c){for(n.__e=n.__c.base=null,l=0;l<n.__k.length;l++)if(null!=(u=n.__k[l])&&null!=u.__e){n.__e=n.__c.base=u.__e;break}return m$1(n)}}function w$1(n){(!n.__d&&(n.__d=!0)&&t$1.push(n)&&!x.__r++||o$2!==l$1.debounceRendering)&&((o$2=l$1.debounceRendering)||r$1)(x);}function x(){var n,l,u,i,o,r,e,c;for(t$1.sort(f$1);n=t$1.shift();)n.__d&&(l=t$1.length,i=void 0,o=void 0,e=(r=(u=n).__v).__e,(c=u.__P)&&(i=[],(o=h$1({},r)).__v=r.__v+1,L(c,r,o,u.__n,void 0!==c.ownerSVGElement,null!=r.__h?[e]:null,i,null==e?g$1(r):e,r.__h),M(i,r),r.__e!=e&&m$1(r)),t$1.length>l&&t$1.sort(f$1));x.__r=0;}function P(n,l,u,i,t,o,r,f,e,a){var h,p,y,_,b,m,w,x=i&&i.__k||s$1,P=x.length;for(u.__k=[],h=0;h<l.length;h++)if(null!=(_=u.__k[h]=null==(_=l[h])||"boolean"==typeof _||"function"==typeof _?null:"string"==typeof _||"number"==typeof _||"bigint"==typeof _?d$1(null,_,null,null,_):v$1(_)?d$1(k$1,{children:_},null,null,null):_.__b>0?d$1(_.type,_.props,_.key,_.ref?_.ref:null,_.__v):_)){if(_.__=u,_.__b=u.__b+1,null===(y=x[h])||y&&_.key==y.key&&_.type===y.type)x[h]=void 0;else for(p=0;p<P;p++){if((y=x[p])&&_.key==y.key&&_.type===y.type){x[p]=void 0;break}y=null;}L(n,_,y=y||c$1,t,o,r,f,e,a),b=_.__e,(p=_.ref)&&y.ref!=p&&(w||(w=[]),y.ref&&w.push(y.ref,null,_),w.push(p,_.__c||b,_)),null!=b?(null==m&&(m=b),"function"==typeof _.type&&_.__k===y.__k?_.__d=e=C(_,e,n):e=$(n,_,y,x,b,e),"function"==typeof u.type&&(u.__d=e)):e&&y.__e==e&&e.parentNode!=n&&(e=g$1(y));}for(u.__e=m,h=P;h--;)null!=x[h]&&("function"==typeof u.type&&null!=x[h].__e&&x[h].__e==u.__d&&(u.__d=A(i).nextSibling),q$1(x[h],x[h]));if(w)for(h=0;h<w.length;h++)O(w[h],w[++h],w[++h]);}function C(n,l,u){for(var i,t=n.__k,o=0;t&&o<t.length;o++)(i=t[o])&&(i.__=n,l="function"==typeof i.type?C(i,l,u):$(u,i,i,t,i.__e,l));return l}function $(n,l,u,i,t,o){var r,f,e;if(void 0!==l.__d)r=l.__d,l.__d=void 0;else if(null==u||t!=o||null==t.parentNode)n:if(null==o||o.parentNode!==n)n.appendChild(t),r=null;else {for(f=o,e=0;(f=f.nextSibling)&&e<i.length;e+=1)if(f==t)break n;n.insertBefore(t,o),r=o;}return void 0!==r?r:t.nextSibling}function A(n){var l,u,i;if(null==n.type||"string"==typeof n.type)return n.__e;if(n.__k)for(l=n.__k.length-1;l>=0;l--)if((u=n.__k[l])&&(i=A(u)))return i;return null}function H(n,l,u,i,t){var o;for(o in u)"children"===o||"key"===o||o in l||T$1(n,o,null,u[o],i);for(o in l)t&&"function"!=typeof l[o]||"children"===o||"key"===o||"value"===o||"checked"===o||u[o]===l[o]||T$1(n,o,l[o],u[o],i);}function I(n,l,u){"-"===l[0]?n.setProperty(l,null==u?"":u):n[l]=null==u?"":"number"!=typeof u||a$1.test(l)?u:u+"px";}function T$1(n,l,u,i,t){var o;n:if("style"===l)if("string"==typeof u)n.style.cssText=u;else {if("string"==typeof i&&(n.style.cssText=i=""),i)for(l in i)u&&l in u||I(n.style,l,"");if(u)for(l in u)i&&u[l]===i[l]||I(n.style,l,u[l]);}else if("o"===l[0]&&"n"===l[1])o=l!==(l=l.replace(/Capture$/,"")),l=l.toLowerCase()in n?l.toLowerCase().slice(2):l.slice(2),n.l||(n.l={}),n.l[l+o]=u,u?i||n.addEventListener(l,o?z$1:j$1,o):n.removeEventListener(l,o?z$1:j$1,o);else if("dangerouslySetInnerHTML"!==l){if(t)l=l.replace(/xlink(H|:h)/,"h").replace(/sName$/,"s");else if("width"!==l&&"height"!==l&&"href"!==l&&"list"!==l&&"form"!==l&&"tabIndex"!==l&&"download"!==l&&"rowSpan"!==l&&"colSpan"!==l&&l in n)try{n[l]=null==u?"":u;break n}catch(n){}"function"==typeof u||(null==u||!1===u&&"-"!==l[4]?n.removeAttribute(l):n.setAttribute(l,u));}}function j$1(n){return this.l[n.type+!1](l$1.event?l$1.event(n):n)}function z$1(n){return this.l[n.type+!0](l$1.event?l$1.event(n):n)}function L(n,u,i,t,o,r,f,e,c){var s,a,p,y,d,_,g,m,w,x,C,S,$,A,H,I=u.type;if(void 0!==u.constructor)return null;null!=i.__h&&(c=i.__h,e=u.__e=i.__e,u.__h=null,r=[e]),(s=l$1.__b)&&s(u);try{n:if("function"==typeof I){if(m=u.props,w=(s=I.contextType)&&t[s.__c],x=s?w?w.props.value:s.__:t,i.__c?g=(a=u.__c=i.__c).__=a.__E:("prototype"in I&&I.prototype.render?u.__c=a=new I(m,x):(u.__c=a=new b$1(m,x),a.constructor=I,a.render=B$1),w&&w.sub(a),a.props=m,a.state||(a.state={}),a.context=x,a.__n=t,p=a.__d=!0,a.__h=[],a._sb=[]),null==a.__s&&(a.__s=a.state),null!=I.getDerivedStateFromProps&&(a.__s==a.state&&(a.__s=h$1({},a.__s)),h$1(a.__s,I.getDerivedStateFromProps(m,a.__s))),y=a.props,d=a.state,a.__v=u,p)null==I.getDerivedStateFromProps&&null!=a.componentWillMount&&a.componentWillMount(),null!=a.componentDidMount&&a.__h.push(a.componentDidMount);else {if(null==I.getDerivedStateFromProps&&m!==y&&null!=a.componentWillReceiveProps&&a.componentWillReceiveProps(m,x),!a.__e&&null!=a.shouldComponentUpdate&&!1===a.shouldComponentUpdate(m,a.__s,x)||u.__v===i.__v){for(u.__v!==i.__v&&(a.props=m,a.state=a.__s,a.__d=!1),a.__e=!1,u.__e=i.__e,u.__k=i.__k,u.__k.forEach(function(n){n&&(n.__=u);}),C=0;C<a._sb.length;C++)a.__h.push(a._sb[C]);a._sb=[],a.__h.length&&f.push(a);break n}null!=a.componentWillUpdate&&a.componentWillUpdate(m,a.__s,x),null!=a.componentDidUpdate&&a.__h.push(function(){a.componentDidUpdate(y,d,_);});}if(a.context=x,a.props=m,a.__P=n,S=l$1.__r,$=0,"prototype"in I&&I.prototype.render){for(a.state=a.__s,a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),A=0;A<a._sb.length;A++)a.__h.push(a._sb[A]);a._sb=[];}else do{a.__d=!1,S&&S(u),s=a.render(a.props,a.state,a.context),a.state=a.__s;}while(a.__d&&++$<25);a.state=a.__s,null!=a.getChildContext&&(t=h$1(h$1({},t),a.getChildContext())),p||null==a.getSnapshotBeforeUpdate||(_=a.getSnapshotBeforeUpdate(y,d)),P(n,v$1(H=null!=s&&s.type===k$1&&null==s.key?s.props.children:s)?H:[H],u,i,t,o,r,f,e,c),a.base=u.__e,u.__h=null,a.__h.length&&f.push(a),g&&(a.__E=a.__=null),a.__e=!1;}else null==r&&u.__v===i.__v?(u.__k=i.__k,u.__e=i.__e):u.__e=N(i.__e,u,i,t,o,r,f,c);(s=l$1.diffed)&&s(u);}catch(n){u.__v=null,(c||null!=r)&&(u.__e=e,u.__h=!!c,r[r.indexOf(e)]=null),l$1.__e(n,u,i);}}function M(n,u){l$1.__c&&l$1.__c(u,n),n.some(function(u){try{n=u.__h,u.__h=[],n.some(function(n){n.call(u);});}catch(n){l$1.__e(n,u.__v);}});}function N(l,u,i,t,o,r,f,e){var s,a,h,y=i.props,d=u.props,_=u.type,k=0;if("svg"===_&&(o=!0),null!=r)for(;k<r.length;k++)if((s=r[k])&&"setAttribute"in s==!!_&&(_?s.localName===_:3===s.nodeType)){l=s,r[k]=null;break}if(null==l){if(null===_)return document.createTextNode(d);l=o?document.createElementNS("http://www.w3.org/2000/svg",_):document.createElement(_,d.is&&d),r=null,e=!1;}if(null===_)y===d||e&&l.data===d||(l.data=d);else {if(r=r&&n.call(l.childNodes),a=(y=i.props||c$1).dangerouslySetInnerHTML,h=d.dangerouslySetInnerHTML,!e){if(null!=r)for(y={},k=0;k<l.attributes.length;k++)y[l.attributes[k].name]=l.attributes[k].value;(h||a)&&(h&&(a&&h.__html==a.__html||h.__html===l.innerHTML)||(l.innerHTML=h&&h.__html||""));}if(H(l,d,y,o,e),h)u.__k=[];else if(P(l,v$1(k=u.props.children)?k:[k],u,i,t,o&&"foreignObject"!==_,r,f,r?r[0]:i.__k&&g$1(i,0),e),null!=r)for(k=r.length;k--;)null!=r[k]&&p$1(r[k]);e||("value"in d&&void 0!==(k=d.value)&&(k!==l.value||"progress"===_&&!k||"option"===_&&k!==y.value)&&T$1(l,"value",k,y.value,!1),"checked"in d&&void 0!==(k=d.checked)&&k!==l.checked&&T$1(l,"checked",k,y.checked,!1));}return l}function O(n,u,i){try{"function"==typeof n?n(u):n.current=u;}catch(n){l$1.__e(n,i);}}function q$1(n,u,i){var t,o;if(l$1.unmount&&l$1.unmount(n),(t=n.ref)&&(t.current&&t.current!==n.__e||O(t,null,u)),null!=(t=n.__c)){if(t.componentWillUnmount)try{t.componentWillUnmount();}catch(n){l$1.__e(n,u);}t.base=t.__P=null,n.__c=void 0;}if(t=n.__k)for(o=0;o<t.length;o++)t[o]&&q$1(t[o],u,i||"function"!=typeof n.type);i||null==n.__e||p$1(n.__e),n.__=n.__e=n.__d=void 0;}function B$1(n,l,u){return this.constructor(n,u)}function D(u,i,t){var o,r,f;l$1.__&&l$1.__(u,i),r=(o="function"==typeof t)?null:t&&t.__k||i.__k,f=[],L(i,u=(!o&&t||i).__k=y$1(k$1,null,[u]),r||c$1,c$1,void 0!==i.ownerSVGElement,!o&&t?[t]:r?null:i.firstChild?n.call(i.childNodes):null,f,!o&&t?t:r?r.__e:i.firstChild,o),M(f,u);}function G(n,l){var u={__c:l="__cC"+e$1++,__:n,Consumer:function(n,l){return n.children(l)},Provider:function(n){var u,i;return this.getChildContext||(u=[],(i={})[l]=this,this.getChildContext=function(){return i},this.shouldComponentUpdate=function(n){this.props.value!==n.value&&u.some(function(n){n.__e=!0,w$1(n);});},this.sub=function(n){u.push(n);var l=n.componentWillUnmount;n.componentWillUnmount=function(){u.splice(u.indexOf(n),1),l&&l.call(n);};}),n.children}};return u.Provider.__=u.Consumer.contextType=u}n=s$1.slice,l$1={__e:function(n,l,u,i){for(var t,o,r;l=l.__;)if((t=l.__c)&&!t.__)try{if((o=t.constructor)&&null!=o.getDerivedStateFromError&&(t.setState(o.getDerivedStateFromError(n)),r=t.__d),null!=t.componentDidCatch&&(t.componentDidCatch(n,i||{}),r=t.__d),r)return t.__E=t}catch(l){n=l;}throw n}},u$1=0,b$1.prototype.setState=function(n,l){var u;u=null!=this.__s&&this.__s!==this.state?this.__s:this.__s=h$1({},this.state),"function"==typeof n&&(n=n(h$1({},u),this.props)),n&&h$1(u,n),null!=n&&this.__v&&(l&&this._sb.push(l),w$1(this));},b$1.prototype.forceUpdate=function(n){this.__v&&(this.__e=!0,n&&this.__h.push(n),w$1(this));},b$1.prototype.render=k$1,t$1=[],r$1="function"==typeof Promise?Promise.prototype.then.bind(Promise.resolve()):setTimeout,f$1=function(n,l){return n.__v.__b-l.__v.__b},x.__r=0,e$1=0;
+
+  var _$1=0;function o$1(o,e,n,t,f,l){var s,u,a={};for(u in e)"ref"==u?s=e[u]:a[u]=e[u];var i={type:o,props:a,key:n,ref:s,__k:null,__:null,__b:0,__e:null,__d:void 0,__c:null,__h:null,constructor:void 0,__v:--_$1,__source:f,__self:l};if("function"==typeof o&&(s=o.defaultProps))for(u in s)void 0===a[u]&&(a[u]=s[u]);return l$1.vnode&&l$1.vnode(i),i}
+
+  function count$1(node) {
+    var sum = 0,
+        children = node.children,
+        i = children && children.length;
+    if (!i) sum = 1;
+    else while (--i >= 0) sum += children[i].value;
+    node.value = sum;
+  }
+
+  function node_count() {
+    return this.eachAfter(count$1);
+  }
+
+  function node_each(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_eachBefore(callback, that) {
+    var node = this, nodes = [node], children, i, index = -1;
+    while (node = nodes.pop()) {
+      callback.call(that, node, ++index, this);
+      if (children = node.children) {
+        for (i = children.length - 1; i >= 0; --i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    return this;
+  }
+
+  function node_eachAfter(callback, that) {
+    var node = this, nodes = [node], next = [], children, i, n, index = -1;
+    while (node = nodes.pop()) {
+      next.push(node);
+      if (children = node.children) {
+        for (i = 0, n = children.length; i < n; ++i) {
+          nodes.push(children[i]);
+        }
+      }
+    }
+    while (node = next.pop()) {
+      callback.call(that, node, ++index, this);
+    }
+    return this;
+  }
+
+  function node_find(callback, that) {
+    let index = -1;
+    for (const node of this) {
+      if (callback.call(that, node, ++index, this)) {
+        return node;
+      }
+    }
+  }
+
+  function node_sum(value) {
+    return this.eachAfter(function(node) {
+      var sum = +value(node.data) || 0,
+          children = node.children,
+          i = children && children.length;
+      while (--i >= 0) sum += children[i].value;
+      node.value = sum;
+    });
+  }
+
+  function node_sort(compare) {
+    return this.eachBefore(function(node) {
+      if (node.children) {
+        node.children.sort(compare);
+      }
+    });
+  }
+
+  function node_path(end) {
+    var start = this,
+        ancestor = leastCommonAncestor(start, end),
+        nodes = [start];
+    while (start !== ancestor) {
+      start = start.parent;
+      nodes.push(start);
+    }
+    var k = nodes.length;
+    while (end !== ancestor) {
+      nodes.splice(k, 0, end);
+      end = end.parent;
+    }
+    return nodes;
+  }
+
+  function leastCommonAncestor(a, b) {
+    if (a === b) return a;
+    var aNodes = a.ancestors(),
+        bNodes = b.ancestors(),
+        c = null;
+    a = aNodes.pop();
+    b = bNodes.pop();
+    while (a === b) {
+      c = a;
+      a = aNodes.pop();
+      b = bNodes.pop();
+    }
+    return c;
+  }
+
+  function node_ancestors() {
+    var node = this, nodes = [node];
+    while (node = node.parent) {
+      nodes.push(node);
+    }
+    return nodes;
+  }
+
+  function node_descendants() {
+    return Array.from(this);
+  }
+
+  function node_leaves() {
+    var leaves = [];
+    this.eachBefore(function(node) {
+      if (!node.children) {
+        leaves.push(node);
+      }
+    });
+    return leaves;
+  }
+
+  function node_links() {
+    var root = this, links = [];
+    root.each(function(node) {
+      if (node !== root) { // Don’t include the root’s parent, if any.
+        links.push({source: node.parent, target: node});
+      }
+    });
+    return links;
+  }
+
+  function* node_iterator() {
+    var node = this, current, next = [node], children, i, n;
+    do {
+      current = next.reverse(), next = [];
+      while (node = current.pop()) {
+        yield node;
+        if (children = node.children) {
+          for (i = 0, n = children.length; i < n; ++i) {
+            next.push(children[i]);
+          }
+        }
+      }
+    } while (next.length);
+  }
+
+  function hierarchy(data, children) {
+    if (data instanceof Map) {
+      data = [undefined, data];
+      if (children === undefined) children = mapChildren;
+    } else if (children === undefined) {
+      children = objectChildren;
+    }
+
+    var root = new Node$1(data),
+        node,
+        nodes = [root],
+        child,
+        childs,
+        i,
+        n;
+
+    while (node = nodes.pop()) {
+      if ((childs = children(node.data)) && (n = (childs = Array.from(childs)).length)) {
+        node.children = childs;
+        for (i = n - 1; i >= 0; --i) {
+          nodes.push(child = childs[i] = new Node$1(childs[i]));
+          child.parent = node;
+          child.depth = node.depth + 1;
+        }
+      }
+    }
+
+    return root.eachBefore(computeHeight);
+  }
+
+  function node_copy() {
+    return hierarchy(this).eachBefore(copyData);
+  }
+
+  function objectChildren(d) {
+    return d.children;
+  }
+
+  function mapChildren(d) {
+    return Array.isArray(d) ? d[1] : null;
+  }
+
+  function copyData(node) {
+    if (node.data.value !== undefined) node.value = node.data.value;
+    node.data = node.data.data;
+  }
+
+  function computeHeight(node) {
+    var height = 0;
+    do node.height = height;
+    while ((node = node.parent) && (node.height < ++height));
+  }
+
+  function Node$1(data) {
+    this.data = data;
+    this.depth =
+    this.height = 0;
+    this.parent = null;
+  }
+
+  Node$1.prototype = hierarchy.prototype = {
+    constructor: Node$1,
+    count: node_count,
+    each: node_each,
+    eachAfter: node_eachAfter,
+    eachBefore: node_eachBefore,
+    find: node_find,
+    sum: node_sum,
+    sort: node_sort,
+    path: node_path,
+    ancestors: node_ancestors,
+    descendants: node_descendants,
+    leaves: node_leaves,
+    links: node_links,
+    copy: node_copy,
+    [Symbol.iterator]: node_iterator
+  };
+
+  function required(f) {
+    if (typeof f !== "function") throw new Error;
+    return f;
+  }
+
+  function constantZero() {
+    return 0;
+  }
+
+  function constant$1(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function roundNode(node) {
+    node.x0 = Math.round(node.x0);
+    node.y0 = Math.round(node.y0);
+    node.x1 = Math.round(node.x1);
+    node.y1 = Math.round(node.y1);
+  }
+
+  function treemapDice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (x1 - x0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.y0 = y0, node.y1 = y1;
+      node.x0 = x0, node.x1 = x0 += node.value * k;
+    }
+  }
+
+  function treemapSlice(parent, x0, y0, x1, y1) {
+    var nodes = parent.children,
+        node,
+        i = -1,
+        n = nodes.length,
+        k = parent.value && (y1 - y0) / parent.value;
+
+    while (++i < n) {
+      node = nodes[i], node.x0 = x0, node.x1 = x1;
+      node.y0 = y0, node.y1 = y0 += node.value * k;
+    }
+  }
+
+  var phi = (1 + Math.sqrt(5)) / 2;
+
+  function squarifyRatio(ratio, parent, x0, y0, x1, y1) {
+    var rows = [],
+        nodes = parent.children,
+        row,
+        nodeValue,
+        i0 = 0,
+        i1 = 0,
+        n = nodes.length,
+        dx, dy,
+        value = parent.value,
+        sumValue,
+        minValue,
+        maxValue,
+        newRatio,
+        minRatio,
+        alpha,
+        beta;
+
+    while (i0 < n) {
+      dx = x1 - x0, dy = y1 - y0;
+
+      // Find the next non-empty node.
+      do sumValue = nodes[i1++].value; while (!sumValue && i1 < n);
+      minValue = maxValue = sumValue;
+      alpha = Math.max(dy / dx, dx / dy) / (value * ratio);
+      beta = sumValue * sumValue * alpha;
+      minRatio = Math.max(maxValue / beta, beta / minValue);
+
+      // Keep adding nodes while the aspect ratio maintains or improves.
+      for (; i1 < n; ++i1) {
+        sumValue += nodeValue = nodes[i1].value;
+        if (nodeValue < minValue) minValue = nodeValue;
+        if (nodeValue > maxValue) maxValue = nodeValue;
+        beta = sumValue * sumValue * alpha;
+        newRatio = Math.max(maxValue / beta, beta / minValue);
+        if (newRatio > minRatio) { sumValue -= nodeValue; break; }
+        minRatio = newRatio;
+      }
+
+      // Position and record the row orientation.
+      rows.push(row = {value: sumValue, dice: dx < dy, children: nodes.slice(i0, i1)});
+      if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += dy * sumValue / value : y1);
+      else treemapSlice(row, x0, y0, value ? x0 += dx * sumValue / value : x1, y1);
+      value -= sumValue, i0 = i1;
+    }
+
+    return rows;
+  }
+
+  var squarify = (function custom(ratio) {
+
+    function squarify(parent, x0, y0, x1, y1) {
+      squarifyRatio(ratio, parent, x0, y0, x1, y1);
+    }
+
+    squarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return squarify;
+  })(phi);
+
+  function treemap() {
+    var tile = squarify,
+        round = false,
+        dx = 1,
+        dy = 1,
+        paddingStack = [0],
+        paddingInner = constantZero,
+        paddingTop = constantZero,
+        paddingRight = constantZero,
+        paddingBottom = constantZero,
+        paddingLeft = constantZero;
+
+    function treemap(root) {
+      root.x0 =
+      root.y0 = 0;
+      root.x1 = dx;
+      root.y1 = dy;
+      root.eachBefore(positionNode);
+      paddingStack = [0];
+      if (round) root.eachBefore(roundNode);
+      return root;
+    }
+
+    function positionNode(node) {
+      var p = paddingStack[node.depth],
+          x0 = node.x0 + p,
+          y0 = node.y0 + p,
+          x1 = node.x1 - p,
+          y1 = node.y1 - p;
+      if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+      if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+      node.x0 = x0;
+      node.y0 = y0;
+      node.x1 = x1;
+      node.y1 = y1;
+      if (node.children) {
+        p = paddingStack[node.depth + 1] = paddingInner(node) / 2;
+        x0 += paddingLeft(node) - p;
+        y0 += paddingTop(node) - p;
+        x1 -= paddingRight(node) - p;
+        y1 -= paddingBottom(node) - p;
+        if (x1 < x0) x0 = x1 = (x0 + x1) / 2;
+        if (y1 < y0) y0 = y1 = (y0 + y1) / 2;
+        tile(node, x0, y0, x1, y1);
+      }
+    }
+
+    treemap.round = function(x) {
+      return arguments.length ? (round = !!x, treemap) : round;
+    };
+
+    treemap.size = function(x) {
+      return arguments.length ? (dx = +x[0], dy = +x[1], treemap) : [dx, dy];
+    };
+
+    treemap.tile = function(x) {
+      return arguments.length ? (tile = required(x), treemap) : tile;
+    };
+
+    treemap.padding = function(x) {
+      return arguments.length ? treemap.paddingInner(x).paddingOuter(x) : treemap.paddingInner();
+    };
+
+    treemap.paddingInner = function(x) {
+      return arguments.length ? (paddingInner = typeof x === "function" ? x : constant$1(+x), treemap) : paddingInner;
+    };
+
+    treemap.paddingOuter = function(x) {
+      return arguments.length ? treemap.paddingTop(x).paddingRight(x).paddingBottom(x).paddingLeft(x) : treemap.paddingTop();
+    };
+
+    treemap.paddingTop = function(x) {
+      return arguments.length ? (paddingTop = typeof x === "function" ? x : constant$1(+x), treemap) : paddingTop;
+    };
+
+    treemap.paddingRight = function(x) {
+      return arguments.length ? (paddingRight = typeof x === "function" ? x : constant$1(+x), treemap) : paddingRight;
+    };
+
+    treemap.paddingBottom = function(x) {
+      return arguments.length ? (paddingBottom = typeof x === "function" ? x : constant$1(+x), treemap) : paddingBottom;
+    };
+
+    treemap.paddingLeft = function(x) {
+      return arguments.length ? (paddingLeft = typeof x === "function" ? x : constant$1(+x), treemap) : paddingLeft;
+    };
+
+    return treemap;
+  }
+
+  var treemapResquarify = (function custom(ratio) {
+
+    function resquarify(parent, x0, y0, x1, y1) {
+      if ((rows = parent._squarify) && (rows.ratio === ratio)) {
+        var rows,
+            row,
+            nodes,
+            i,
+            j = -1,
+            n,
+            m = rows.length,
+            value = parent.value;
+
+        while (++j < m) {
+          row = rows[j], nodes = row.children;
+          for (i = row.value = 0, n = nodes.length; i < n; ++i) row.value += nodes[i].value;
+          if (row.dice) treemapDice(row, x0, y0, x1, value ? y0 += (y1 - y0) * row.value / value : y1);
+          else treemapSlice(row, x0, y0, value ? x0 += (x1 - x0) * row.value / value : x1, y1);
+          value -= row.value;
+        }
+      } else {
+        parent._squarify = rows = squarifyRatio(ratio, parent, x0, y0, x1, y1);
+        rows.ratio = ratio;
+      }
+    }
+
+    resquarify.ratio = function(x) {
+      return custom((x = +x) > 1 ? x : 1);
+    };
+
+    return resquarify;
+  })(phi);
+
+  const isModuleTree = (mod) => "children" in mod;
+
+  let count = 0;
+  class Id {
+      constructor(id) {
+          this._id = id;
+          const url = new URL(window.location.href);
+          url.hash = id;
+          this._href = url.toString();
+      }
+      get id() {
+          return this._id;
+      }
+      get href() {
+          return this._href;
+      }
+      toString() {
+          return `url(${this.href})`;
+      }
+  }
+  function generateUniqueId(name) {
+      count += 1;
+      const id = ["O", name, count].filter(Boolean).join("-");
+      return new Id(id);
+  }
+
+  const LABELS = {
+      renderedLength: "Rendered",
+      gzipLength: "Gzip",
+      brotliLength: "Brotli",
+  };
+  const getAvailableSizeOptions = (options) => {
+      const availableSizeProperties = ["renderedLength"];
+      if (options.gzip) {
+          availableSizeProperties.push("gzipLength");
+      }
+      if (options.brotli) {
+          availableSizeProperties.push("brotliLength");
+      }
+      return availableSizeProperties;
+  };
+
+  var t,r,u,i,o=0,f=[],c=[],e=l$1.__b,a=l$1.__r,v=l$1.diffed,l=l$1.__c,m=l$1.unmount;function d(t,u){l$1.__h&&l$1.__h(r,t,o||u),o=0;var i=r.__H||(r.__H={__:[],__h:[]});return t>=i.__.length&&i.__.push({__V:c}),i.__[t]}function h(n){return o=1,s(B,n)}function s(n,u,i){var o=d(t++,2);if(o.t=n,!o.__c&&(o.__=[i?i(u):B(void 0,u),function(n){var t=o.__N?o.__N[0]:o.__[0],r=o.t(t,n);t!==r&&(o.__N=[r,o.__[1]],o.__c.setState({}));}],o.__c=r,!r.u)){var f=function(n,t,r){if(!o.__c.__H)return !0;var u=o.__c.__H.__.filter(function(n){return n.__c});if(u.every(function(n){return !n.__N}))return !c||c.call(this,n,t,r);var i=!1;return u.forEach(function(n){if(n.__N){var t=n.__[0];n.__=n.__N,n.__N=void 0,t!==n.__[0]&&(i=!0);}}),!(!i&&o.__c.props===n)&&(!c||c.call(this,n,t,r))};r.u=!0;var c=r.shouldComponentUpdate,e=r.componentWillUpdate;r.componentWillUpdate=function(n,t,r){if(this.__e){var u=c;c=void 0,f(n,t,r),c=u;}e&&e.call(this,n,t,r);},r.shouldComponentUpdate=f;}return o.__N||o.__}function p(u,i){var o=d(t++,3);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__H.__h.push(o));}function y(u,i){var o=d(t++,4);!l$1.__s&&z(o.__H,i)&&(o.__=u,o.i=i,r.__h.push(o));}function _(n){return o=5,F(function(){return {current:n}},[])}function F(n,r){var u=d(t++,7);return z(u.__H,r)?(u.__V=n(),u.i=r,u.__h=n,u.__V):u.__}function T(n,t){return o=8,F(function(){return n},t)}function q(n){var u=r.context[n.__c],i=d(t++,9);return i.c=n,u?(null==i.__&&(i.__=!0,u.sub(r)),u.props.value):n.__}function b(){for(var t;t=f.shift();)if(t.__P&&t.__H)try{t.__H.__h.forEach(k),t.__H.__h.forEach(w),t.__H.__h=[];}catch(r){t.__H.__h=[],l$1.__e(r,t.__v);}}l$1.__b=function(n){r=null,e&&e(n);},l$1.__r=function(n){a&&a(n),t=0;var i=(r=n.__c).__H;i&&(u===r?(i.__h=[],r.__h=[],i.__.forEach(function(n){n.__N&&(n.__=n.__N),n.__V=c,n.__N=n.i=void 0;})):(i.__h.forEach(k),i.__h.forEach(w),i.__h=[],t=0)),u=r;},l$1.diffed=function(t){v&&v(t);var o=t.__c;o&&o.__H&&(o.__H.__h.length&&(1!==f.push(o)&&i===l$1.requestAnimationFrame||((i=l$1.requestAnimationFrame)||j)(b)),o.__H.__.forEach(function(n){n.i&&(n.__H=n.i),n.__V!==c&&(n.__=n.__V),n.i=void 0,n.__V=c;})),u=r=null;},l$1.__c=function(t,r){r.some(function(t){try{t.__h.forEach(k),t.__h=t.__h.filter(function(n){return !n.__||w(n)});}catch(u){r.some(function(n){n.__h&&(n.__h=[]);}),r=[],l$1.__e(u,t.__v);}}),l&&l(t,r);},l$1.unmount=function(t){m&&m(t);var r,u=t.__c;u&&u.__H&&(u.__H.__.forEach(function(n){try{k(n);}catch(n){r=n;}}),u.__H=void 0,r&&l$1.__e(r,u.__v));};var g="function"==typeof requestAnimationFrame;function j(n){var t,r=function(){clearTimeout(u),g&&cancelAnimationFrame(t),setTimeout(n);},u=setTimeout(r,100);g&&(t=requestAnimationFrame(r));}function k(n){var t=r,u=n.__c;"function"==typeof u&&(n.__c=void 0,u()),r=t;}function w(n){var t=r;n.__c=n.__(),r=t;}function z(n,t){return !n||n.length!==t.length||t.some(function(t,r){return t!==n[r]})}function B(n,t){return "function"==typeof t?t(n):t}
+
+  const PLACEHOLDER = "bundle-*:**/file/**,**/file**, bundle-*:";
+  const SideBar = ({ availableSizeProperties, sizeProperty, setSizeProperty, onExcludeChange, onIncludeChange, }) => {
+      const [includeValue, setIncludeValue] = h("");
+      const [excludeValue, setExcludeValue] = h("");
+      const handleSizePropertyChange = (sizeProp) => () => {
+          if (sizeProp !== sizeProperty) {
+              setSizeProperty(sizeProp);
+          }
+      };
+      const handleIncludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setIncludeValue(value);
+          onIncludeChange(value);
+      };
+      const handleExcludeChange = (event) => {
+          const value = event.currentTarget.value;
+          setExcludeValue(value);
+          onExcludeChange(value);
+      };
+      return (o$1("aside", { className: "sidebar", children: [o$1("div", { className: "size-selectors", children: availableSizeProperties.length > 1 &&
+                      availableSizeProperties.map((sizeProp) => {
+                          const id = `selector-${sizeProp}`;
+                          return (o$1("div", { className: "size-selector", children: [o$1("input", { type: "radio", id: id, checked: sizeProp === sizeProperty, onChange: handleSizePropertyChange(sizeProp) }), o$1("label", { htmlFor: id, children: LABELS[sizeProp] })] }, sizeProp));
+                      }) }), o$1("div", { className: "module-filters", children: [o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-exclude", children: "Exclude" }), o$1("input", { type: "text", id: "module-filter-exclude", value: excludeValue, onInput: handleExcludeChange, placeholder: PLACEHOLDER })] }), o$1("div", { className: "module-filter", children: [o$1("label", { htmlFor: "module-filter-include", children: "Include" }), o$1("input", { type: "text", id: "module-filter-include", value: includeValue, onInput: handleIncludeChange, placeholder: PLACEHOLDER })] })] })] }));
+  };
+
+  function getDefaultExportFromCjs (x) {
+  	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+  }
+
+  var utils$3 = {};
+
+  const WIN_SLASH = '\\\\/';
+  const WIN_NO_SLASH = `[^${WIN_SLASH}]`;
+
+  /**
+   * Posix glob regex
+   */
+
+  const DOT_LITERAL = '\\.';
+  const PLUS_LITERAL = '\\+';
+  const QMARK_LITERAL = '\\?';
+  const SLASH_LITERAL = '\\/';
+  const ONE_CHAR = '(?=.)';
+  const QMARK = '[^/]';
+  const END_ANCHOR = `(?:${SLASH_LITERAL}|$)`;
+  const START_ANCHOR = `(?:^|${SLASH_LITERAL})`;
+  const DOTS_SLASH = `${DOT_LITERAL}{1,2}${END_ANCHOR}`;
+  const NO_DOT = `(?!${DOT_LITERAL})`;
+  const NO_DOTS = `(?!${START_ANCHOR}${DOTS_SLASH})`;
+  const NO_DOT_SLASH = `(?!${DOT_LITERAL}{0,1}${END_ANCHOR})`;
+  const NO_DOTS_SLASH = `(?!${DOTS_SLASH})`;
+  const QMARK_NO_DOT = `[^.${SLASH_LITERAL}]`;
+  const STAR = `${QMARK}*?`;
+  const SEP = '/';
+
+  const POSIX_CHARS = {
+    DOT_LITERAL,
+    PLUS_LITERAL,
+    QMARK_LITERAL,
+    SLASH_LITERAL,
+    ONE_CHAR,
+    QMARK,
+    END_ANCHOR,
+    DOTS_SLASH,
+    NO_DOT,
+    NO_DOTS,
+    NO_DOT_SLASH,
+    NO_DOTS_SLASH,
+    QMARK_NO_DOT,
+    STAR,
+    START_ANCHOR,
+    SEP
+  };
+
+  /**
+   * Windows glob regex
+   */
+
+  const WINDOWS_CHARS = {
+    ...POSIX_CHARS,
+
+    SLASH_LITERAL: `[${WIN_SLASH}]`,
+    QMARK: WIN_NO_SLASH,
+    STAR: `${WIN_NO_SLASH}*?`,
+    DOTS_SLASH: `${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$)`,
+    NO_DOT: `(?!${DOT_LITERAL})`,
+    NO_DOTS: `(?!(?:^|[${WIN_SLASH}])${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    NO_DOT_SLASH: `(?!${DOT_LITERAL}{0,1}(?:[${WIN_SLASH}]|$))`,
+    NO_DOTS_SLASH: `(?!${DOT_LITERAL}{1,2}(?:[${WIN_SLASH}]|$))`,
+    QMARK_NO_DOT: `[^.${WIN_SLASH}]`,
+    START_ANCHOR: `(?:^|[${WIN_SLASH}])`,
+    END_ANCHOR: `(?:[${WIN_SLASH}]|$)`,
+    SEP: '\\'
+  };
+
+  /**
+   * POSIX Bracket Regex
+   */
+
+  const POSIX_REGEX_SOURCE$1 = {
+    alnum: 'a-zA-Z0-9',
+    alpha: 'a-zA-Z',
+    ascii: '\\x00-\\x7F',
+    blank: ' \\t',
+    cntrl: '\\x00-\\x1F\\x7F',
+    digit: '0-9',
+    graph: '\\x21-\\x7E',
+    lower: 'a-z',
+    print: '\\x20-\\x7E ',
+    punct: '\\-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~',
+    space: ' \\t\\r\\n\\v\\f',
+    upper: 'A-Z',
+    word: 'A-Za-z0-9_',
+    xdigit: 'A-Fa-f0-9'
+  };
+
+  var constants$3 = {
+    MAX_LENGTH: 1024 * 64,
+    POSIX_REGEX_SOURCE: POSIX_REGEX_SOURCE$1,
+
+    // regular expressions
+    REGEX_BACKSLASH: /\\(?![*+?^${}(|)[\]])/g,
+    REGEX_NON_SPECIAL_CHARS: /^[^@![\].,$*+?^{}()|\\/]+/,
+    REGEX_SPECIAL_CHARS: /[-*+?.^${}(|)[\]]/,
+    REGEX_SPECIAL_CHARS_BACKREF: /(\\?)((\W)(\3*))/g,
+    REGEX_SPECIAL_CHARS_GLOBAL: /([-*+?.^${}(|)[\]])/g,
+    REGEX_REMOVE_BACKSLASH: /(?:\[.*?[^\\]\]|\\(?=.))/g,
+
+    // Replace globs with equivalent patterns to reduce parsing time.
+    REPLACEMENTS: {
+      '***': '*',
+      '**/**': '**',
+      '**/**/**': '**'
+    },
+
+    // Digits
+    CHAR_0: 48, /* 0 */
+    CHAR_9: 57, /* 9 */
+
+    // Alphabet chars.
+    CHAR_UPPERCASE_A: 65, /* A */
+    CHAR_LOWERCASE_A: 97, /* a */
+    CHAR_UPPERCASE_Z: 90, /* Z */
+    CHAR_LOWERCASE_Z: 122, /* z */
+
+    CHAR_LEFT_PARENTHESES: 40, /* ( */
+    CHAR_RIGHT_PARENTHESES: 41, /* ) */
+
+    CHAR_ASTERISK: 42, /* * */
+
+    // Non-alphabetic chars.
+    CHAR_AMPERSAND: 38, /* & */
+    CHAR_AT: 64, /* @ */
+    CHAR_BACKWARD_SLASH: 92, /* \ */
+    CHAR_CARRIAGE_RETURN: 13, /* \r */
+    CHAR_CIRCUMFLEX_ACCENT: 94, /* ^ */
+    CHAR_COLON: 58, /* : */
+    CHAR_COMMA: 44, /* , */
+    CHAR_DOT: 46, /* . */
+    CHAR_DOUBLE_QUOTE: 34, /* " */
+    CHAR_EQUAL: 61, /* = */
+    CHAR_EXCLAMATION_MARK: 33, /* ! */
+    CHAR_FORM_FEED: 12, /* \f */
+    CHAR_FORWARD_SLASH: 47, /* / */
+    CHAR_GRAVE_ACCENT: 96, /* ` */
+    CHAR_HASH: 35, /* # */
+    CHAR_HYPHEN_MINUS: 45, /* - */
+    CHAR_LEFT_ANGLE_BRACKET: 60, /* < */
+    CHAR_LEFT_CURLY_BRACE: 123, /* { */
+    CHAR_LEFT_SQUARE_BRACKET: 91, /* [ */
+    CHAR_LINE_FEED: 10, /* \n */
+    CHAR_NO_BREAK_SPACE: 160, /* \u00A0 */
+    CHAR_PERCENT: 37, /* % */
+    CHAR_PLUS: 43, /* + */
+    CHAR_QUESTION_MARK: 63, /* ? */
+    CHAR_RIGHT_ANGLE_BRACKET: 62, /* > */
+    CHAR_RIGHT_CURLY_BRACE: 125, /* } */
+    CHAR_RIGHT_SQUARE_BRACKET: 93, /* ] */
+    CHAR_SEMICOLON: 59, /* ; */
+    CHAR_SINGLE_QUOTE: 39, /* ' */
+    CHAR_SPACE: 32, /*   */
+    CHAR_TAB: 9, /* \t */
+    CHAR_UNDERSCORE: 95, /* _ */
+    CHAR_VERTICAL_LINE: 124, /* | */
+    CHAR_ZERO_WIDTH_NOBREAK_SPACE: 65279, /* \uFEFF */
+
+    /**
+     * Create EXTGLOB_CHARS
+     */
+
+    extglobChars(chars) {
+      return {
+        '!': { type: 'negate', open: '(?:(?!(?:', close: `))${chars.STAR})` },
+        '?': { type: 'qmark', open: '(?:', close: ')?' },
+        '+': { type: 'plus', open: '(?:', close: ')+' },
+        '*': { type: 'star', open: '(?:', close: ')*' },
+        '@': { type: 'at', open: '(?:', close: ')' }
+      };
+    },
+
+    /**
+     * Create GLOB_CHARS
+     */
+
+    globChars(win32) {
+      return win32 === true ? WINDOWS_CHARS : POSIX_CHARS;
+    }
+  };
+
+  (function (exports) {
+
+  	const {
+  	  REGEX_BACKSLASH,
+  	  REGEX_REMOVE_BACKSLASH,
+  	  REGEX_SPECIAL_CHARS,
+  	  REGEX_SPECIAL_CHARS_GLOBAL
+  	} = constants$3;
+
+  	exports.isObject = val => val !== null && typeof val === 'object' && !Array.isArray(val);
+  	exports.hasRegexChars = str => REGEX_SPECIAL_CHARS.test(str);
+  	exports.isRegexChar = str => str.length === 1 && exports.hasRegexChars(str);
+  	exports.escapeRegex = str => str.replace(REGEX_SPECIAL_CHARS_GLOBAL, '\\$1');
+  	exports.toPosixSlashes = str => str.replace(REGEX_BACKSLASH, '/');
+
+  	exports.removeBackslashes = str => {
+  	  return str.replace(REGEX_REMOVE_BACKSLASH, match => {
+  	    return match === '\\' ? '' : match;
+  	  });
+  	};
+
+  	exports.supportsLookbehinds = () => {
+  	  const segs = process.version.slice(1).split('.').map(Number);
+  	  if (segs.length === 3 && segs[0] >= 9 || (segs[0] === 8 && segs[1] >= 10)) {
+  	    return true;
+  	  }
+  	  return false;
+  	};
+
+  	exports.escapeLast = (input, char, lastIdx) => {
+  	  const idx = input.lastIndexOf(char, lastIdx);
+  	  if (idx === -1) return input;
+  	  if (input[idx - 1] === '\\') return exports.escapeLast(input, char, idx - 1);
+  	  return `${input.slice(0, idx)}\\${input.slice(idx)}`;
+  	};
+
+  	exports.removePrefix = (input, state = {}) => {
+  	  let output = input;
+  	  if (output.startsWith('./')) {
+  	    output = output.slice(2);
+  	    state.prefix = './';
+  	  }
+  	  return output;
+  	};
+
+  	exports.wrapOutput = (input, state = {}, options = {}) => {
+  	  const prepend = options.contains ? '' : '^';
+  	  const append = options.contains ? '' : '$';
+
+  	  let output = `${prepend}(?:${input})${append}`;
+  	  if (state.negated === true) {
+  	    output = `(?:^(?!${output}).*$)`;
+  	  }
+  	  return output;
+  	};
+
+  	exports.basename = (path, { windows } = {}) => {
+  	  if (windows) {
+  	    return path.replace(/[\\/]$/, '').replace(/.*[\\/]/, '');
+  	  } else {
+  	    return path.replace(/\/$/, '').replace(/.*\//, '');
+  	  }
+  	}; 
+  } (utils$3));
+
+  const utils$2 = utils$3;
+  const {
+    CHAR_ASTERISK,             /* * */
+    CHAR_AT,                   /* @ */
+    CHAR_BACKWARD_SLASH,       /* \ */
+    CHAR_COMMA,                /* , */
+    CHAR_DOT,                  /* . */
+    CHAR_EXCLAMATION_MARK,     /* ! */
+    CHAR_FORWARD_SLASH,        /* / */
+    CHAR_LEFT_CURLY_BRACE,     /* { */
+    CHAR_LEFT_PARENTHESES,     /* ( */
+    CHAR_LEFT_SQUARE_BRACKET,  /* [ */
+    CHAR_PLUS,                 /* + */
+    CHAR_QUESTION_MARK,        /* ? */
+    CHAR_RIGHT_CURLY_BRACE,    /* } */
+    CHAR_RIGHT_PARENTHESES,    /* ) */
+    CHAR_RIGHT_SQUARE_BRACKET  /* ] */
+  } = constants$3;
+
+  const isPathSeparator = code => {
+    return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+  };
+
+  const depth = token => {
+    if (token.isPrefix !== true) {
+      token.depth = token.isGlobstar ? Infinity : 1;
+    }
+  };
+
+  /**
+   * Quickly scans a glob pattern and returns an object with a handful of
+   * useful properties, like `isGlob`, `path` (the leading non-glob, if it exists),
+   * `glob` (the actual pattern), and `negated` (true if the path starts with `!`).
+   *
+   * ```js
+   * const pm = require('picomatch');
+   * console.log(pm.scan('foo/bar/*.js'));
+   * { isGlob: true, input: 'foo/bar/*.js', base: 'foo/bar', glob: '*.js' }
+   * ```
+   * @param {String} `str`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with tokens and regex source string.
+   * @api public
+   */
+
+  const scan$1 = (input, options) => {
+    const opts = options || {};
+
+    const length = input.length - 1;
+    const scanToEnd = opts.parts === true || opts.scanToEnd === true;
+    const slashes = [];
+    const tokens = [];
+    const parts = [];
+
+    let str = input;
+    let index = -1;
+    let start = 0;
+    let lastIndex = 0;
+    let isBrace = false;
+    let isBracket = false;
+    let isGlob = false;
+    let isExtglob = false;
+    let isGlobstar = false;
+    let braceEscaped = false;
+    let backslashes = false;
+    let negated = false;
+    let finished = false;
+    let braces = 0;
+    let prev;
+    let code;
+    let token = { value: '', depth: 0, isGlob: false };
+
+    const eos = () => index >= length;
+    const peek = () => str.charCodeAt(index + 1);
+    const advance = () => {
+      prev = code;
+      return str.charCodeAt(++index);
+    };
+
+    while (index < length) {
+      code = advance();
+      let next;
+
+      if (code === CHAR_BACKWARD_SLASH) {
+        backslashes = token.backslashes = true;
+        code = advance();
+
+        if (code === CHAR_LEFT_CURLY_BRACE) {
+          braceEscaped = true;
+        }
+        continue;
+      }
+
+      if (braceEscaped === true || code === CHAR_LEFT_CURLY_BRACE) {
+        braces++;
+
+        while (eos() !== true && (code = advance())) {
+          if (code === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (code === CHAR_LEFT_CURLY_BRACE) {
+            braces++;
+            continue;
+          }
+
+          if (braceEscaped !== true && code === CHAR_DOT && (code = advance()) === CHAR_DOT) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (braceEscaped !== true && code === CHAR_COMMA) {
+            isBrace = token.isBrace = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+
+            break;
+          }
+
+          if (code === CHAR_RIGHT_CURLY_BRACE) {
+            braces--;
+
+            if (braces === 0) {
+              braceEscaped = false;
+              isBrace = token.isBrace = true;
+              finished = true;
+              break;
+            }
+          }
+        }
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+
+      if (code === CHAR_FORWARD_SLASH) {
+        slashes.push(index);
+        tokens.push(token);
+        token = { value: '', depth: 0, isGlob: false };
+
+        if (finished === true) continue;
+        if (prev === CHAR_DOT && index === (start + 1)) {
+          start += 2;
+          continue;
+        }
+
+        lastIndex = index + 1;
+        continue;
+      }
+
+      if (opts.noext !== true) {
+        const isExtglobChar = code === CHAR_PLUS
+          || code === CHAR_AT
+          || code === CHAR_ASTERISK
+          || code === CHAR_QUESTION_MARK
+          || code === CHAR_EXCLAMATION_MARK;
+
+        if (isExtglobChar === true && peek() === CHAR_LEFT_PARENTHESES) {
+          isGlob = token.isGlob = true;
+          isExtglob = token.isExtglob = true;
+          finished = true;
+
+          if (scanToEnd === true) {
+            while (eos() !== true && (code = advance())) {
+              if (code === CHAR_BACKWARD_SLASH) {
+                backslashes = token.backslashes = true;
+                code = advance();
+                continue;
+              }
+
+              if (code === CHAR_RIGHT_PARENTHESES) {
+                isGlob = token.isGlob = true;
+                finished = true;
+                break;
+              }
+            }
+            continue;
+          }
+          break;
+        }
+      }
+
+      if (code === CHAR_ASTERISK) {
+        if (prev === CHAR_ASTERISK) isGlobstar = token.isGlobstar = true;
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_QUESTION_MARK) {
+        isGlob = token.isGlob = true;
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+        break;
+      }
+
+      if (code === CHAR_LEFT_SQUARE_BRACKET) {
+        while (eos() !== true && (next = advance())) {
+          if (next === CHAR_BACKWARD_SLASH) {
+            backslashes = token.backslashes = true;
+            advance();
+            continue;
+          }
+
+          if (next === CHAR_RIGHT_SQUARE_BRACKET) {
+            isBracket = token.isBracket = true;
+            isGlob = token.isGlob = true;
+            finished = true;
+
+            if (scanToEnd === true) {
+              continue;
+            }
+            break;
+          }
+        }
+      }
+
+      if (opts.nonegate !== true && code === CHAR_EXCLAMATION_MARK && index === start) {
+        negated = token.negated = true;
+        start++;
+        continue;
+      }
+
+      if (opts.noparen !== true && code === CHAR_LEFT_PARENTHESES) {
+        isGlob = token.isGlob = true;
+
+        if (scanToEnd === true) {
+          while (eos() !== true && (code = advance())) {
+            if (code === CHAR_LEFT_PARENTHESES) {
+              backslashes = token.backslashes = true;
+              code = advance();
+              continue;
+            }
+
+            if (code === CHAR_RIGHT_PARENTHESES) {
+              finished = true;
+              break;
+            }
+          }
+          continue;
+        }
+        break;
+      }
+
+      if (isGlob === true) {
+        finished = true;
+
+        if (scanToEnd === true) {
+          continue;
+        }
+
+        break;
+      }
+    }
+
+    if (opts.noext === true) {
+      isExtglob = false;
+      isGlob = false;
+    }
+
+    let base = str;
+    let prefix = '';
+    let glob = '';
+
+    if (start > 0) {
+      prefix = str.slice(0, start);
+      str = str.slice(start);
+      lastIndex -= start;
+    }
+
+    if (base && isGlob === true && lastIndex > 0) {
+      base = str.slice(0, lastIndex);
+      glob = str.slice(lastIndex);
+    } else if (isGlob === true) {
+      base = '';
+      glob = str;
+    } else {
+      base = str;
+    }
+
+    if (base && base !== '' && base !== '/' && base !== str) {
+      if (isPathSeparator(base.charCodeAt(base.length - 1))) {
+        base = base.slice(0, -1);
+      }
+    }
+
+    if (opts.unescape === true) {
+      if (glob) glob = utils$2.removeBackslashes(glob);
+
+      if (base && backslashes === true) {
+        base = utils$2.removeBackslashes(base);
+      }
+    }
+
+    const state = {
+      prefix,
+      input,
+      start,
+      base,
+      glob,
+      isBrace,
+      isBracket,
+      isGlob,
+      isExtglob,
+      isGlobstar,
+      negated
+    };
+
+    if (opts.tokens === true) {
+      state.maxDepth = 0;
+      if (!isPathSeparator(code)) {
+        tokens.push(token);
+      }
+      state.tokens = tokens;
+    }
+
+    if (opts.parts === true || opts.tokens === true) {
+      let prevIndex;
+
+      for (let idx = 0; idx < slashes.length; idx++) {
+        const n = prevIndex ? prevIndex + 1 : start;
+        const i = slashes[idx];
+        const value = input.slice(n, i);
+        if (opts.tokens) {
+          if (idx === 0 && start !== 0) {
+            tokens[idx].isPrefix = true;
+            tokens[idx].value = prefix;
+          } else {
+            tokens[idx].value = value;
+          }
+          depth(tokens[idx]);
+          state.maxDepth += tokens[idx].depth;
+        }
+        if (idx !== 0 || value !== '') {
+          parts.push(value);
+        }
+        prevIndex = i;
+      }
+
+      if (prevIndex && prevIndex + 1 < input.length) {
+        const value = input.slice(prevIndex + 1);
+        parts.push(value);
+
+        if (opts.tokens) {
+          tokens[tokens.length - 1].value = value;
+          depth(tokens[tokens.length - 1]);
+          state.maxDepth += tokens[tokens.length - 1].depth;
+        }
+      }
+
+      state.slashes = slashes;
+      state.parts = parts;
+    }
+
+    return state;
+  };
+
+  var scan_1 = scan$1;
+
+  const constants$2 = constants$3;
+  const utils$1 = utils$3;
+
+  /**
+   * Constants
+   */
+
+  const {
+    MAX_LENGTH,
+    POSIX_REGEX_SOURCE,
+    REGEX_NON_SPECIAL_CHARS,
+    REGEX_SPECIAL_CHARS_BACKREF,
+    REPLACEMENTS
+  } = constants$2;
+
+  /**
+   * Helpers
+   */
+
+  const expandRange = (args, options) => {
+    if (typeof options.expandRange === 'function') {
+      return options.expandRange(...args, options);
+    }
+
+    args.sort();
+    const value = `[${args.join('-')}]`;
+
+    try {
+      /* eslint-disable-next-line no-new */
+      new RegExp(value);
+    } catch (ex) {
+      return args.map(v => utils$1.escapeRegex(v)).join('..');
+    }
+
+    return value;
+  };
+
+  /**
+   * Create the message for a syntax error
+   */
+
+  const syntaxError = (type, char) => {
+    return `Missing ${type}: "${char}" - use "\\\\${char}" to match literal characters`;
+  };
+
+  /**
+   * Parse the given input string.
+   * @param {String} input
+   * @param {Object} options
+   * @return {Object}
+   */
+
+  const parse$2 = (input, options) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected a string');
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+
+    let len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    const bos = { type: 'bos', value: '', output: opts.prepend || '' };
+    const tokens = [bos];
+
+    const capture = opts.capture ? '' : '?:';
+
+    // create constants based on platform, for windows or posix
+    const PLATFORM_CHARS = constants$2.globChars(opts.windows);
+    const EXTGLOB_CHARS = constants$2.extglobChars(PLATFORM_CHARS);
+
+    const {
+      DOT_LITERAL,
+      PLUS_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOT_SLASH,
+      NO_DOTS_SLASH,
+      QMARK,
+      QMARK_NO_DOT,
+      STAR,
+      START_ANCHOR
+    } = PLATFORM_CHARS;
+
+    const globstar = (opts) => {
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const nodot = opts.dot ? '' : NO_DOT;
+    const qmarkNoDot = opts.dot ? QMARK : QMARK_NO_DOT;
+    let star = opts.bash === true ? globstar(opts) : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    // minimatch options support
+    if (typeof opts.noext === 'boolean') {
+      opts.noextglob = opts.noext;
+    }
+
+    const state = {
+      input,
+      index: -1,
+      start: 0,
+      dot: opts.dot === true,
+      consumed: '',
+      output: '',
+      prefix: '',
+      backtrack: false,
+      negated: false,
+      brackets: 0,
+      braces: 0,
+      parens: 0,
+      quotes: 0,
+      globstar: false,
+      tokens
+    };
+
+    input = utils$1.removePrefix(input, state);
+    len = input.length;
+
+    const extglobs = [];
+    const braces = [];
+    const stack = [];
+    let prev = bos;
+    let value;
+
+    /**
+     * Tokenizing helpers
+     */
+
+    const eos = () => state.index === len - 1;
+    const peek = state.peek = (n = 1) => input[state.index + n];
+    const advance = state.advance = () => input[++state.index];
+    const remaining = () => input.slice(state.index + 1);
+    const consume = (value = '', num = 0) => {
+      state.consumed += value;
+      state.index += num;
+    };
+    const append = token => {
+      state.output += token.output != null ? token.output : token.value;
+      consume(token.value);
+    };
+
+    const negate = () => {
+      let count = 1;
+
+      while (peek() === '!' && (peek(2) !== '(' || peek(3) === '?')) {
+        advance();
+        state.start++;
+        count++;
+      }
+
+      if (count % 2 === 0) {
+        return false;
+      }
+
+      state.negated = true;
+      state.start++;
+      return true;
+    };
+
+    const increment = type => {
+      state[type]++;
+      stack.push(type);
+    };
+
+    const decrement = type => {
+      state[type]--;
+      stack.pop();
+    };
+
+    /**
+     * Push tokens onto the tokens array. This helper speeds up
+     * tokenizing by 1) helping us avoid backtracking as much as possible,
+     * and 2) helping us avoid creating extra tokens when consecutive
+     * characters are plain text. This improves performance and simplifies
+     * lookbehinds.
+     */
+
+    const push = tok => {
+      if (prev.type === 'globstar') {
+        const isBrace = state.braces > 0 && (tok.type === 'comma' || tok.type === 'brace');
+        const isExtglob = tok.extglob === true || (extglobs.length && (tok.type === 'pipe' || tok.type === 'paren'));
+
+        if (tok.type !== 'slash' && tok.type !== 'paren' && !isBrace && !isExtglob) {
+          state.output = state.output.slice(0, -prev.output.length);
+          prev.type = 'star';
+          prev.value = '*';
+          prev.output = star;
+          state.output += prev.output;
+        }
+      }
+
+      if (extglobs.length && tok.type !== 'paren' && !EXTGLOB_CHARS[tok.value]) {
+        extglobs[extglobs.length - 1].inner += tok.value;
+      }
+
+      if (tok.value || tok.output) append(tok);
+      if (prev && prev.type === 'text' && tok.type === 'text') {
+        prev.value += tok.value;
+        prev.output = (prev.output || '') + tok.value;
+        return;
+      }
+
+      tok.prev = prev;
+      tokens.push(tok);
+      prev = tok;
+    };
+
+    const extglobOpen = (type, value) => {
+      const token = { ...EXTGLOB_CHARS[value], conditions: 1, inner: '' };
+
+      token.prev = prev;
+      token.parens = state.parens;
+      token.output = state.output;
+      const output = (opts.capture ? '(' : '') + token.open;
+
+      increment('parens');
+      push({ type, value, output: state.output ? '' : ONE_CHAR });
+      push({ type: 'paren', extglob: true, value: advance(), output });
+      extglobs.push(token);
+    };
+
+    const extglobClose = token => {
+      let output = token.close + (opts.capture ? ')' : '');
+
+      if (token.type === 'negate') {
+        let extglobStar = star;
+
+        if (token.inner && token.inner.length > 1 && token.inner.includes('/')) {
+          extglobStar = globstar(opts);
+        }
+
+        if (extglobStar !== star || eos() || /^\)+$/.test(remaining())) {
+          output = token.close = `)$))${extglobStar}`;
+        }
+
+        if (token.prev.type === 'bos' && eos()) {
+          state.negatedExtglob = true;
+        }
+      }
+
+      push({ type: 'paren', extglob: true, value, output });
+      decrement('parens');
+    };
+
+    /**
+     * Fast paths
+     */
+
+    if (opts.fastpaths !== false && !/(^[*!]|[/()[\]{}"])/.test(input)) {
+      let backslashes = false;
+
+      let output = input.replace(REGEX_SPECIAL_CHARS_BACKREF, (m, esc, chars, first, rest, index) => {
+        if (first === '\\') {
+          backslashes = true;
+          return m;
+        }
+
+        if (first === '?') {
+          if (esc) {
+            return esc + first + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          if (index === 0) {
+            return qmarkNoDot + (rest ? QMARK.repeat(rest.length) : '');
+          }
+          return QMARK.repeat(chars.length);
+        }
+
+        if (first === '.') {
+          return DOT_LITERAL.repeat(chars.length);
+        }
+
+        if (first === '*') {
+          if (esc) {
+            return esc + first + (rest ? star : '');
+          }
+          return star;
+        }
+        return esc ? m : `\\${m}`;
+      });
+
+      if (backslashes === true) {
+        if (opts.unescape === true) {
+          output = output.replace(/\\/g, '');
+        } else {
+          output = output.replace(/\\+/g, m => {
+            return m.length % 2 === 0 ? '\\\\' : (m ? '\\' : '');
+          });
+        }
+      }
+
+      if (output === input && opts.contains === true) {
+        state.output = input;
+        return state;
+      }
+
+      state.output = utils$1.wrapOutput(output, state, options);
+      return state;
+    }
+
+    /**
+     * Tokenize input until we reach end-of-string
+     */
+
+    while (!eos()) {
+      value = advance();
+
+      if (value === '\u0000') {
+        continue;
+      }
+
+      /**
+       * Escaped characters
+       */
+
+      if (value === '\\') {
+        const next = peek();
+
+        if (next === '/' && opts.bash !== true) {
+          continue;
+        }
+
+        if (next === '.' || next === ';') {
+          continue;
+        }
+
+        if (!next) {
+          value += '\\';
+          push({ type: 'text', value });
+          continue;
+        }
+
+        // collapse slashes to reduce potential for exploits
+        const match = /^\\+/.exec(remaining());
+        let slashes = 0;
+
+        if (match && match[0].length > 2) {
+          slashes = match[0].length;
+          state.index += slashes;
+          if (slashes % 2 !== 0) {
+            value += '\\';
+          }
+        }
+
+        if (opts.unescape === true) {
+          value = advance() || '';
+        } else {
+          value += advance() || '';
+        }
+
+        if (state.brackets === 0) {
+          push({ type: 'text', value });
+          continue;
+        }
+      }
+
+      /**
+       * If we're inside a regex character class, continue
+       * until we reach the closing bracket.
+       */
+
+      if (state.brackets > 0 && (value !== ']' || prev.value === '[' || prev.value === '[^')) {
+        if (opts.posix !== false && value === ':') {
+          const inner = prev.value.slice(1);
+          if (inner.includes('[')) {
+            prev.posix = true;
+
+            if (inner.includes(':')) {
+              const idx = prev.value.lastIndexOf('[');
+              const pre = prev.value.slice(0, idx);
+              const rest = prev.value.slice(idx + 2);
+              const posix = POSIX_REGEX_SOURCE[rest];
+              if (posix) {
+                prev.value = pre + posix;
+                state.backtrack = true;
+                advance();
+
+                if (!bos.output && tokens.indexOf(prev) === 1) {
+                  bos.output = ONE_CHAR;
+                }
+                continue;
+              }
+            }
+          }
+        }
+
+        if ((value === '[' && peek() !== ':') || (value === '-' && peek() === ']')) {
+          value = `\\${value}`;
+        }
+
+        if (value === ']' && (prev.value === '[' || prev.value === '[^')) {
+          value = `\\${value}`;
+        }
+
+        if (opts.posix === true && value === '!' && prev.value === '[') {
+          value = '^';
+        }
+
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * If we're inside a quoted string, continue
+       * until we reach the closing double quote.
+       */
+
+      if (state.quotes === 1 && value !== '"') {
+        value = utils$1.escapeRegex(value);
+        prev.value += value;
+        append({ value });
+        continue;
+      }
+
+      /**
+       * Double quotes
+       */
+
+      if (value === '"') {
+        state.quotes = state.quotes === 1 ? 0 : 1;
+        if (opts.keepQuotes === true) {
+          push({ type: 'text', value });
+        }
+        continue;
+      }
+
+      /**
+       * Parentheses
+       */
+
+      if (value === '(') {
+        increment('parens');
+        push({ type: 'paren', value });
+        continue;
+      }
+
+      if (value === ')') {
+        if (state.parens === 0 && opts.strictBrackets === true) {
+          throw new SyntaxError(syntaxError('opening', '('));
+        }
+
+        const extglob = extglobs[extglobs.length - 1];
+        if (extglob && state.parens === extglob.parens + 1) {
+          extglobClose(extglobs.pop());
+          continue;
+        }
+
+        push({ type: 'paren', value, output: state.parens ? ')' : '\\)' });
+        decrement('parens');
+        continue;
+      }
+
+      /**
+       * Square brackets
+       */
+
+      if (value === '[') {
+        if (opts.nobracket === true || !remaining().includes(']')) {
+          if (opts.nobracket !== true && opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('closing', ']'));
+          }
+
+          value = `\\${value}`;
+        } else {
+          increment('brackets');
+        }
+
+        push({ type: 'bracket', value });
+        continue;
+      }
+
+      if (value === ']') {
+        if (opts.nobracket === true || (prev && prev.type === 'bracket' && prev.value.length === 1)) {
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        if (state.brackets === 0) {
+          if (opts.strictBrackets === true) {
+            throw new SyntaxError(syntaxError('opening', '['));
+          }
+
+          push({ type: 'text', value, output: `\\${value}` });
+          continue;
+        }
+
+        decrement('brackets');
+
+        const prevValue = prev.value.slice(1);
+        if (prev.posix !== true && prevValue[0] === '^' && !prevValue.includes('/')) {
+          value = `/${value}`;
+        }
+
+        prev.value += value;
+        append({ value });
+
+        // when literal brackets are explicitly disabled
+        // assume we should match with a regex character class
+        if (opts.literalBrackets === false || utils$1.hasRegexChars(prevValue)) {
+          continue;
+        }
+
+        const escaped = utils$1.escapeRegex(prev.value);
+        state.output = state.output.slice(0, -prev.value.length);
+
+        // when literal brackets are explicitly enabled
+        // assume we should escape the brackets to match literal characters
+        if (opts.literalBrackets === true) {
+          state.output += escaped;
+          prev.value = escaped;
+          continue;
+        }
+
+        // when the user specifies nothing, try to match both
+        prev.value = `(${capture}${escaped}|${prev.value})`;
+        state.output += prev.value;
+        continue;
+      }
+
+      /**
+       * Braces
+       */
+
+      if (value === '{' && opts.nobrace !== true) {
+        increment('braces');
+
+        const open = {
+          type: 'brace',
+          value,
+          output: '(',
+          outputIndex: state.output.length,
+          tokensIndex: state.tokens.length
+        };
+
+        braces.push(open);
+        push(open);
+        continue;
+      }
+
+      if (value === '}') {
+        const brace = braces[braces.length - 1];
+
+        if (opts.nobrace === true || !brace) {
+          push({ type: 'text', value, output: value });
+          continue;
+        }
+
+        let output = ')';
+
+        if (brace.dots === true) {
+          const arr = tokens.slice();
+          const range = [];
+
+          for (let i = arr.length - 1; i >= 0; i--) {
+            tokens.pop();
+            if (arr[i].type === 'brace') {
+              break;
+            }
+            if (arr[i].type !== 'dots') {
+              range.unshift(arr[i].value);
+            }
+          }
+
+          output = expandRange(range, opts);
+          state.backtrack = true;
+        }
+
+        if (brace.comma !== true && brace.dots !== true) {
+          const out = state.output.slice(0, brace.outputIndex);
+          const toks = state.tokens.slice(brace.tokensIndex);
+          brace.value = brace.output = '\\{';
+          value = output = '\\}';
+          state.output = out;
+          for (const t of toks) {
+            state.output += (t.output || t.value);
+          }
+        }
+
+        push({ type: 'brace', value, output });
+        decrement('braces');
+        braces.pop();
+        continue;
+      }
+
+      /**
+       * Pipes
+       */
+
+      if (value === '|') {
+        if (extglobs.length > 0) {
+          extglobs[extglobs.length - 1].conditions++;
+        }
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Commas
+       */
+
+      if (value === ',') {
+        let output = value;
+
+        const brace = braces[braces.length - 1];
+        if (brace && stack[stack.length - 1] === 'braces') {
+          brace.comma = true;
+          output = '|';
+        }
+
+        push({ type: 'comma', value, output });
+        continue;
+      }
+
+      /**
+       * Slashes
+       */
+
+      if (value === '/') {
+        // if the beginning of the glob is "./", advance the start
+        // to the current index, and don't add the "./" characters
+        // to the state. This greatly simplifies lookbehinds when
+        // checking for BOS characters like "!" and "." (not "./")
+        if (prev.type === 'dot' && state.index === state.start + 1) {
+          state.start = state.index + 1;
+          state.consumed = '';
+          state.output = '';
+          tokens.pop();
+          prev = bos; // reset "prev" to the first token
+          continue;
+        }
+
+        push({ type: 'slash', value, output: SLASH_LITERAL });
+        continue;
+      }
+
+      /**
+       * Dots
+       */
+
+      if (value === '.') {
+        if (state.braces > 0 && prev.type === 'dot') {
+          if (prev.value === '.') prev.output = DOT_LITERAL;
+          const brace = braces[braces.length - 1];
+          prev.type = 'dots';
+          prev.output += value;
+          prev.value += value;
+          brace.dots = true;
+          continue;
+        }
+
+        if ((state.braces + state.parens) === 0 && prev.type !== 'bos' && prev.type !== 'slash') {
+          push({ type: 'text', value, output: DOT_LITERAL });
+          continue;
+        }
+
+        push({ type: 'dot', value, output: DOT_LITERAL });
+        continue;
+      }
+
+      /**
+       * Question marks
+       */
+
+      if (value === '?') {
+        const isGroup = prev && prev.value === '(';
+        if (!isGroup && opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('qmark', value);
+          continue;
+        }
+
+        if (prev && prev.type === 'paren') {
+          const next = peek();
+          let output = value;
+
+          if (next === '<' && !utils$1.supportsLookbehinds()) {
+            throw new Error('Node.js v10 or higher is required for regex lookbehinds');
+          }
+
+          if ((prev.value === '(' && !/[!=<:]/.test(next)) || (next === '<' && !/<([!=]|\w+>)/.test(remaining()))) {
+            output = `\\${value}`;
+          }
+
+          push({ type: 'text', value, output });
+          continue;
+        }
+
+        if (opts.dot !== true && (prev.type === 'slash' || prev.type === 'bos')) {
+          push({ type: 'qmark', value, output: QMARK_NO_DOT });
+          continue;
+        }
+
+        push({ type: 'qmark', value, output: QMARK });
+        continue;
+      }
+
+      /**
+       * Exclamation
+       */
+
+      if (value === '!') {
+        if (opts.noextglob !== true && peek() === '(') {
+          if (peek(2) !== '?' || !/[!=<:]/.test(peek(3))) {
+            extglobOpen('negate', value);
+            continue;
+          }
+        }
+
+        if (opts.nonegate !== true && state.index === 0) {
+          negate();
+          continue;
+        }
+      }
+
+      /**
+       * Plus
+       */
+
+      if (value === '+') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          extglobOpen('plus', value);
+          continue;
+        }
+
+        if ((prev && prev.value === '(') || opts.regex === false) {
+          push({ type: 'plus', value, output: PLUS_LITERAL });
+          continue;
+        }
+
+        if ((prev && (prev.type === 'bracket' || prev.type === 'paren' || prev.type === 'brace')) || state.parens > 0) {
+          push({ type: 'plus', value });
+          continue;
+        }
+
+        push({ type: 'plus', value: PLUS_LITERAL });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value === '@') {
+        if (opts.noextglob !== true && peek() === '(' && peek(2) !== '?') {
+          push({ type: 'at', extglob: true, value, output: '' });
+          continue;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Plain text
+       */
+
+      if (value !== '*') {
+        if (value === '$' || value === '^') {
+          value = `\\${value}`;
+        }
+
+        const match = REGEX_NON_SPECIAL_CHARS.exec(remaining());
+        if (match) {
+          value += match[0];
+          state.index += match[0].length;
+        }
+
+        push({ type: 'text', value });
+        continue;
+      }
+
+      /**
+       * Stars
+       */
+
+      if (prev && (prev.type === 'globstar' || prev.star === true)) {
+        prev.type = 'star';
+        prev.star = true;
+        prev.value += value;
+        prev.output = star;
+        state.backtrack = true;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      let rest = remaining();
+      if (opts.noextglob !== true && /^\([^?]/.test(rest)) {
+        extglobOpen('star', value);
+        continue;
+      }
+
+      if (prev.type === 'star') {
+        if (opts.noglobstar === true) {
+          consume(value);
+          continue;
+        }
+
+        const prior = prev.prev;
+        const before = prior.prev;
+        const isStart = prior.type === 'slash' || prior.type === 'bos';
+        const afterStar = before && (before.type === 'star' || before.type === 'globstar');
+
+        if (opts.bash === true && (!isStart || (rest[0] && rest[0] !== '/'))) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        const isBrace = state.braces > 0 && (prior.type === 'comma' || prior.type === 'brace');
+        const isExtglob = extglobs.length && (prior.type === 'pipe' || prior.type === 'paren');
+        if (!isStart && prior.type !== 'paren' && !isBrace && !isExtglob) {
+          push({ type: 'star', value, output: '' });
+          continue;
+        }
+
+        // strip consecutive `/**/`
+        while (rest.slice(0, 3) === '/**') {
+          const after = input[state.index + 4];
+          if (after && after !== '/') {
+            break;
+          }
+          rest = rest.slice(3);
+          consume('/**', 3);
+        }
+
+        if (prior.type === 'bos' && eos()) {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = globstar(opts);
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && !afterStar && eos()) {
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = globstar(opts) + (opts.strictSlashes ? ')' : '|$)');
+          prev.value += value;
+          state.globstar = true;
+          state.output += prior.output + prev.output;
+          consume(value);
+          continue;
+        }
+
+        if (prior.type === 'slash' && prior.prev.type !== 'bos' && rest[0] === '/') {
+          const end = rest[1] !== void 0 ? '|$' : '';
+
+          state.output = state.output.slice(0, -(prior.output + prev.output).length);
+          prior.output = `(?:${prior.output}`;
+
+          prev.type = 'globstar';
+          prev.output = `${globstar(opts)}${SLASH_LITERAL}|${SLASH_LITERAL}${end})`;
+          prev.value += value;
+
+          state.output += prior.output + prev.output;
+          state.globstar = true;
+
+          consume(value + advance());
+
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        if (prior.type === 'bos' && rest[0] === '/') {
+          prev.type = 'globstar';
+          prev.value += value;
+          prev.output = `(?:^|${SLASH_LITERAL}|${globstar(opts)}${SLASH_LITERAL})`;
+          state.output = prev.output;
+          state.globstar = true;
+          consume(value + advance());
+          push({ type: 'slash', value: '/', output: '' });
+          continue;
+        }
+
+        // remove single star from output
+        state.output = state.output.slice(0, -prev.output.length);
+
+        // reset previous token to globstar
+        prev.type = 'globstar';
+        prev.output = globstar(opts);
+        prev.value += value;
+
+        // reset output with globstar
+        state.output += prev.output;
+        state.globstar = true;
+        consume(value);
+        continue;
+      }
+
+      const token = { type: 'star', value, output: star };
+
+      if (opts.bash === true) {
+        token.output = '.*?';
+        if (prev.type === 'bos' || prev.type === 'slash') {
+          token.output = nodot + token.output;
+        }
+        push(token);
+        continue;
+      }
+
+      if (prev && (prev.type === 'bracket' || prev.type === 'paren') && opts.regex === true) {
+        token.output = value;
+        push(token);
+        continue;
+      }
+
+      if (state.index === state.start || prev.type === 'slash' || prev.type === 'dot') {
+        if (prev.type === 'dot') {
+          state.output += NO_DOT_SLASH;
+          prev.output += NO_DOT_SLASH;
+
+        } else if (opts.dot === true) {
+          state.output += NO_DOTS_SLASH;
+          prev.output += NO_DOTS_SLASH;
+
+        } else {
+          state.output += nodot;
+          prev.output += nodot;
+        }
+
+        if (peek() !== '*') {
+          state.output += ONE_CHAR;
+          prev.output += ONE_CHAR;
+        }
+      }
+
+      push(token);
+    }
+
+    while (state.brackets > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ']'));
+      state.output = utils$1.escapeLast(state.output, '[');
+      decrement('brackets');
+    }
+
+    while (state.parens > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', ')'));
+      state.output = utils$1.escapeLast(state.output, '(');
+      decrement('parens');
+    }
+
+    while (state.braces > 0) {
+      if (opts.strictBrackets === true) throw new SyntaxError(syntaxError('closing', '}'));
+      state.output = utils$1.escapeLast(state.output, '{');
+      decrement('braces');
+    }
+
+    if (opts.strictSlashes !== true && (prev.type === 'star' || prev.type === 'bracket')) {
+      push({ type: 'maybe_slash', value: '', output: `${SLASH_LITERAL}?` });
+    }
+
+    // rebuild the output if we had to backtrack at any point
+    if (state.backtrack === true) {
+      state.output = '';
+
+      for (const token of state.tokens) {
+        state.output += token.output != null ? token.output : token.value;
+
+        if (token.suffix) {
+          state.output += token.suffix;
+        }
+      }
+    }
+
+    return state;
+  };
+
+  /**
+   * Fast paths for creating regular expressions for common glob patterns.
+   * This can significantly speed up processing and has very little downside
+   * impact when none of the fast paths match.
+   */
+
+  parse$2.fastpaths = (input, options) => {
+    const opts = { ...options };
+    const max = typeof opts.maxLength === 'number' ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
+    const len = input.length;
+    if (len > max) {
+      throw new SyntaxError(`Input length: ${len}, exceeds maximum allowed length: ${max}`);
+    }
+
+    input = REPLACEMENTS[input] || input;
+
+    // create constants based on platform, for windows or posix
+    const {
+      DOT_LITERAL,
+      SLASH_LITERAL,
+      ONE_CHAR,
+      DOTS_SLASH,
+      NO_DOT,
+      NO_DOTS,
+      NO_DOTS_SLASH,
+      STAR,
+      START_ANCHOR
+    } = constants$2.globChars(opts.windows);
+
+    const nodot = opts.dot ? NO_DOTS : NO_DOT;
+    const slashDot = opts.dot ? NO_DOTS_SLASH : NO_DOT;
+    const capture = opts.capture ? '' : '?:';
+    const state = { negated: false, prefix: '' };
+    let star = opts.bash === true ? '.*?' : STAR;
+
+    if (opts.capture) {
+      star = `(${star})`;
+    }
+
+    const globstar = (opts) => {
+      if (opts.noglobstar === true) return star;
+      return `(${capture}(?:(?!${START_ANCHOR}${opts.dot ? DOTS_SLASH : DOT_LITERAL}).)*?)`;
+    };
+
+    const create = str => {
+      switch (str) {
+        case '*':
+          return `${nodot}${ONE_CHAR}${star}`;
+
+        case '.*':
+          return `${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*.*':
+          return `${nodot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '*/*':
+          return `${nodot}${star}${SLASH_LITERAL}${ONE_CHAR}${slashDot}${star}`;
+
+        case '**':
+          return nodot + globstar(opts);
+
+        case '**/*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${ONE_CHAR}${star}`;
+
+        case '**/*.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${slashDot}${star}${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        case '**/.*':
+          return `(?:${nodot}${globstar(opts)}${SLASH_LITERAL})?${DOT_LITERAL}${ONE_CHAR}${star}`;
+
+        default: {
+          const match = /^(.*?)\.(\w+)$/.exec(str);
+          if (!match) return;
+
+          const source = create(match[1]);
+          if (!source) return;
+
+          return source + DOT_LITERAL + match[2];
+        }
+      }
+    };
+
+    const output = utils$1.removePrefix(input, state);
+    let source = create(output);
+
+    if (source && opts.strictSlashes !== true) {
+      source += `${SLASH_LITERAL}?`;
+    }
+
+    return source;
+  };
+
+  var parse_1 = parse$2;
+
+  const scan = scan_1;
+  const parse$1 = parse_1;
+  const utils = utils$3;
+  const constants$1 = constants$3;
+  const isObject = val => val && typeof val === 'object' && !Array.isArray(val);
+
+  /**
+   * Creates a matcher function from one or more glob patterns. The
+   * returned function takes a string to match as its first argument,
+   * and returns true if the string is a match. The returned matcher
+   * function also takes a boolean as the second argument that, when true,
+   * returns an object with additional information.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch(glob[, options]);
+   *
+   * const isMatch = picomatch('*.!(*a)');
+   * console.log(isMatch('a.a')); //=> false
+   * console.log(isMatch('a.b')); //=> true
+   * ```
+   * @name picomatch
+   * @param {String|Array} `globs` One or more glob patterns.
+   * @param {Object=} `options`
+   * @return {Function=} Returns a matcher function.
+   * @api public
+   */
+
+  const picomatch = (glob, options, returnState = false) => {
+    if (Array.isArray(glob)) {
+      const fns = glob.map(input => picomatch(input, options, returnState));
+      const arrayMatcher = str => {
+        for (const isMatch of fns) {
+          const state = isMatch(str);
+          if (state) return state;
+        }
+        return false;
+      };
+      return arrayMatcher;
+    }
+
+    const isState = isObject(glob) && glob.tokens && glob.input;
+
+    if (glob === '' || (typeof glob !== 'string' && !isState)) {
+      throw new TypeError('Expected pattern to be a non-empty string');
+    }
+
+    const opts = options || {};
+    const posix = opts.windows;
+    const regex = isState
+      ? picomatch.compileRe(glob, options)
+      : picomatch.makeRe(glob, options, false, true);
+
+    const state = regex.state;
+    delete regex.state;
+
+    let isIgnored = () => false;
+    if (opts.ignore) {
+      const ignoreOpts = { ...options, ignore: null, onMatch: null, onResult: null };
+      isIgnored = picomatch(opts.ignore, ignoreOpts, returnState);
+    }
+
+    const matcher = (input, returnObject = false) => {
+      const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+      const result = { glob, state, regex, posix, input, output, match, isMatch };
+
+      if (typeof opts.onResult === 'function') {
+        opts.onResult(result);
+      }
+
+      if (isMatch === false) {
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (isIgnored(input)) {
+        if (typeof opts.onIgnore === 'function') {
+          opts.onIgnore(result);
+        }
+        result.isMatch = false;
+        return returnObject ? result : false;
+      }
+
+      if (typeof opts.onMatch === 'function') {
+        opts.onMatch(result);
+      }
+      return returnObject ? result : true;
+    };
+
+    if (returnState) {
+      matcher.state = state;
+    }
+
+    return matcher;
+  };
+
+  /**
+   * Test `input` with the given `regex`. This is used by the main
+   * `picomatch()` function to test the input string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.test(input, regex[, options]);
+   *
+   * console.log(picomatch.test('foo/bar', /^(?:([^/]*?)\/([^/]*?))$/));
+   * // { isMatch: true, match: [ 'foo/', 'foo', 'bar' ], output: 'foo/bar' }
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp} `regex`
+   * @return {Object} Returns an object with matching info.
+   * @api public
+   */
+
+  picomatch.test = (input, regex, options, { glob, posix } = {}) => {
+    if (typeof input !== 'string') {
+      throw new TypeError('Expected input to be a string');
+    }
+
+    if (input === '') {
+      return { isMatch: false, output: '' };
+    }
+
+    const opts = options || {};
+    const format = opts.format || (posix ? utils.toPosixSlashes : null);
+    let match = input === glob;
+    let output = (match && format) ? format(input) : input;
+
+    if (match === false) {
+      output = format ? format(input) : input;
+      match = output === glob;
+    }
+
+    if (match === false || opts.capture === true) {
+      if (opts.matchBase === true || opts.basename === true) {
+        match = picomatch.matchBase(input, regex, options, posix);
+      } else {
+        match = regex.exec(output);
+      }
+    }
+
+    return { isMatch: Boolean(match), match, output };
+  };
+
+  /**
+   * Match the basename of a filepath.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.matchBase(input, glob[, options]);
+   * console.log(picomatch.matchBase('foo/bar.js', '*.js'); // true
+   * ```
+   * @param {String} `input` String to test.
+   * @param {RegExp|String} `glob` Glob pattern or regex created by [.makeRe](#makeRe).
+   * @return {Boolean}
+   * @api public
+   */
+
+  picomatch.matchBase = (input, glob, options) => {
+    const regex = glob instanceof RegExp ? glob : picomatch.makeRe(glob, options);
+    return regex.test(utils.basename(input));
+  };
+
+  /**
+   * Returns true if **any** of the given glob `patterns` match the specified `string`.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.isMatch(string, patterns[, options]);
+   *
+   * console.log(picomatch.isMatch('a.a', ['b.*', '*.a'])); //=> true
+   * console.log(picomatch.isMatch('a.a', 'b.*')); //=> false
+   * ```
+   * @param {String|Array} str The string to test.
+   * @param {String|Array} patterns One or more glob patterns to use for matching.
+   * @param {Object} [options] See available [options](#options).
+   * @return {Boolean} Returns true if any patterns match `str`
+   * @api public
+   */
+
+  picomatch.isMatch = (str, patterns, options) => picomatch(patterns, options)(str);
+
+  /**
+   * Parse a glob pattern to create the source string for a regular
+   * expression.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const result = picomatch.parse(pattern[, options]);
+   * ```
+   * @param {String} `pattern`
+   * @param {Object} `options`
+   * @return {Object} Returns an object with useful properties and output to be used as a regex source string.
+   * @api public
+   */
+
+  picomatch.parse = (pattern, options) => {
+    if (Array.isArray(pattern)) return pattern.map(p => picomatch.parse(p, options));
+    return parse$1(pattern, { ...options, fastpaths: false });
+  };
+
+  /**
+   * Scan a glob pattern to separate the pattern into segments.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.scan(input[, options]);
+   *
+   * const result = picomatch.scan('!./foo/*.js');
+   * console.log(result);
+   * { prefix: '!./',
+   *   input: '!./foo/*.js',
+   *   start: 3,
+   *   base: 'foo',
+   *   glob: '*.js',
+   *   isBrace: false,
+   *   isBracket: false,
+   *   isGlob: true,
+   *   isExtglob: false,
+   *   isGlobstar: false,
+   *   negated: true }
+   * ```
+   * @param {String} `input` Glob pattern to scan.
+   * @param {Object} `options`
+   * @return {Object} Returns an object with
+   * @api public
+   */
+
+  picomatch.scan = (input, options) => scan(input, options);
+
+  /**
+   * Create a regular expression from a parsed glob pattern.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * const state = picomatch.parse('*.js');
+   * // picomatch.compileRe(state[, options]);
+   *
+   * console.log(picomatch.compileRe(state));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `state` The object returned from the `.parse` method.
+   * @param {Object} `options`
+   * @return {RegExp} Returns a regex created from the given pattern.
+   * @api public
+   */
+
+  picomatch.compileRe = (parsed, options, returnOutput = false, returnState = false) => {
+    if (returnOutput === true) {
+      return parsed.output;
+    }
+
+    const opts = options || {};
+    const prepend = opts.contains ? '' : '^';
+    const append = opts.contains ? '' : '$';
+
+    let source = `${prepend}(?:${parsed.output})${append}`;
+    if (parsed && parsed.negated === true) {
+      source = `^(?!${source}).*$`;
+    }
+
+    const regex = picomatch.toRegex(source, options);
+    if (returnState === true) {
+      regex.state = parsed;
+    }
+
+    return regex;
+  };
+
+  picomatch.makeRe = (input, options, returnOutput = false, returnState = false) => {
+    if (!input || typeof input !== 'string') {
+      throw new TypeError('Expected a non-empty string');
+    }
+
+    const opts = options || {};
+    let parsed = { negated: false, fastpaths: true };
+    let prefix = '';
+    let output;
+
+    if (input.startsWith('./')) {
+      input = input.slice(2);
+      prefix = parsed.prefix = './';
+    }
+
+    if (opts.fastpaths !== false && (input[0] === '.' || input[0] === '*')) {
+      output = parse$1.fastpaths(input, options);
+    }
+
+    if (output === undefined) {
+      parsed = parse$1(input, options);
+      parsed.prefix = prefix + (parsed.prefix || '');
+    } else {
+      parsed.output = output;
+    }
+
+    return picomatch.compileRe(parsed, options, returnOutput, returnState);
+  };
+
+  /**
+   * Create a regular expression from the given regex source string.
+   *
+   * ```js
+   * const picomatch = require('picomatch');
+   * // picomatch.toRegex(source[, options]);
+   *
+   * const { output } = picomatch.parse('*.js');
+   * console.log(picomatch.toRegex(output));
+   * //=> /^(?:(?!\.)(?=.)[^/]*?\.js)$/
+   * ```
+   * @param {String} `source` Regular expression source string.
+   * @param {Object} `options`
+   * @return {RegExp}
+   * @api public
+   */
+
+  picomatch.toRegex = (source, options) => {
+    try {
+      const opts = options || {};
+      return new RegExp(source, opts.flags || (opts.nocase ? 'i' : ''));
+    } catch (err) {
+      if (options && options.debug === true) throw err;
+      return /$^/;
+    }
+  };
+
+  /**
+   * Picomatch constants.
+   * @return {Object}
+   */
+
+  picomatch.constants = constants$1;
+
+  /**
+   * Expose "picomatch"
+   */
+
+  var picomatch_1 = picomatch;
+
+  var picomatchBrowser = picomatch_1;
+
+  var pm = /*@__PURE__*/getDefaultExportFromCjs(picomatchBrowser);
+
+  function isArray(arg) {
+      return Array.isArray(arg);
+  }
+  function ensureArray(thing) {
+      if (isArray(thing))
+          return thing;
+      if (thing == null)
+          return [];
+      return [thing];
+  }
+  const globToTest = (glob) => {
+      const pattern = glob;
+      const fn = pm(pattern, { dot: true });
+      return {
+          test: (what) => {
+              const result = fn(what);
+              return result;
+          },
+      };
+  };
+  const testTrue = {
+      test: () => true,
+  };
+  const getMatcher = (filter) => {
+      const bundleTest = "bundle" in filter && filter.bundle != null ? globToTest(filter.bundle) : testTrue;
+      const fileTest = "file" in filter && filter.file != null ? globToTest(filter.file) : testTrue;
+      return { bundleTest, fileTest };
+  };
+  const createFilter = (include, exclude) => {
+      const includeMatchers = ensureArray(include).map(getMatcher);
+      const excludeMatchers = ensureArray(exclude).map(getMatcher);
+      return (bundleId, id) => {
+          for (let i = 0; i < excludeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = excludeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return false;
+          }
+          for (let i = 0; i < includeMatchers.length; ++i) {
+              const { bundleTest, fileTest } = includeMatchers[i];
+              if (bundleTest.test(bundleId) && fileTest.test(id))
+                  return true;
+          }
+          return !includeMatchers.length;
+      };
+  };
+
+  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      return (val) => {
+          if (!waiting) {
+              callback(val);
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+              }, limit);
+          }
+      };
+  };
+  const prepareFilter = (filt) => {
+      if (filt === "")
+          return [];
+      return (filt
+          .split(",")
+          // remove spaces before and after
+          .map((entry) => entry.trim())
+          // unquote "
+          .map((entry) => entry.startsWith('"') && entry.endsWith('"') ? entry.substring(1, entry.length - 1) : entry)
+          // unquote '
+          .map((entry) => entry.startsWith("'") && entry.endsWith("'") ? entry.substring(1, entry.length - 1) : entry)
+          // remove empty strings
+          .filter((entry) => entry)
+          // parse bundle:file
+          .map((entry) => entry.split(":"))
+          // normalize entry just in case
+          .flatMap((entry) => {
+          if (entry.length === 0)
+              return [];
+          let bundle = null;
+          let file = null;
+          if (entry.length === 1 && entry[0]) {
+              file = entry[0];
+              return [{ file, bundle }];
+          }
+          bundle = entry[0] || null;
+          file = entry.slice(1).join(":") || null;
+          return [{ bundle, file }];
+      }));
+  };
+  const useFilter = () => {
+      const [includeFilter, setIncludeFilter] = h("");
+      const [excludeFilter, setExcludeFilter] = h("");
+      const setIncludeFilterTrottled = F(() => throttleFilter(setIncludeFilter, 200), []);
+      const setExcludeFilterTrottled = F(() => throttleFilter(setExcludeFilter, 200), []);
+      const isIncluded = F(() => createFilter(prepareFilter(includeFilter), prepareFilter(excludeFilter)), [includeFilter, excludeFilter]);
+      const getModuleFilterMultiplier = T((bundleId, data) => {
+          return isIncluded(bundleId, data.id) ? 1 : 0;
+      }, [isIncluded]);
+      return {
+          getModuleFilterMultiplier,
+          includeFilter,
+          excludeFilter,
+          setExcludeFilter: setExcludeFilterTrottled,
+          setIncludeFilter: setIncludeFilterTrottled,
+      };
+  };
+
+  function ascending(a, b) {
+    return a == null || b == null ? NaN : a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
+  }
+
+  function descending(a, b) {
+    return a == null || b == null ? NaN
+      : b < a ? -1
+      : b > a ? 1
+      : b >= a ? 0
+      : NaN;
+  }
+
+  function bisector(f) {
+    let compare1, compare2, delta;
+
+    // If an accessor is specified, promote it to a comparator. In this case we
+    // can test whether the search value is (self-) comparable. We can’t do this
+    // for a comparator (except for specific, known comparators) because we can’t
+    // tell if the comparator is symmetric, and an asymmetric comparator can’t be
+    // used to test whether a single value is comparable.
+    if (f.length !== 2) {
+      compare1 = ascending;
+      compare2 = (d, x) => ascending(f(d), x);
+      delta = (d, x) => f(d) - x;
+    } else {
+      compare1 = f === ascending || f === descending ? f : zero$1;
+      compare2 = f;
+      delta = f;
+    }
+
+    function left(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) < 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function right(a, x, lo = 0, hi = a.length) {
+      if (lo < hi) {
+        if (compare1(x, x) !== 0) return hi;
+        do {
+          const mid = (lo + hi) >>> 1;
+          if (compare2(a[mid], x) <= 0) lo = mid + 1;
+          else hi = mid;
+        } while (lo < hi);
+      }
+      return lo;
+    }
+
+    function center(a, x, lo = 0, hi = a.length) {
+      const i = left(a, x, lo, hi - 1);
+      return i > lo && delta(a[i - 1], x) > -delta(a[i], x) ? i - 1 : i;
+    }
+
+    return {left, center, right};
+  }
+
+  function zero$1() {
+    return 0;
+  }
+
+  function number$1(x) {
+    return x === null ? NaN : +x;
+  }
+
+  const ascendingBisect = bisector(ascending);
+  const bisectRight = ascendingBisect.right;
+  bisector(number$1).center;
+  var bisect = bisectRight;
+
+  class InternMap extends Map {
+    constructor(entries, key = keyof) {
+      super();
+      Object.defineProperties(this, {_intern: {value: new Map()}, _key: {value: key}});
+      if (entries != null) for (const [key, value] of entries) this.set(key, value);
+    }
+    get(key) {
+      return super.get(intern_get(this, key));
+    }
+    has(key) {
+      return super.has(intern_get(this, key));
+    }
+    set(key, value) {
+      return super.set(intern_set(this, key), value);
+    }
+    delete(key) {
+      return super.delete(intern_delete(this, key));
+    }
+  }
+
+  function intern_get({_intern, _key}, value) {
+    const key = _key(value);
+    return _intern.has(key) ? _intern.get(key) : value;
+  }
+
+  function intern_set({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) return _intern.get(key);
+    _intern.set(key, value);
+    return value;
+  }
+
+  function intern_delete({_intern, _key}, value) {
+    const key = _key(value);
+    if (_intern.has(key)) {
+      value = _intern.get(key);
+      _intern.delete(key);
+    }
+    return value;
+  }
+
+  function keyof(value) {
+    return value !== null && typeof value === "object" ? value.valueOf() : value;
+  }
+
+  function identity$2(x) {
+    return x;
+  }
+
+  function group(values, ...keys) {
+    return nest(values, identity$2, identity$2, keys);
+  }
+
+  function nest(values, map, reduce, keys) {
+    return (function regroup(values, i) {
+      if (i >= keys.length) return reduce(values);
+      const groups = new InternMap();
+      const keyof = keys[i++];
+      let index = -1;
+      for (const value of values) {
+        const key = keyof(value, ++index, values);
+        const group = groups.get(key);
+        if (group) group.push(value);
+        else groups.set(key, [value]);
+      }
+      for (const [key, values] of groups) {
+        groups.set(key, regroup(values, i));
+      }
+      return map(groups);
+    })(values, 0);
+  }
+
+  const e10 = Math.sqrt(50),
+      e5 = Math.sqrt(10),
+      e2 = Math.sqrt(2);
+
+  function tickSpec(start, stop, count) {
+    const step = (stop - start) / Math.max(0, count),
+        power = Math.floor(Math.log10(step)),
+        error = step / Math.pow(10, power),
+        factor = error >= e10 ? 10 : error >= e5 ? 5 : error >= e2 ? 2 : 1;
+    let i1, i2, inc;
+    if (power < 0) {
+      inc = Math.pow(10, -power) / factor;
+      i1 = Math.round(start * inc);
+      i2 = Math.round(stop * inc);
+      if (i1 / inc < start) ++i1;
+      if (i2 / inc > stop) --i2;
+      inc = -inc;
+    } else {
+      inc = Math.pow(10, power) * factor;
+      i1 = Math.round(start / inc);
+      i2 = Math.round(stop / inc);
+      if (i1 * inc < start) ++i1;
+      if (i2 * inc > stop) --i2;
+    }
+    if (i2 < i1 && 0.5 <= count && count < 2) return tickSpec(start, stop, count * 2);
+    return [i1, i2, inc];
+  }
+
+  function ticks(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    if (!(count > 0)) return [];
+    if (start === stop) return [start];
+    const reverse = stop < start, [i1, i2, inc] = reverse ? tickSpec(stop, start, count) : tickSpec(start, stop, count);
+    if (!(i2 >= i1)) return [];
+    const n = i2 - i1 + 1, ticks = new Array(n);
+    if (reverse) {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i2 - i) * inc;
+    } else {
+      if (inc < 0) for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) / -inc;
+      else for (let i = 0; i < n; ++i) ticks[i] = (i1 + i) * inc;
+    }
+    return ticks;
+  }
+
+  function tickIncrement(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    return tickSpec(start, stop, count)[2];
+  }
+
+  function tickStep(start, stop, count) {
+    stop = +stop, start = +start, count = +count;
+    const reverse = stop < start, inc = reverse ? tickIncrement(stop, start, count) : tickIncrement(start, stop, count);
+    return (reverse ? -1 : 1) * (inc < 0 ? 1 / -inc : inc);
+  }
+
+  const TOP_PADDING = 20;
+  const PADDING = 2;
+
+  const Node = ({ node, onMouseOver, onClick, selected }) => {
+      const { getModuleColor } = q(StaticContext);
+      const { backgroundColor, fontColor } = getModuleColor(node);
+      const { x0, x1, y1, y0, data, children = null } = node;
+      const textRef = _(null);
+      const textRectRef = _();
+      const width = x1 - x0;
+      const height = y1 - y0;
+      const textProps = {
+          "font-size": "0.7em",
+          "dominant-baseline": "middle",
+          "text-anchor": "middle",
+          x: width / 2,
+      };
+      if (children != null) {
+          textProps.y = (TOP_PADDING + PADDING) / 2;
+      }
+      else {
+          textProps.y = height / 2;
+      }
+      y(() => {
+          if (width == 0 || height == 0 || !textRef.current) {
+              return;
+          }
+          if (textRectRef.current == null) {
+              textRectRef.current = textRef.current.getBoundingClientRect();
+          }
+          let scale = 1;
+          if (children != null) {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, Math.min(height, TOP_PADDING + PADDING) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(Math.min(TOP_PADDING + PADDING, height) / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          else {
+              scale = Math.min((width * 0.9) / textRectRef.current.width, (height * 0.9) / textRectRef.current.height);
+              scale = Math.min(1, scale);
+              textRef.current.setAttribute("y", String(height / 2 / scale));
+              textRef.current.setAttribute("x", String(width / 2 / scale));
+          }
+          textRef.current.setAttribute("transform", `scale(${scale.toFixed(2)})`);
+      }, [children, height, width]);
+      if (width == 0 || height == 0) {
+          return null;
+      }
+      return (o$1("g", { className: "node", transform: `translate(${x0},${y0})`, onClick: (event) => {
+              event.stopPropagation();
+              onClick(node);
+          }, onMouseOver: (event) => {
+              event.stopPropagation();
+              onMouseOver(node);
+          }, children: [o$1("rect", { fill: backgroundColor, rx: 2, ry: 2, width: x1 - x0, height: y1 - y0, stroke: selected ? "#fff" : undefined, "stroke-width": selected ? 2 : undefined }), o$1("text", Object.assign({ ref: textRef, fill: fontColor, onClick: (event) => {
+                      var _a;
+                      if (((_a = window.getSelection()) === null || _a === void 0 ? void 0 : _a.toString()) !== "") {
+                          event.stopPropagation();
+                      }
+                  } }, textProps, { children: data.name }))] }));
+  };
+
+  const TreeMap = ({ root, onNodeHover, selectedNode, onNodeClick, }) => {
+      const { width, height, getModuleIds } = q(StaticContext);
+      console.time("layering");
+      // this will make groups by height
+      const nestedData = F(() => {
+          const nestedDataMap = group(root.descendants(), (d) => d.height);
+          const nestedData = Array.from(nestedDataMap, ([key, values]) => ({
+              key,
+              values,
+          }));
+          nestedData.sort((a, b) => b.key - a.key);
+          return nestedData;
+      }, [root]);
+      console.timeEnd("layering");
+      return (o$1("svg", { xmlns: "http://www.w3.org/2000/svg", viewBox: `0 0 ${width} ${height}`, children: nestedData.map(({ key, values }) => {
+              return (o$1("g", { className: "layer", children: values.map((node) => {
+                      return (o$1(Node, { node: node, onMouseOver: onNodeHover, selected: selectedNode === node, onClick: onNodeClick }, getModuleIds(node.data).nodeUid.id));
+                  }) }, key));
+          }) }));
+  };
+
+  var bytes$1 = {exports: {}};
+
+  /*!
+   * bytes
+   * Copyright(c) 2012-2014 TJ Holowaychuk
+   * Copyright(c) 2015 Jed Watson
+   * MIT Licensed
+   */
+
+  /**
+   * Module exports.
+   * @public
+   */
+
+  bytes$1.exports = bytes;
+  var format_1 = bytes$1.exports.format = format$1;
+  bytes$1.exports.parse = parse;
+
+  /**
+   * Module variables.
+   * @private
+   */
+
+  var formatThousandsRegExp = /\B(?=(\d{3})+(?!\d))/g;
+
+  var formatDecimalsRegExp = /(?:\.0*|(\.[^0]+)0+)$/;
+
+  var map$1 = {
+    b:  1,
+    kb: 1 << 10,
+    mb: 1 << 20,
+    gb: 1 << 30,
+    tb: Math.pow(1024, 4),
+    pb: Math.pow(1024, 5),
+  };
+
+  var parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
+
+  /**
+   * Convert the given value in bytes into a string or parse to string to an integer in bytes.
+   *
+   * @param {string|number} value
+   * @param {{
+   *  case: [string],
+   *  decimalPlaces: [number]
+   *  fixedDecimals: [boolean]
+   *  thousandsSeparator: [string]
+   *  unitSeparator: [string]
+   *  }} [options] bytes options.
+   *
+   * @returns {string|number|null}
+   */
+
+  function bytes(value, options) {
+    if (typeof value === 'string') {
+      return parse(value);
+    }
+
+    if (typeof value === 'number') {
+      return format$1(value, options);
+    }
+
+    return null;
+  }
+
+  /**
+   * Format the given value in bytes into a string.
+   *
+   * If the value is negative, it is kept as such. If it is a float,
+   * it is rounded.
+   *
+   * @param {number} value
+   * @param {object} [options]
+   * @param {number} [options.decimalPlaces=2]
+   * @param {number} [options.fixedDecimals=false]
+   * @param {string} [options.thousandsSeparator=]
+   * @param {string} [options.unit=]
+   * @param {string} [options.unitSeparator=]
+   *
+   * @returns {string|null}
+   * @public
+   */
+
+  function format$1(value, options) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    var mag = Math.abs(value);
+    var thousandsSeparator = (options && options.thousandsSeparator) || '';
+    var unitSeparator = (options && options.unitSeparator) || '';
+    var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
+    var fixedDecimals = Boolean(options && options.fixedDecimals);
+    var unit = (options && options.unit) || '';
+
+    if (!unit || !map$1[unit.toLowerCase()]) {
+      if (mag >= map$1.pb) {
+        unit = 'PB';
+      } else if (mag >= map$1.tb) {
+        unit = 'TB';
+      } else if (mag >= map$1.gb) {
+        unit = 'GB';
+      } else if (mag >= map$1.mb) {
+        unit = 'MB';
+      } else if (mag >= map$1.kb) {
+        unit = 'KB';
+      } else {
+        unit = 'B';
+      }
+    }
+
+    var val = value / map$1[unit.toLowerCase()];
+    var str = val.toFixed(decimalPlaces);
+
+    if (!fixedDecimals) {
+      str = str.replace(formatDecimalsRegExp, '$1');
+    }
+
+    if (thousandsSeparator) {
+      str = str.split('.').map(function (s, i) {
+        return i === 0
+          ? s.replace(formatThousandsRegExp, thousandsSeparator)
+          : s
+      }).join('.');
+    }
+
+    return str + unitSeparator + unit;
+  }
+
+  /**
+   * Parse the string value into an integer in bytes.
+   *
+   * If no unit is given, it is assumed the value is in bytes.
+   *
+   * @param {number|string} val
+   *
+   * @returns {number|null}
+   * @public
+   */
+
+  function parse(val) {
+    if (typeof val === 'number' && !isNaN(val)) {
+      return val;
+    }
+
+    if (typeof val !== 'string') {
+      return null;
+    }
+
+    // Test if the string passed is valid
+    var results = parseRegExp.exec(val);
+    var floatValue;
+    var unit = 'b';
+
+    if (!results) {
+      // Nothing could be extracted from the given string
+      floatValue = parseInt(val, 10);
+      unit = 'b';
+    } else {
+      // Retrieve the value and the unit
+      floatValue = parseFloat(results[1]);
+      unit = results[4].toLowerCase();
+    }
+
+    if (isNaN(floatValue)) {
+      return null;
+    }
+
+    return Math.floor(map$1[unit] * floatValue);
+  }
+
+  const Tooltip_marginX = 10;
+  const Tooltip_marginY = 30;
+  const SOURCEMAP_RENDERED = (o$1("span", { children: [" ", o$1("b", { children: LABELS.renderedLength }), " is a number of characters in the file after individual and ", o$1("br", {}), " ", "whole bundle transformations according to sourcemap."] }));
+  const RENDRED = (o$1("span", { children: [o$1("b", { children: LABELS.renderedLength }), " is a byte size of individual file after transformations and treeshake."] }));
+  const COMPRESSED = (o$1("span", { children: [o$1("b", { children: LABELS.gzipLength }), " and ", o$1("b", { children: LABELS.brotliLength }), " is a byte size of individual file after individual transformations,", o$1("br", {}), " treeshake and compression."] }));
+  const Tooltip = ({ node, visible, root, sizeProperty, }) => {
+      const { availableSizeProperties, getModuleSize, data } = q(StaticContext);
+      const ref = _(null);
+      const [style, setStyle] = h({});
+      const content = F(() => {
+          if (!node)
+              return null;
+          const mainSize = getModuleSize(node.data, sizeProperty);
+          const percentageNum = (100 * mainSize) / getModuleSize(root.data, sizeProperty);
+          const percentage = percentageNum.toFixed(2);
+          const percentageString = percentage + "%";
+          const path = node
+              .ancestors()
+              .reverse()
+              .map((d) => d.data.name)
+              .join("/");
+          let dataNode = null;
+          if (!isModuleTree(node.data)) {
+              const mainUid = data.nodeParts[node.data.uid].metaUid;
+              dataNode = data.nodeMetas[mainUid];
+          }
+          return (o$1(k$1, { children: [o$1("div", { children: path }), availableSizeProperties.map((sizeProp) => {
+                      if (sizeProp === sizeProperty) {
+                          return (o$1("div", { children: [o$1("b", { children: [LABELS[sizeProp], ": ", format_1(mainSize)] }), " ", "(", percentageString, ")"] }, sizeProp));
+                      }
+                      else {
+                          return (o$1("div", { children: [LABELS[sizeProp], ": ", format_1(getModuleSize(node.data, sizeProp))] }, sizeProp));
+                      }
+                  }), o$1("br", {}), dataNode && dataNode.importedBy.length > 0 && (o$1("div", { children: [o$1("div", { children: [o$1("b", { children: "Imported By" }), ":"] }), dataNode.importedBy.map(({ uid }) => {
+                              const id = data.nodeMetas[uid].id;
+                              return o$1("div", { children: id }, id);
+                          })] })), o$1("br", {}), o$1("small", { children: data.options.sourcemap ? SOURCEMAP_RENDERED : RENDRED }), (data.options.gzip || data.options.brotli) && (o$1(k$1, { children: [o$1("br", {}), o$1("small", { children: COMPRESSED })] }))] }));
+      }, [availableSizeProperties, data, getModuleSize, node, root.data, sizeProperty]);
+      const updatePosition = (mouseCoords) => {
+          if (!ref.current)
+              return;
+          const pos = {
+              left: mouseCoords.x + Tooltip_marginX,
+              top: mouseCoords.y + Tooltip_marginY,
+          };
+          const boundingRect = ref.current.getBoundingClientRect();
+          if (pos.left + boundingRect.width > window.innerWidth) {
+              // Shifting horizontally
+              pos.left = window.innerWidth - boundingRect.width;
+          }
+          if (pos.top + boundingRect.height > window.innerHeight) {
+              // Flipping vertically
+              pos.top = mouseCoords.y - Tooltip_marginY - boundingRect.height;
+          }
+          setStyle(pos);
+      };
+      p(() => {
+          const handleMouseMove = (event) => {
+              updatePosition({
+                  x: event.pageX,
+                  y: event.pageY,
+              });
+          };
+          document.addEventListener("mousemove", handleMouseMove, true);
+          return () => {
+              document.removeEventListener("mousemove", handleMouseMove, true);
+          };
+      }, []);
+      return (o$1("div", { className: `tooltip ${visible ? "" : "tooltip-hidden"}`, ref: ref, style: style, children: content }));
+  };
+
+  const Chart = ({ root, sizeProperty, selectedNode, setSelectedNode, }) => {
+      const [showTooltip, setShowTooltip] = h(false);
+      const [tooltipNode, setTooltipNode] = h(undefined);
+      p(() => {
+          const handleMouseOut = () => {
+              setShowTooltip(false);
+          };
+          document.addEventListener("mouseover", handleMouseOut);
+          return () => {
+              document.removeEventListener("mouseover", handleMouseOut);
+          };
+      }, []);
+      return (o$1(k$1, { children: [o$1(TreeMap, { root: root, onNodeHover: (node) => {
+                      setTooltipNode(node);
+                      setShowTooltip(true);
+                  }, selectedNode: selectedNode, onNodeClick: (node) => {
+                      setSelectedNode(selectedNode === node ? undefined : node);
+                  } }), o$1(Tooltip, { visible: showTooltip, node: tooltipNode, root: root, sizeProperty: sizeProperty })] }));
+  };
+
+  const Main = () => {
+      const { availableSizeProperties, rawHierarchy, getModuleSize, layout, data } = q(StaticContext);
+      const [sizeProperty, setSizeProperty] = h(availableSizeProperties[0]);
+      const [selectedNode, setSelectedNode] = h(undefined);
+      const { getModuleFilterMultiplier, setExcludeFilter, setIncludeFilter } = useFilter();
+      console.time("getNodeSizeMultiplier");
+      const getNodeSizeMultiplier = F(() => {
+          const selectedMultiplier = 1; // selectedSize < rootSize * increaseFactor ? (rootSize * increaseFactor) / selectedSize : rootSize / selectedSize;
+          const nonSelectedMultiplier = 0; // 1 / selectedMultiplier
+          if (selectedNode === undefined) {
+              return () => 1;
+          }
+          else if (isModuleTree(selectedNode.data)) {
+              const leaves = new Set(selectedNode.leaves().map((d) => d.data));
+              return (node) => {
+                  if (leaves.has(node)) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+          else {
+              return (node) => {
+                  if (node === selectedNode.data) {
+                      return selectedMultiplier;
+                  }
+                  return nonSelectedMultiplier;
+              };
+          }
+      }, [getModuleSize, rawHierarchy.data, selectedNode, sizeProperty]);
+      console.timeEnd("getNodeSizeMultiplier");
+      console.time("root hierarchy compute");
+      // root here always be the same as rawHierarchy even after layouting
+      const root = F(() => {
+          const rootWithSizesAndSorted = rawHierarchy
+              .sum((node) => {
+              var _a;
+              if (isModuleTree(node))
+                  return 0;
+              const meta = data.nodeMetas[data.nodeParts[node.uid].metaUid];
+              const bundleId = (_a = Object.entries(meta.moduleParts).find(([bundleId, uid]) => uid == node.uid)) === null || _a === void 0 ? void 0 : _a[0];
+              const ownSize = getModuleSize(node, sizeProperty);
+              const zoomMultiplier = getNodeSizeMultiplier(node);
+              const filterMultiplier = getModuleFilterMultiplier(bundleId, meta);
+              return ownSize * zoomMultiplier * filterMultiplier;
+          })
+              .sort((a, b) => getModuleSize(a.data, sizeProperty) - getModuleSize(b.data, sizeProperty));
+          return layout(rootWithSizesAndSorted);
+      }, [
+          data,
+          getModuleFilterMultiplier,
+          getModuleSize,
+          getNodeSizeMultiplier,
+          layout,
+          rawHierarchy,
+          sizeProperty,
+      ]);
+      console.timeEnd("root hierarchy compute");
+      return (o$1(k$1, { children: [o$1(SideBar, { sizeProperty: sizeProperty, availableSizeProperties: availableSizeProperties, setSizeProperty: setSizeProperty, onExcludeChange: setExcludeFilter, onIncludeChange: setIncludeFilter }), o$1(Chart, { root: root, sizeProperty: sizeProperty, selectedNode: selectedNode, setSelectedNode: setSelectedNode })] }));
+  };
+
+  function initRange(domain, range) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: this.range(domain); break;
+      default: this.range(range).domain(domain); break;
+    }
+    return this;
+  }
+
+  function initInterpolator(domain, interpolator) {
+    switch (arguments.length) {
+      case 0: break;
+      case 1: {
+        if (typeof domain === "function") this.interpolator(domain);
+        else this.range(domain);
+        break;
+      }
+      default: {
+        this.domain(domain);
+        if (typeof interpolator === "function") this.interpolator(interpolator);
+        else this.range(interpolator);
+        break;
+      }
+    }
+    return this;
+  }
+
+  function define(constructor, factory, prototype) {
+    constructor.prototype = factory.prototype = prototype;
+    prototype.constructor = constructor;
+  }
+
+  function extend(parent, definition) {
+    var prototype = Object.create(parent.prototype);
+    for (var key in definition) prototype[key] = definition[key];
+    return prototype;
+  }
+
+  function Color() {}
+
+  var darker = 0.7;
+  var brighter = 1 / darker;
+
+  var reI = "\\s*([+-]?\\d+)\\s*",
+      reN = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*",
+      reP = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*",
+      reHex = /^#([0-9a-f]{3,8})$/,
+      reRgbInteger = new RegExp(`^rgb\\(${reI},${reI},${reI}\\)$`),
+      reRgbPercent = new RegExp(`^rgb\\(${reP},${reP},${reP}\\)$`),
+      reRgbaInteger = new RegExp(`^rgba\\(${reI},${reI},${reI},${reN}\\)$`),
+      reRgbaPercent = new RegExp(`^rgba\\(${reP},${reP},${reP},${reN}\\)$`),
+      reHslPercent = new RegExp(`^hsl\\(${reN},${reP},${reP}\\)$`),
+      reHslaPercent = new RegExp(`^hsla\\(${reN},${reP},${reP},${reN}\\)$`);
+
+  var named = {
+    aliceblue: 0xf0f8ff,
+    antiquewhite: 0xfaebd7,
+    aqua: 0x00ffff,
+    aquamarine: 0x7fffd4,
+    azure: 0xf0ffff,
+    beige: 0xf5f5dc,
+    bisque: 0xffe4c4,
+    black: 0x000000,
+    blanchedalmond: 0xffebcd,
+    blue: 0x0000ff,
+    blueviolet: 0x8a2be2,
+    brown: 0xa52a2a,
+    burlywood: 0xdeb887,
+    cadetblue: 0x5f9ea0,
+    chartreuse: 0x7fff00,
+    chocolate: 0xd2691e,
+    coral: 0xff7f50,
+    cornflowerblue: 0x6495ed,
+    cornsilk: 0xfff8dc,
+    crimson: 0xdc143c,
+    cyan: 0x00ffff,
+    darkblue: 0x00008b,
+    darkcyan: 0x008b8b,
+    darkgoldenrod: 0xb8860b,
+    darkgray: 0xa9a9a9,
+    darkgreen: 0x006400,
+    darkgrey: 0xa9a9a9,
+    darkkhaki: 0xbdb76b,
+    darkmagenta: 0x8b008b,
+    darkolivegreen: 0x556b2f,
+    darkorange: 0xff8c00,
+    darkorchid: 0x9932cc,
+    darkred: 0x8b0000,
+    darksalmon: 0xe9967a,
+    darkseagreen: 0x8fbc8f,
+    darkslateblue: 0x483d8b,
+    darkslategray: 0x2f4f4f,
+    darkslategrey: 0x2f4f4f,
+    darkturquoise: 0x00ced1,
+    darkviolet: 0x9400d3,
+    deeppink: 0xff1493,
+    deepskyblue: 0x00bfff,
+    dimgray: 0x696969,
+    dimgrey: 0x696969,
+    dodgerblue: 0x1e90ff,
+    firebrick: 0xb22222,
+    floralwhite: 0xfffaf0,
+    forestgreen: 0x228b22,
+    fuchsia: 0xff00ff,
+    gainsboro: 0xdcdcdc,
+    ghostwhite: 0xf8f8ff,
+    gold: 0xffd700,
+    goldenrod: 0xdaa520,
+    gray: 0x808080,
+    green: 0x008000,
+    greenyellow: 0xadff2f,
+    grey: 0x808080,
+    honeydew: 0xf0fff0,
+    hotpink: 0xff69b4,
+    indianred: 0xcd5c5c,
+    indigo: 0x4b0082,
+    ivory: 0xfffff0,
+    khaki: 0xf0e68c,
+    lavender: 0xe6e6fa,
+    lavenderblush: 0xfff0f5,
+    lawngreen: 0x7cfc00,
+    lemonchiffon: 0xfffacd,
+    lightblue: 0xadd8e6,
+    lightcoral: 0xf08080,
+    lightcyan: 0xe0ffff,
+    lightgoldenrodyellow: 0xfafad2,
+    lightgray: 0xd3d3d3,
+    lightgreen: 0x90ee90,
+    lightgrey: 0xd3d3d3,
+    lightpink: 0xffb6c1,
+    lightsalmon: 0xffa07a,
+    lightseagreen: 0x20b2aa,
+    lightskyblue: 0x87cefa,
+    lightslategray: 0x778899,
+    lightslategrey: 0x778899,
+    lightsteelblue: 0xb0c4de,
+    lightyellow: 0xffffe0,
+    lime: 0x00ff00,
+    limegreen: 0x32cd32,
+    linen: 0xfaf0e6,
+    magenta: 0xff00ff,
+    maroon: 0x800000,
+    mediumaquamarine: 0x66cdaa,
+    mediumblue: 0x0000cd,
+    mediumorchid: 0xba55d3,
+    mediumpurple: 0x9370db,
+    mediumseagreen: 0x3cb371,
+    mediumslateblue: 0x7b68ee,
+    mediumspringgreen: 0x00fa9a,
+    mediumturquoise: 0x48d1cc,
+    mediumvioletred: 0xc71585,
+    midnightblue: 0x191970,
+    mintcream: 0xf5fffa,
+    mistyrose: 0xffe4e1,
+    moccasin: 0xffe4b5,
+    navajowhite: 0xffdead,
+    navy: 0x000080,
+    oldlace: 0xfdf5e6,
+    olive: 0x808000,
+    olivedrab: 0x6b8e23,
+    orange: 0xffa500,
+    orangered: 0xff4500,
+    orchid: 0xda70d6,
+    palegoldenrod: 0xeee8aa,
+    palegreen: 0x98fb98,
+    paleturquoise: 0xafeeee,
+    palevioletred: 0xdb7093,
+    papayawhip: 0xffefd5,
+    peachpuff: 0xffdab9,
+    peru: 0xcd853f,
+    pink: 0xffc0cb,
+    plum: 0xdda0dd,
+    powderblue: 0xb0e0e6,
+    purple: 0x800080,
+    rebeccapurple: 0x663399,
+    red: 0xff0000,
+    rosybrown: 0xbc8f8f,
+    royalblue: 0x4169e1,
+    saddlebrown: 0x8b4513,
+    salmon: 0xfa8072,
+    sandybrown: 0xf4a460,
+    seagreen: 0x2e8b57,
+    seashell: 0xfff5ee,
+    sienna: 0xa0522d,
+    silver: 0xc0c0c0,
+    skyblue: 0x87ceeb,
+    slateblue: 0x6a5acd,
+    slategray: 0x708090,
+    slategrey: 0x708090,
+    snow: 0xfffafa,
+    springgreen: 0x00ff7f,
+    steelblue: 0x4682b4,
+    tan: 0xd2b48c,
+    teal: 0x008080,
+    thistle: 0xd8bfd8,
+    tomato: 0xff6347,
+    turquoise: 0x40e0d0,
+    violet: 0xee82ee,
+    wheat: 0xf5deb3,
+    white: 0xffffff,
+    whitesmoke: 0xf5f5f5,
+    yellow: 0xffff00,
+    yellowgreen: 0x9acd32
+  };
+
+  define(Color, color, {
+    copy(channels) {
+      return Object.assign(new this.constructor, this, channels);
+    },
+    displayable() {
+      return this.rgb().displayable();
+    },
+    hex: color_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: color_formatHex,
+    formatHex8: color_formatHex8,
+    formatHsl: color_formatHsl,
+    formatRgb: color_formatRgb,
+    toString: color_formatRgb
+  });
+
+  function color_formatHex() {
+    return this.rgb().formatHex();
+  }
+
+  function color_formatHex8() {
+    return this.rgb().formatHex8();
+  }
+
+  function color_formatHsl() {
+    return hslConvert(this).formatHsl();
+  }
+
+  function color_formatRgb() {
+    return this.rgb().formatRgb();
+  }
+
+  function color(format) {
+    var m, l;
+    format = (format + "").trim().toLowerCase();
+    return (m = reHex.exec(format)) ? (l = m[1].length, m = parseInt(m[1], 16), l === 6 ? rgbn(m) // #ff0000
+        : l === 3 ? new Rgb((m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), ((m & 0xf) << 4) | (m & 0xf), 1) // #f00
+        : l === 8 ? rgba(m >> 24 & 0xff, m >> 16 & 0xff, m >> 8 & 0xff, (m & 0xff) / 0xff) // #ff000000
+        : l === 4 ? rgba((m >> 12 & 0xf) | (m >> 8 & 0xf0), (m >> 8 & 0xf) | (m >> 4 & 0xf0), (m >> 4 & 0xf) | (m & 0xf0), (((m & 0xf) << 4) | (m & 0xf)) / 0xff) // #f000
+        : null) // invalid hex
+        : (m = reRgbInteger.exec(format)) ? new Rgb(m[1], m[2], m[3], 1) // rgb(255, 0, 0)
+        : (m = reRgbPercent.exec(format)) ? new Rgb(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, 1) // rgb(100%, 0%, 0%)
+        : (m = reRgbaInteger.exec(format)) ? rgba(m[1], m[2], m[3], m[4]) // rgba(255, 0, 0, 1)
+        : (m = reRgbaPercent.exec(format)) ? rgba(m[1] * 255 / 100, m[2] * 255 / 100, m[3] * 255 / 100, m[4]) // rgb(100%, 0%, 0%, 1)
+        : (m = reHslPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, 1) // hsl(120, 50%, 50%)
+        : (m = reHslaPercent.exec(format)) ? hsla(m[1], m[2] / 100, m[3] / 100, m[4]) // hsla(120, 50%, 50%, 1)
+        : named.hasOwnProperty(format) ? rgbn(named[format]) // eslint-disable-line no-prototype-builtins
+        : format === "transparent" ? new Rgb(NaN, NaN, NaN, 0)
+        : null;
+  }
+
+  function rgbn(n) {
+    return new Rgb(n >> 16 & 0xff, n >> 8 & 0xff, n & 0xff, 1);
+  }
+
+  function rgba(r, g, b, a) {
+    if (a <= 0) r = g = b = NaN;
+    return new Rgb(r, g, b, a);
+  }
+
+  function rgbConvert(o) {
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Rgb;
+    o = o.rgb();
+    return new Rgb(o.r, o.g, o.b, o.opacity);
+  }
+
+  function rgb$1(r, g, b, opacity) {
+    return arguments.length === 1 ? rgbConvert(r) : new Rgb(r, g, b, opacity == null ? 1 : opacity);
+  }
+
+  function Rgb(r, g, b, opacity) {
+    this.r = +r;
+    this.g = +g;
+    this.b = +b;
+    this.opacity = +opacity;
+  }
+
+  define(Rgb, rgb$1, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Rgb(this.r * k, this.g * k, this.b * k, this.opacity);
+    },
+    rgb() {
+      return this;
+    },
+    clamp() {
+      return new Rgb(clampi(this.r), clampi(this.g), clampi(this.b), clampa(this.opacity));
+    },
+    displayable() {
+      return (-0.5 <= this.r && this.r < 255.5)
+          && (-0.5 <= this.g && this.g < 255.5)
+          && (-0.5 <= this.b && this.b < 255.5)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    hex: rgb_formatHex, // Deprecated! Use color.formatHex.
+    formatHex: rgb_formatHex,
+    formatHex8: rgb_formatHex8,
+    formatRgb: rgb_formatRgb,
+    toString: rgb_formatRgb
+  }));
+
+  function rgb_formatHex() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}`;
+  }
+
+  function rgb_formatHex8() {
+    return `#${hex(this.r)}${hex(this.g)}${hex(this.b)}${hex((isNaN(this.opacity) ? 1 : this.opacity) * 255)}`;
+  }
+
+  function rgb_formatRgb() {
+    const a = clampa(this.opacity);
+    return `${a === 1 ? "rgb(" : "rgba("}${clampi(this.r)}, ${clampi(this.g)}, ${clampi(this.b)}${a === 1 ? ")" : `, ${a})`}`;
+  }
+
+  function clampa(opacity) {
+    return isNaN(opacity) ? 1 : Math.max(0, Math.min(1, opacity));
+  }
+
+  function clampi(value) {
+    return Math.max(0, Math.min(255, Math.round(value) || 0));
+  }
+
+  function hex(value) {
+    value = clampi(value);
+    return (value < 16 ? "0" : "") + value.toString(16);
+  }
+
+  function hsla(h, s, l, a) {
+    if (a <= 0) h = s = l = NaN;
+    else if (l <= 0 || l >= 1) h = s = NaN;
+    else if (s <= 0) h = NaN;
+    return new Hsl(h, s, l, a);
+  }
+
+  function hslConvert(o) {
+    if (o instanceof Hsl) return new Hsl(o.h, o.s, o.l, o.opacity);
+    if (!(o instanceof Color)) o = color(o);
+    if (!o) return new Hsl;
+    if (o instanceof Hsl) return o;
+    o = o.rgb();
+    var r = o.r / 255,
+        g = o.g / 255,
+        b = o.b / 255,
+        min = Math.min(r, g, b),
+        max = Math.max(r, g, b),
+        h = NaN,
+        s = max - min,
+        l = (max + min) / 2;
+    if (s) {
+      if (r === max) h = (g - b) / s + (g < b) * 6;
+      else if (g === max) h = (b - r) / s + 2;
+      else h = (r - g) / s + 4;
+      s /= l < 0.5 ? max + min : 2 - max - min;
+      h *= 60;
+    } else {
+      s = l > 0 && l < 1 ? 0 : h;
+    }
+    return new Hsl(h, s, l, o.opacity);
+  }
+
+  function hsl(h, s, l, opacity) {
+    return arguments.length === 1 ? hslConvert(h) : new Hsl(h, s, l, opacity == null ? 1 : opacity);
+  }
+
+  function Hsl(h, s, l, opacity) {
+    this.h = +h;
+    this.s = +s;
+    this.l = +l;
+    this.opacity = +opacity;
+  }
+
+  define(Hsl, hsl, extend(Color, {
+    brighter(k) {
+      k = k == null ? brighter : Math.pow(brighter, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    darker(k) {
+      k = k == null ? darker : Math.pow(darker, k);
+      return new Hsl(this.h, this.s, this.l * k, this.opacity);
+    },
+    rgb() {
+      var h = this.h % 360 + (this.h < 0) * 360,
+          s = isNaN(h) || isNaN(this.s) ? 0 : this.s,
+          l = this.l,
+          m2 = l + (l < 0.5 ? l : 1 - l) * s,
+          m1 = 2 * l - m2;
+      return new Rgb(
+        hsl2rgb(h >= 240 ? h - 240 : h + 120, m1, m2),
+        hsl2rgb(h, m1, m2),
+        hsl2rgb(h < 120 ? h + 240 : h - 120, m1, m2),
+        this.opacity
+      );
+    },
+    clamp() {
+      return new Hsl(clamph(this.h), clampt(this.s), clampt(this.l), clampa(this.opacity));
+    },
+    displayable() {
+      return (0 <= this.s && this.s <= 1 || isNaN(this.s))
+          && (0 <= this.l && this.l <= 1)
+          && (0 <= this.opacity && this.opacity <= 1);
+    },
+    formatHsl() {
+      const a = clampa(this.opacity);
+      return `${a === 1 ? "hsl(" : "hsla("}${clamph(this.h)}, ${clampt(this.s) * 100}%, ${clampt(this.l) * 100}%${a === 1 ? ")" : `, ${a})`}`;
+    }
+  }));
+
+  function clamph(value) {
+    value = (value || 0) % 360;
+    return value < 0 ? value + 360 : value;
+  }
+
+  function clampt(value) {
+    return Math.max(0, Math.min(1, value || 0));
+  }
+
+  /* From FvD 13.37, CSS Color Module Level 3 */
+  function hsl2rgb(h, m1, m2) {
+    return (h < 60 ? m1 + (m2 - m1) * h / 60
+        : h < 180 ? m2
+        : h < 240 ? m1 + (m2 - m1) * (240 - h) / 60
+        : m1) * 255;
+  }
+
+  var constant = x => () => x;
+
+  function linear$1(a, d) {
+    return function(t) {
+      return a + t * d;
+    };
+  }
+
+  function exponential(a, b, y) {
+    return a = Math.pow(a, y), b = Math.pow(b, y) - a, y = 1 / y, function(t) {
+      return Math.pow(a + t * b, y);
+    };
+  }
+
+  function gamma(y) {
+    return (y = +y) === 1 ? nogamma : function(a, b) {
+      return b - a ? exponential(a, b, y) : constant(isNaN(a) ? b : a);
+    };
+  }
+
+  function nogamma(a, b) {
+    var d = b - a;
+    return d ? linear$1(a, d) : constant(isNaN(a) ? b : a);
+  }
+
+  var rgb = (function rgbGamma(y) {
+    var color = gamma(y);
+
+    function rgb(start, end) {
+      var r = color((start = rgb$1(start)).r, (end = rgb$1(end)).r),
+          g = color(start.g, end.g),
+          b = color(start.b, end.b),
+          opacity = nogamma(start.opacity, end.opacity);
+      return function(t) {
+        start.r = r(t);
+        start.g = g(t);
+        start.b = b(t);
+        start.opacity = opacity(t);
+        return start + "";
+      };
+    }
+
+    rgb.gamma = rgbGamma;
+
+    return rgb;
+  })(1);
+
+  function numberArray(a, b) {
+    if (!b) b = [];
+    var n = a ? Math.min(b.length, a.length) : 0,
+        c = b.slice(),
+        i;
+    return function(t) {
+      for (i = 0; i < n; ++i) c[i] = a[i] * (1 - t) + b[i] * t;
+      return c;
+    };
+  }
+
+  function isNumberArray(x) {
+    return ArrayBuffer.isView(x) && !(x instanceof DataView);
+  }
+
+  function genericArray(a, b) {
+    var nb = b ? b.length : 0,
+        na = a ? Math.min(nb, a.length) : 0,
+        x = new Array(na),
+        c = new Array(nb),
+        i;
+
+    for (i = 0; i < na; ++i) x[i] = interpolate(a[i], b[i]);
+    for (; i < nb; ++i) c[i] = b[i];
+
+    return function(t) {
+      for (i = 0; i < na; ++i) c[i] = x[i](t);
+      return c;
+    };
+  }
+
+  function date(a, b) {
+    var d = new Date;
+    return a = +a, b = +b, function(t) {
+      return d.setTime(a * (1 - t) + b * t), d;
+    };
+  }
+
+  function interpolateNumber(a, b) {
+    return a = +a, b = +b, function(t) {
+      return a * (1 - t) + b * t;
+    };
+  }
+
+  function object(a, b) {
+    var i = {},
+        c = {},
+        k;
+
+    if (a === null || typeof a !== "object") a = {};
+    if (b === null || typeof b !== "object") b = {};
+
+    for (k in b) {
+      if (k in a) {
+        i[k] = interpolate(a[k], b[k]);
+      } else {
+        c[k] = b[k];
+      }
+    }
+
+    return function(t) {
+      for (k in i) c[k] = i[k](t);
+      return c;
+    };
+  }
+
+  var reA = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g,
+      reB = new RegExp(reA.source, "g");
+
+  function zero(b) {
+    return function() {
+      return b;
+    };
+  }
+
+  function one(b) {
+    return function(t) {
+      return b(t) + "";
+    };
+  }
+
+  function string(a, b) {
+    var bi = reA.lastIndex = reB.lastIndex = 0, // scan index for next number in b
+        am, // current match in a
+        bm, // current match in b
+        bs, // string preceding current number in b, if any
+        i = -1, // index in s
+        s = [], // string constants and placeholders
+        q = []; // number interpolators
+
+    // Coerce inputs to strings.
+    a = a + "", b = b + "";
+
+    // Interpolate pairs of numbers in a & b.
+    while ((am = reA.exec(a))
+        && (bm = reB.exec(b))) {
+      if ((bs = bm.index) > bi) { // a string precedes the next number in b
+        bs = b.slice(bi, bs);
+        if (s[i]) s[i] += bs; // coalesce with previous string
+        else s[++i] = bs;
+      }
+      if ((am = am[0]) === (bm = bm[0])) { // numbers in a & b match
+        if (s[i]) s[i] += bm; // coalesce with previous string
+        else s[++i] = bm;
+      } else { // interpolate non-matching numbers
+        s[++i] = null;
+        q.push({i: i, x: interpolateNumber(am, bm)});
+      }
+      bi = reB.lastIndex;
+    }
+
+    // Add remains of b.
+    if (bi < b.length) {
+      bs = b.slice(bi);
+      if (s[i]) s[i] += bs; // coalesce with previous string
+      else s[++i] = bs;
+    }
+
+    // Special optimization for only a single match.
+    // Otherwise, interpolate each of the numbers and rejoin the string.
+    return s.length < 2 ? (q[0]
+        ? one(q[0].x)
+        : zero(b))
+        : (b = q.length, function(t) {
+            for (var i = 0, o; i < b; ++i) s[(o = q[i]).i] = o.x(t);
+            return s.join("");
+          });
+  }
+
+  function interpolate(a, b) {
+    var t = typeof b, c;
+    return b == null || t === "boolean" ? constant(b)
+        : (t === "number" ? interpolateNumber
+        : t === "string" ? ((c = color(b)) ? (b = c, rgb) : string)
+        : b instanceof color ? rgb
+        : b instanceof Date ? date
+        : isNumberArray(b) ? numberArray
+        : Array.isArray(b) ? genericArray
+        : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
+        : interpolateNumber)(a, b);
+  }
+
+  function interpolateRound(a, b) {
+    return a = +a, b = +b, function(t) {
+      return Math.round(a * (1 - t) + b * t);
+    };
+  }
+
+  function constants(x) {
+    return function() {
+      return x;
+    };
+  }
+
+  function number(x) {
+    return +x;
+  }
+
+  var unit = [0, 1];
+
+  function identity$1(x) {
+    return x;
+  }
+
+  function normalize(a, b) {
+    return (b -= (a = +a))
+        ? function(x) { return (x - a) / b; }
+        : constants(isNaN(b) ? NaN : 0.5);
+  }
+
+  function clamper(a, b) {
+    var t;
+    if (a > b) t = a, a = b, b = t;
+    return function(x) { return Math.max(a, Math.min(b, x)); };
+  }
+
+  // normalize(a, b)(x) takes a domain value x in [a,b] and returns the corresponding parameter t in [0,1].
+  // interpolate(a, b)(t) takes a parameter t in [0,1] and returns the corresponding range value x in [a,b].
+  function bimap(domain, range, interpolate) {
+    var d0 = domain[0], d1 = domain[1], r0 = range[0], r1 = range[1];
+    if (d1 < d0) d0 = normalize(d1, d0), r0 = interpolate(r1, r0);
+    else d0 = normalize(d0, d1), r0 = interpolate(r0, r1);
+    return function(x) { return r0(d0(x)); };
+  }
+
+  function polymap(domain, range, interpolate) {
+    var j = Math.min(domain.length, range.length) - 1,
+        d = new Array(j),
+        r = new Array(j),
+        i = -1;
+
+    // Reverse descending domains.
+    if (domain[j] < domain[0]) {
+      domain = domain.slice().reverse();
+      range = range.slice().reverse();
+    }
+
+    while (++i < j) {
+      d[i] = normalize(domain[i], domain[i + 1]);
+      r[i] = interpolate(range[i], range[i + 1]);
+    }
+
+    return function(x) {
+      var i = bisect(domain, x, 1, j) - 1;
+      return r[i](d[i](x));
+    };
+  }
+
+  function copy$1(source, target) {
+    return target
+        .domain(source.domain())
+        .range(source.range())
+        .interpolate(source.interpolate())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function transformer$1() {
+    var domain = unit,
+        range = unit,
+        interpolate$1 = interpolate,
+        transform,
+        untransform,
+        unknown,
+        clamp = identity$1,
+        piecewise,
+        output,
+        input;
+
+    function rescale() {
+      var n = Math.min(domain.length, range.length);
+      if (clamp !== identity$1) clamp = clamper(domain[0], domain[n - 1]);
+      piecewise = n > 2 ? polymap : bimap;
+      output = input = null;
+      return scale;
+    }
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : (output || (output = piecewise(domain.map(transform), range, interpolate$1)))(transform(clamp(x)));
+    }
+
+    scale.invert = function(y) {
+      return clamp(untransform((input || (input = piecewise(range, domain.map(transform), interpolateNumber)))(y)));
+    };
+
+    scale.domain = function(_) {
+      return arguments.length ? (domain = Array.from(_, number), rescale()) : domain.slice();
+    };
+
+    scale.range = function(_) {
+      return arguments.length ? (range = Array.from(_), rescale()) : range.slice();
+    };
+
+    scale.rangeRound = function(_) {
+      return range = Array.from(_), interpolate$1 = interpolateRound, rescale();
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = _ ? true : identity$1, rescale()) : clamp !== identity$1;
+    };
+
+    scale.interpolate = function(_) {
+      return arguments.length ? (interpolate$1 = _, rescale()) : interpolate$1;
+    };
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t, u) {
+      transform = t, untransform = u;
+      return rescale();
+    };
+  }
+
+  function continuous() {
+    return transformer$1()(identity$1, identity$1);
+  }
+
+  function formatDecimal(x) {
+    return Math.abs(x = Math.round(x)) >= 1e21
+        ? x.toLocaleString("en").replace(/,/g, "")
+        : x.toString(10);
+  }
+
+  // Computes the decimal coefficient and exponent of the specified number x with
+  // significant digits p, where x is positive and p is in [1, 21] or undefined.
+  // For example, formatDecimalParts(1.23) returns ["123", 0].
+  function formatDecimalParts(x, p) {
+    if ((i = (x = p ? x.toExponential(p - 1) : x.toExponential()).indexOf("e")) < 0) return null; // NaN, ±Infinity
+    var i, coefficient = x.slice(0, i);
+
+    // The string returned by toExponential either has the form \d\.\d+e[-+]\d+
+    // (e.g., 1.2e+3) or the form \de[-+]\d+ (e.g., 1e+3).
+    return [
+      coefficient.length > 1 ? coefficient[0] + coefficient.slice(2) : coefficient,
+      +x.slice(i + 1)
+    ];
+  }
+
+  function exponent(x) {
+    return x = formatDecimalParts(Math.abs(x)), x ? x[1] : NaN;
+  }
+
+  function formatGroup(grouping, thousands) {
+    return function(value, width) {
+      var i = value.length,
+          t = [],
+          j = 0,
+          g = grouping[0],
+          length = 0;
+
+      while (i > 0 && g > 0) {
+        if (length + g + 1 > width) g = Math.max(1, width - length);
+        t.push(value.substring(i -= g, i + g));
+        if ((length += g + 1) > width) break;
+        g = grouping[j = (j + 1) % grouping.length];
+      }
+
+      return t.reverse().join(thousands);
+    };
+  }
+
+  function formatNumerals(numerals) {
+    return function(value) {
+      return value.replace(/[0-9]/g, function(i) {
+        return numerals[+i];
+      });
+    };
+  }
+
+  // [[fill]align][sign][symbol][0][width][,][.precision][~][type]
+  var re = /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
+
+  function formatSpecifier(specifier) {
+    if (!(match = re.exec(specifier))) throw new Error("invalid format: " + specifier);
+    var match;
+    return new FormatSpecifier({
+      fill: match[1],
+      align: match[2],
+      sign: match[3],
+      symbol: match[4],
+      zero: match[5],
+      width: match[6],
+      comma: match[7],
+      precision: match[8] && match[8].slice(1),
+      trim: match[9],
+      type: match[10]
+    });
+  }
+
+  formatSpecifier.prototype = FormatSpecifier.prototype; // instanceof
+
+  function FormatSpecifier(specifier) {
+    this.fill = specifier.fill === undefined ? " " : specifier.fill + "";
+    this.align = specifier.align === undefined ? ">" : specifier.align + "";
+    this.sign = specifier.sign === undefined ? "-" : specifier.sign + "";
+    this.symbol = specifier.symbol === undefined ? "" : specifier.symbol + "";
+    this.zero = !!specifier.zero;
+    this.width = specifier.width === undefined ? undefined : +specifier.width;
+    this.comma = !!specifier.comma;
+    this.precision = specifier.precision === undefined ? undefined : +specifier.precision;
+    this.trim = !!specifier.trim;
+    this.type = specifier.type === undefined ? "" : specifier.type + "";
+  }
+
+  FormatSpecifier.prototype.toString = function() {
+    return this.fill
+        + this.align
+        + this.sign
+        + this.symbol
+        + (this.zero ? "0" : "")
+        + (this.width === undefined ? "" : Math.max(1, this.width | 0))
+        + (this.comma ? "," : "")
+        + (this.precision === undefined ? "" : "." + Math.max(0, this.precision | 0))
+        + (this.trim ? "~" : "")
+        + this.type;
+  };
+
+  // Trims insignificant zeros, e.g., replaces 1.2000k with 1.2k.
+  function formatTrim(s) {
+    out: for (var n = s.length, i = 1, i0 = -1, i1; i < n; ++i) {
+      switch (s[i]) {
+        case ".": i0 = i1 = i; break;
+        case "0": if (i0 === 0) i0 = i; i1 = i; break;
+        default: if (!+s[i]) break out; if (i0 > 0) i0 = 0; break;
+      }
+    }
+    return i0 > 0 ? s.slice(0, i0) + s.slice(i1 + 1) : s;
+  }
+
+  var prefixExponent;
+
+  function formatPrefixAuto(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1],
+        i = exponent - (prefixExponent = Math.max(-8, Math.min(8, Math.floor(exponent / 3))) * 3) + 1,
+        n = coefficient.length;
+    return i === n ? coefficient
+        : i > n ? coefficient + new Array(i - n + 1).join("0")
+        : i > 0 ? coefficient.slice(0, i) + "." + coefficient.slice(i)
+        : "0." + new Array(1 - i).join("0") + formatDecimalParts(x, Math.max(0, p + i - 1))[0]; // less than 1y!
+  }
+
+  function formatRounded(x, p) {
+    var d = formatDecimalParts(x, p);
+    if (!d) return x + "";
+    var coefficient = d[0],
+        exponent = d[1];
+    return exponent < 0 ? "0." + new Array(-exponent).join("0") + coefficient
+        : coefficient.length > exponent + 1 ? coefficient.slice(0, exponent + 1) + "." + coefficient.slice(exponent + 1)
+        : coefficient + new Array(exponent - coefficient.length + 2).join("0");
+  }
+
+  var formatTypes = {
+    "%": (x, p) => (x * 100).toFixed(p),
+    "b": (x) => Math.round(x).toString(2),
+    "c": (x) => x + "",
+    "d": formatDecimal,
+    "e": (x, p) => x.toExponential(p),
+    "f": (x, p) => x.toFixed(p),
+    "g": (x, p) => x.toPrecision(p),
+    "o": (x) => Math.round(x).toString(8),
+    "p": (x, p) => formatRounded(x * 100, p),
+    "r": formatRounded,
+    "s": formatPrefixAuto,
+    "X": (x) => Math.round(x).toString(16).toUpperCase(),
+    "x": (x) => Math.round(x).toString(16)
+  };
+
+  function identity(x) {
+    return x;
+  }
+
+  var map = Array.prototype.map,
+      prefixes = ["y","z","a","f","p","n","µ","m","","k","M","G","T","P","E","Z","Y"];
+
+  function formatLocale(locale) {
+    var group = locale.grouping === undefined || locale.thousands === undefined ? identity : formatGroup(map.call(locale.grouping, Number), locale.thousands + ""),
+        currencyPrefix = locale.currency === undefined ? "" : locale.currency[0] + "",
+        currencySuffix = locale.currency === undefined ? "" : locale.currency[1] + "",
+        decimal = locale.decimal === undefined ? "." : locale.decimal + "",
+        numerals = locale.numerals === undefined ? identity : formatNumerals(map.call(locale.numerals, String)),
+        percent = locale.percent === undefined ? "%" : locale.percent + "",
+        minus = locale.minus === undefined ? "−" : locale.minus + "",
+        nan = locale.nan === undefined ? "NaN" : locale.nan + "";
+
+    function newFormat(specifier) {
+      specifier = formatSpecifier(specifier);
+
+      var fill = specifier.fill,
+          align = specifier.align,
+          sign = specifier.sign,
+          symbol = specifier.symbol,
+          zero = specifier.zero,
+          width = specifier.width,
+          comma = specifier.comma,
+          precision = specifier.precision,
+          trim = specifier.trim,
+          type = specifier.type;
+
+      // The "n" type is an alias for ",g".
+      if (type === "n") comma = true, type = "g";
+
+      // The "" type, and any invalid type, is an alias for ".12~g".
+      else if (!formatTypes[type]) precision === undefined && (precision = 12), trim = true, type = "g";
+
+      // If zero fill is specified, padding goes after sign and before digits.
+      if (zero || (fill === "0" && align === "=")) zero = true, fill = "0", align = "=";
+
+      // Compute the prefix and suffix.
+      // For SI-prefix, the suffix is lazily computed.
+      var prefix = symbol === "$" ? currencyPrefix : symbol === "#" && /[boxX]/.test(type) ? "0" + type.toLowerCase() : "",
+          suffix = symbol === "$" ? currencySuffix : /[%p]/.test(type) ? percent : "";
+
+      // What format function should we use?
+      // Is this an integer type?
+      // Can this type generate exponential notation?
+      var formatType = formatTypes[type],
+          maybeSuffix = /[defgprs%]/.test(type);
+
+      // Set the default precision if not specified,
+      // or clamp the specified precision to the supported range.
+      // For significant precision, it must be in [1, 21].
+      // For fixed precision, it must be in [0, 20].
+      precision = precision === undefined ? 6
+          : /[gprs]/.test(type) ? Math.max(1, Math.min(21, precision))
+          : Math.max(0, Math.min(20, precision));
+
+      function format(value) {
+        var valuePrefix = prefix,
+            valueSuffix = suffix,
+            i, n, c;
+
+        if (type === "c") {
+          valueSuffix = formatType(value) + valueSuffix;
+          value = "";
+        } else {
+          value = +value;
+
+          // Determine the sign. -0 is not less than 0, but 1 / -0 is!
+          var valueNegative = value < 0 || 1 / value < 0;
+
+          // Perform the initial formatting.
+          value = isNaN(value) ? nan : formatType(Math.abs(value), precision);
+
+          // Trim insignificant zeros.
+          if (trim) value = formatTrim(value);
+
+          // If a negative value rounds to zero after formatting, and no explicit positive sign is requested, hide the sign.
+          if (valueNegative && +value === 0 && sign !== "+") valueNegative = false;
+
+          // Compute the prefix and suffix.
+          valuePrefix = (valueNegative ? (sign === "(" ? sign : minus) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
+          valueSuffix = (type === "s" ? prefixes[8 + prefixExponent / 3] : "") + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
+
+          // Break the formatted value into the integer “value” part that can be
+          // grouped, and fractional or exponential “suffix” part that is not.
+          if (maybeSuffix) {
+            i = -1, n = value.length;
+            while (++i < n) {
+              if (c = value.charCodeAt(i), 48 > c || c > 57) {
+                valueSuffix = (c === 46 ? decimal + value.slice(i + 1) : value.slice(i)) + valueSuffix;
+                value = value.slice(0, i);
+                break;
+              }
+            }
+          }
+        }
+
+        // If the fill character is not "0", grouping is applied before padding.
+        if (comma && !zero) value = group(value, Infinity);
+
+        // Compute the padding.
+        var length = valuePrefix.length + value.length + valueSuffix.length,
+            padding = length < width ? new Array(width - length + 1).join(fill) : "";
+
+        // If the fill character is "0", grouping is applied after padding.
+        if (comma && zero) value = group(padding + value, padding.length ? width - valueSuffix.length : Infinity), padding = "";
+
+        // Reconstruct the final output based on the desired alignment.
+        switch (align) {
+          case "<": value = valuePrefix + value + valueSuffix + padding; break;
+          case "=": value = valuePrefix + padding + value + valueSuffix; break;
+          case "^": value = padding.slice(0, length = padding.length >> 1) + valuePrefix + value + valueSuffix + padding.slice(length); break;
+          default: value = padding + valuePrefix + value + valueSuffix; break;
+        }
+
+        return numerals(value);
+      }
+
+      format.toString = function() {
+        return specifier + "";
+      };
+
+      return format;
+    }
+
+    function formatPrefix(specifier, value) {
+      var f = newFormat((specifier = formatSpecifier(specifier), specifier.type = "f", specifier)),
+          e = Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3,
+          k = Math.pow(10, -e),
+          prefix = prefixes[8 + e / 3];
+      return function(value) {
+        return f(k * value) + prefix;
+      };
+    }
+
+    return {
+      format: newFormat,
+      formatPrefix: formatPrefix
+    };
+  }
+
+  var locale;
+  var format;
+  var formatPrefix;
+
+  defaultLocale({
+    thousands: ",",
+    grouping: [3],
+    currency: ["$", ""]
+  });
+
+  function defaultLocale(definition) {
+    locale = formatLocale(definition);
+    format = locale.format;
+    formatPrefix = locale.formatPrefix;
+    return locale;
+  }
+
+  function precisionFixed(step) {
+    return Math.max(0, -exponent(Math.abs(step)));
+  }
+
+  function precisionPrefix(step, value) {
+    return Math.max(0, Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3 - exponent(Math.abs(step)));
+  }
+
+  function precisionRound(step, max) {
+    step = Math.abs(step), max = Math.abs(max) - step;
+    return Math.max(0, exponent(max) - exponent(step)) + 1;
+  }
+
+  function tickFormat(start, stop, count, specifier) {
+    var step = tickStep(start, stop, count),
+        precision;
+    specifier = formatSpecifier(specifier == null ? ",f" : specifier);
+    switch (specifier.type) {
+      case "s": {
+        var value = Math.max(Math.abs(start), Math.abs(stop));
+        if (specifier.precision == null && !isNaN(precision = precisionPrefix(step, value))) specifier.precision = precision;
+        return formatPrefix(specifier, value);
+      }
+      case "":
+      case "e":
+      case "g":
+      case "p":
+      case "r": {
+        if (specifier.precision == null && !isNaN(precision = precisionRound(step, Math.max(Math.abs(start), Math.abs(stop))))) specifier.precision = precision - (specifier.type === "e");
+        break;
+      }
+      case "f":
+      case "%": {
+        if (specifier.precision == null && !isNaN(precision = precisionFixed(step))) specifier.precision = precision - (specifier.type === "%") * 2;
+        break;
+      }
+    }
+    return format(specifier);
+  }
+
+  function linearish(scale) {
+    var domain = scale.domain;
+
+    scale.ticks = function(count) {
+      var d = domain();
+      return ticks(d[0], d[d.length - 1], count == null ? 10 : count);
+    };
+
+    scale.tickFormat = function(count, specifier) {
+      var d = domain();
+      return tickFormat(d[0], d[d.length - 1], count == null ? 10 : count, specifier);
+    };
+
+    scale.nice = function(count) {
+      if (count == null) count = 10;
+
+      var d = domain();
+      var i0 = 0;
+      var i1 = d.length - 1;
+      var start = d[i0];
+      var stop = d[i1];
+      var prestep;
+      var step;
+      var maxIter = 10;
+
+      if (stop < start) {
+        step = start, start = stop, stop = step;
+        step = i0, i0 = i1, i1 = step;
+      }
+      
+      while (maxIter-- > 0) {
+        step = tickIncrement(start, stop, count);
+        if (step === prestep) {
+          d[i0] = start;
+          d[i1] = stop;
+          return domain(d);
+        } else if (step > 0) {
+          start = Math.floor(start / step) * step;
+          stop = Math.ceil(stop / step) * step;
+        } else if (step < 0) {
+          start = Math.ceil(start * step) / step;
+          stop = Math.floor(stop * step) / step;
+        } else {
+          break;
+        }
+        prestep = step;
+      }
+
+      return scale;
+    };
+
+    return scale;
+  }
+
+  function linear() {
+    var scale = continuous();
+
+    scale.copy = function() {
+      return copy$1(scale, linear());
+    };
+
+    initRange.apply(scale, arguments);
+
+    return linearish(scale);
+  }
+
+  function transformer() {
+    var x0 = 0,
+        x1 = 1,
+        t0,
+        t1,
+        k10,
+        transform,
+        interpolator = identity$1,
+        clamp = false,
+        unknown;
+
+    function scale(x) {
+      return x == null || isNaN(x = +x) ? unknown : interpolator(k10 === 0 ? 0.5 : (x = (transform(x) - t0) * k10, clamp ? Math.max(0, Math.min(1, x)) : x));
+    }
+
+    scale.domain = function(_) {
+      return arguments.length ? ([x0, x1] = _, t0 = transform(x0 = +x0), t1 = transform(x1 = +x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0), scale) : [x0, x1];
+    };
+
+    scale.clamp = function(_) {
+      return arguments.length ? (clamp = !!_, scale) : clamp;
+    };
+
+    scale.interpolator = function(_) {
+      return arguments.length ? (interpolator = _, scale) : interpolator;
+    };
+
+    function range(interpolate) {
+      return function(_) {
+        var r0, r1;
+        return arguments.length ? ([r0, r1] = _, interpolator = interpolate(r0, r1), scale) : [interpolator(0), interpolator(1)];
+      };
+    }
+
+    scale.range = range(interpolate);
+
+    scale.rangeRound = range(interpolateRound);
+
+    scale.unknown = function(_) {
+      return arguments.length ? (unknown = _, scale) : unknown;
+    };
+
+    return function(t) {
+      transform = t, t0 = t(x0), t1 = t(x1), k10 = t0 === t1 ? 0 : 1 / (t1 - t0);
+      return scale;
+    };
+  }
+
+  function copy(source, target) {
+    return target
+        .domain(source.domain())
+        .interpolator(source.interpolator())
+        .clamp(source.clamp())
+        .unknown(source.unknown());
+  }
+
+  function sequential() {
+    var scale = linearish(transformer()(identity$1));
+
+    scale.copy = function() {
+      return copy(scale, sequential());
+    };
+
+    return initInterpolator.apply(scale, arguments);
+  }
+
+  const COLOR_BASE = "#cecece";
+
+  // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+  const rc = 0.2126;
+  const gc = 0.7152;
+  const bc = 0.0722;
+  // low-gamma adjust coefficient
+  const lowc = 1 / 12.92;
+  function adjustGamma(p) {
+      return Math.pow((p + 0.055) / 1.055, 2.4);
+  }
+  function relativeLuminance(o) {
+      const rsrgb = o.r / 255;
+      const gsrgb = o.g / 255;
+      const bsrgb = o.b / 255;
+      const r = rsrgb <= 0.03928 ? rsrgb * lowc : adjustGamma(rsrgb);
+      const g = gsrgb <= 0.03928 ? gsrgb * lowc : adjustGamma(gsrgb);
+      const b = bsrgb <= 0.03928 ? bsrgb * lowc : adjustGamma(bsrgb);
+      return r * rc + g * gc + b * bc;
+  }
+  const createRainbowColor = (root) => {
+      const colorParentMap = new Map();
+      colorParentMap.set(root, COLOR_BASE);
+      if (root.children != null) {
+          const colorScale = sequential([0, root.children.length], (n) => hsl(360 * n, 0.3, 0.85));
+          root.children.forEach((c, id) => {
+              colorParentMap.set(c, colorScale(id).toString());
+          });
+      }
+      const colorMap = new Map();
+      const lightScale = linear().domain([0, root.height]).range([0.9, 0.3]);
+      const getBackgroundColor = (node) => {
+          const parents = node.ancestors();
+          const colorStr = parents.length === 1
+              ? colorParentMap.get(parents[0])
+              : colorParentMap.get(parents[parents.length - 2]);
+          const hslColor = hsl(colorStr);
+          hslColor.l = lightScale(node.depth);
+          return hslColor;
+      };
+      return (node) => {
+          if (!colorMap.has(node)) {
+              const backgroundColor = getBackgroundColor(node);
+              const l = relativeLuminance(backgroundColor.rgb());
+              const fontColor = l > 0.19 ? "#000" : "#fff";
+              colorMap.set(node, {
+                  backgroundColor: backgroundColor.toString(),
+                  fontColor,
+              });
+          }
+          return colorMap.get(node);
+      };
+  };
+
+  const StaticContext = G({});
+  const drawChart = (parentNode, data, width, height) => {
+      const availableSizeProperties = getAvailableSizeOptions(data.options);
+      console.time("layout create");
+      const layout = treemap()
+          .size([width, height])
+          .paddingOuter(PADDING)
+          .paddingTop(TOP_PADDING)
+          .paddingInner(PADDING)
+          .round(true)
+          .tile(treemapResquarify);
+      console.timeEnd("layout create");
+      console.time("rawHierarchy create");
+      const rawHierarchy = hierarchy(data.tree);
+      console.timeEnd("rawHierarchy create");
+      const nodeSizesCache = new Map();
+      const nodeIdsCache = new Map();
+      const getModuleSize = (node, sizeKey) => { var _a, _b; return (_b = (_a = nodeSizesCache.get(node)) === null || _a === void 0 ? void 0 : _a[sizeKey]) !== null && _b !== void 0 ? _b : 0; };
+      console.time("rawHierarchy eachAfter cache");
+      rawHierarchy.eachAfter((node) => {
+          var _a;
+          const nodeData = node.data;
+          nodeIdsCache.set(nodeData, {
+              nodeUid: generateUniqueId("node"),
+              clipUid: generateUniqueId("clip"),
+          });
+          const sizes = { renderedLength: 0, gzipLength: 0, brotliLength: 0 };
+          if (isModuleTree(nodeData)) {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = nodeData.children.reduce((acc, child) => getModuleSize(child, sizeKey) + acc, 0);
+              }
+          }
+          else {
+              for (const sizeKey of availableSizeProperties) {
+                  sizes[sizeKey] = (_a = data.nodeParts[nodeData.uid][sizeKey]) !== null && _a !== void 0 ? _a : 0;
+              }
+          }
+          nodeSizesCache.set(nodeData, sizes);
+      });
+      console.timeEnd("rawHierarchy eachAfter cache");
+      const getModuleIds = (node) => nodeIdsCache.get(node);
+      console.time("color");
+      const getModuleColor = createRainbowColor(rawHierarchy);
+      console.timeEnd("color");
+      D(o$1(StaticContext.Provider, { value: {
+              data,
+              availableSizeProperties,
+              width,
+              height,
+              getModuleSize,
+              getModuleIds,
+              getModuleColor,
+              rawHierarchy,
+              layout,
+          }, children: o$1(Main, {}) }), parentNode);
+  };
+
+  exports.StaticContext = StaticContext;
+  exports.default = drawChart;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+  return exports;
+
+})({});
+
+  /*-->*/
+  </script>
+  <script>
+    /*<!--*/
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"metamask-sdk.js","children":[{"uid":"5277-3877","name":"\u0000commonjsHelpers.js"},{"name":"\u0000","children":[{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"eciesjs/dist","children":[{"uid":"5277-3879","name":"index.js?commonjs-exports"},{"name":"keys","children":[{"uid":"5277-3881","name":"index.js?commonjs-exports"},{"uid":"5277-3883","name":"PrivateKey.js?commonjs-exports"},{"uid":"5277-4001","name":"PublicKey.js?commonjs-exports"}]},{"uid":"5277-3993","name":"utils.js?commonjs-exports"},{"uid":"5277-3995","name":"consts.js?commonjs-exports"}]},{"name":"elliptic","children":[{"name":"lib","children":[{"uid":"5277-3889","name":"elliptic.js?commonjs-exports"},{"name":"elliptic","children":[{"uid":"5277-3893","name":"utils.js?commonjs-exports"},{"name":"curve/index.js?commonjs-exports","uid":"5277-3915"},{"uid":"5277-3931","name":"curves.js?commonjs-exports"}]}]},{"name":"node_modules/bn.js/lib/bn.js?commonjs-module","uid":"5277-3895"}]},{"name":"minimalistic-crypto-utils/lib/utils.js?commonjs-exports","uid":"5277-3905"},{"name":"brorand/index.js?commonjs-module","uid":"5277-3911"},{"name":"inherits/inherits_browser.js?commonjs-module","uid":"5277-3919"},{"name":"hash.js/lib","children":[{"uid":"5277-3933","name":"hash.js?commonjs-exports"},{"name":"hash","children":[{"uid":"5277-3935","name":"utils.js?commonjs-exports"},{"uid":"5277-3939","name":"common.js?commonjs-exports"},{"uid":"5277-3943","name":"sha.js?commonjs-exports"},{"name":"sha/common.js?commonjs-exports","uid":"5277-3945"},{"uid":"5277-3961","name":"ripemd.js?commonjs-exports"}]}]},{"name":"eventemitter2/lib/eventemitter2.js?commonjs-module","uid":"5277-4011"},{"name":"debug/src/browser.js?commonjs-module","uid":"5277-4041"},{"name":"cross-fetch/dist/react-native-ponyfill.js?commonjs-module","uid":"5277-4093"},{"name":"@metamask","children":[{"name":"providers/dist","children":[{"uid":"5277-4101","name":"index.js?commonjs-exports"},{"uid":"5277-4103","name":"BaseProvider.js?commonjs-exports"},{"uid":"5277-4161","name":"messages.js?commonjs-exports"},{"uid":"5277-4165","name":"utils.js?commonjs-exports"},{"name":"middleware/createRpcWarningMiddleware.js?commonjs-exports","uid":"5277-4167"},{"name":"extension-provider/createExternalExtensionProvider.js?commonjs-exports","uid":"5277-4175"},{"uid":"5277-4185","name":"MetaMaskInpageProvider.js?commonjs-exports"},{"uid":"5277-4187","name":"siteMetadata.js?commonjs-exports"},{"uid":"5277-4191","name":"StreamProvider.js?commonjs-exports"},{"uid":"5277-4281","name":"initializeInpageProvider.js?commonjs-exports"},{"uid":"5277-4283","name":"shimWeb3.js?commonjs-exports"}]},{"name":"safe-event-emitter/index.js?commonjs-exports","uid":"5277-4105"},{"name":"object-multiplex/dist","children":[{"uid":"5277-4193","name":"ObjectMultiplex.js?commonjs-exports"},{"uid":"5277-4245","name":"Substream.js?commonjs-exports"}]}]},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-4109","name":"index.js?commonjs-exports"},{"uid":"5277-4111","name":"classes.js?commonjs-exports"},{"uid":"5277-4117","name":"utils.js?commonjs-exports"},{"uid":"5277-4119","name":"error-constants.js?commonjs-exports"},{"uid":"5277-4125","name":"errors.js?commonjs-exports"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-4133","name":"index.js?commonjs-exports"},{"uid":"5277-4135","name":"idRemapMiddleware.js?commonjs-exports"},{"uid":"5277-4137","name":"getUniqueId.js?commonjs-exports"},{"uid":"5277-4143","name":"createAsyncMiddleware.js?commonjs-exports"},{"uid":"5277-4147","name":"createScaffoldMiddleware.js?commonjs-exports"},{"uid":"5277-4151","name":"JsonRpcEngine.js?commonjs-exports"},{"uid":"5277-4155","name":"mergeMiddleware.js?commonjs-exports"}]},{"name":"extension-port-stream/dist/index.js?commonjs-exports","uid":"5277-4177"},{"name":"detect-browser/index.js?commonjs-exports","uid":"5277-4181"},{"name":"readable-stream","children":[{"uid":"5277-4195","name":"readable-browser.js?commonjs-module"},{"name":"node_modules","children":[{"name":"safe-buffer/index.js?commonjs-module","uid":"5277-4205"},{"name":"string_decoder/lib/string_decoder.js?commonjs-exports","uid":"5277-4225"}]},{"name":"lib/internal/streams/BufferList.js?commonjs-module","uid":"5277-4213"}]},{"name":"process-nextick-args/index.js?commonjs-module","uid":"5277-4197"},{"name":"core-util-is/lib/util.js?commonjs-exports","uid":"5277-4209"},{"name":"once/once.js?commonjs-module","uid":"5277-4237"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-4255","name":"index.js?commonjs-exports"},{"uid":"5277-4257","name":"createEngineStream.js?commonjs-exports"},{"uid":"5277-4261","name":"createStreamMiddleware.js?commonjs-exports"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","uid":"5277-4263"}]},{"name":"bowser/es5.js?commonjs-module","uid":"5277-4399"},{"name":"react","children":[{"uid":"5277-4493","name":"index.js?commonjs-module"},{"name":"cjs","children":[{"uid":"5277-4495","name":"react.production.min.js?commonjs-exports"},{"uid":"5277-4499","name":"react.development.js?commonjs-module"}]}]},{"name":"react-i18next/node_modules/@babel/runtime/helpers/extends.js?commonjs-module","uid":"5277-4505"}]},{"name":"node_modules/cross-fetch/dist/react-native-ponyfill.js?commonjs-module","uid":"5277-4371"}]},{"name":"Volumes/FD/Projects/metamask/metamask-sdk/node_modules","children":[{"name":"futoin-hkdf/hkdf.js","uid":"5277-3885"},{"name":"eciesjs","children":[{"name":"node_modules/secp256k1","children":[{"name":"lib","children":[{"uid":"5277-3887","name":"index.js"},{"uid":"5277-3989","name":"elliptic.js"}]},{"uid":"5277-3991","name":"elliptic.js"}]},{"name":"dist","children":[{"uid":"5277-3997","name":"consts.js"},{"uid":"5277-3999","name":"utils.js"},{"name":"keys","children":[{"uid":"5277-4003","name":"PublicKey.js"},{"uid":"5277-4005","name":"PrivateKey.js"},{"uid":"5277-4007","name":"index.js"}]},{"uid":"5277-4009","name":"index.js"}]}]},{"name":"elliptic","children":[{"uid":"5277-3891","name":"package.json"},{"name":"node_modules/bn.js/lib/bn.js","uid":"5277-3901"},{"name":"lib","children":[{"name":"elliptic","children":[{"uid":"5277-3909","name":"utils.js"},{"name":"curve","children":[{"uid":"5277-3917","name":"base.js"},{"uid":"5277-3923","name":"short.js"},{"uid":"5277-3925","name":"mont.js"},{"uid":"5277-3927","name":"edwards.js"},{"uid":"5277-3929","name":"index.js"}]},{"name":"precomputed/secp256k1.js","uid":"5277-3969"},{"uid":"5277-3971","name":"curves.js"},{"name":"ec","children":[{"uid":"5277-3975","name":"key.js"},{"uid":"5277-3977","name":"signature.js"},{"uid":"5277-3979","name":"index.js"}]},{"name":"eddsa","children":[{"uid":"5277-3981","name":"key.js"},{"uid":"5277-3983","name":"signature.js"},{"uid":"5277-3985","name":"index.js"}]}]},{"uid":"5277-3987","name":"elliptic.js"}]}]},{"name":"minimalistic-assert/index.js","uid":"5277-3903"},{"name":"minimalistic-crypto-utils/lib/utils.js","uid":"5277-3907"},{"name":"brorand/index.js","uid":"5277-3913"},{"name":"inherits/inherits_browser.js","uid":"5277-3921"},{"name":"hash.js/lib","children":[{"name":"hash","children":[{"uid":"5277-3937","name":"utils.js"},{"uid":"5277-3941","name":"common.js"},{"name":"sha","children":[{"uid":"5277-3947","name":"common.js"},{"uid":"5277-3949","name":"1.js"},{"uid":"5277-3951","name":"256.js"},{"uid":"5277-3953","name":"224.js"},{"uid":"5277-3955","name":"512.js"},{"uid":"5277-3957","name":"384.js"}]},{"uid":"5277-3959","name":"sha.js"},{"uid":"5277-3963","name":"ripemd.js"},{"uid":"5277-3965","name":"hmac.js"}]},{"uid":"5277-3967","name":"hash.js"}]},{"name":"hmac-drbg/lib/hmac-drbg.js","uid":"5277-3973"},{"name":"eventemitter2/lib/eventemitter2.js","uid":"5277-4013"},{"name":"uuid/dist/esm-browser","children":[{"uid":"5277-4015","name":"rng.js"},{"uid":"5277-4017","name":"regex.js"},{"uid":"5277-4019","name":"validate.js"},{"uid":"5277-4021","name":"stringify.js"},{"uid":"5277-4023","name":"v4.js"}]},{"name":"engine.io-parser/build/esm","children":[{"uid":"5277-4025","name":"commons.js"},{"uid":"5277-4027","name":"encodePacket.browser.js"},{"name":"contrib/base64-arraybuffer.js","uid":"5277-4029"},{"uid":"5277-4031","name":"decodePacket.browser.js"},{"uid":"5277-4033","name":"index.js"}]},{"name":"@socket.io/component-emitter/index.js","uid":"5277-4035"},{"name":"engine.io-client/build/esm-debug","children":[{"uid":"5277-4037","name":"globalThis.browser.js"},{"uid":"5277-4039","name":"util.js"},{"name":"contrib","children":[{"uid":"5277-4049","name":"parseqs.js"},{"uid":"5277-4053","name":"yeast.js"},{"uid":"5277-4055","name":"has-cors.js"},{"uid":"5277-4069","name":"parseuri.js"}]},{"uid":"5277-4051","name":"transport.js"},{"name":"transports","children":[{"uid":"5277-4057","name":"xmlhttprequest.browser.js"},{"uid":"5277-4059","name":"polling.js"},{"uid":"5277-4061","name":"websocket-constructor.browser.js"},{"uid":"5277-4063","name":"websocket.js"},{"uid":"5277-4065","name":"webtransport.js"},{"uid":"5277-4067","name":"index.js"}]},{"uid":"5277-4071","name":"socket.js"},{"uid":"5277-4073","name":"index.js"}]},{"name":"debug","children":[{"name":"node_modules/ms/index.js","uid":"5277-4043"},{"name":"src","children":[{"uid":"5277-4045","name":"common.js"},{"uid":"5277-4047","name":"browser.js"}]}]},{"name":"socket.io-client/build/esm-debug","children":[{"uid":"5277-4075","name":"url.js"},{"uid":"5277-4083","name":"on.js"},{"uid":"5277-4085","name":"socket.js"},{"name":"contrib/backo2.js","uid":"5277-4087"},{"uid":"5277-4089","name":"manager.js"},{"uid":"5277-4091","name":"index.js"}]},{"name":"socket.io-parser/build/esm-debug","children":[{"uid":"5277-4077","name":"is-binary.js"},{"uid":"5277-4079","name":"binary.js"},{"uid":"5277-4081","name":"index.js"}]},{"name":"cross-fetch/dist/react-native-ponyfill.js","uid":"5277-4095"},{"name":"@metamask","children":[{"name":"safe-event-emitter/index.js","uid":"5277-4107"},{"name":"providers","children":[{"name":"node_modules/fast-deep-equal/index.js","uid":"5277-4131"},{"name":"dist","children":[{"uid":"5277-4163","name":"messages.js"},{"name":"middleware/createRpcWarningMiddleware.js","uid":"5277-4169"},{"uid":"5277-4171","name":"utils.js"},{"uid":"5277-4173","name":"BaseProvider.js"},{"uid":"5277-4189","name":"siteMetadata.js"},{"uid":"5277-4273","name":"StreamProvider.js"},{"uid":"5277-4275","name":"MetaMaskInpageProvider.js"},{"name":"extension-provider","children":[{"uid":"5277-4277","name":"external-extension-config.json"},{"uid":"5277-4279","name":"createExternalExtensionProvider.js"}]},{"uid":"5277-4285","name":"shimWeb3.js"},{"uid":"5277-4287","name":"initializeInpageProvider.js"},{"uid":"5277-4289","name":"index.js"}]}]},{"name":"object-multiplex/dist","children":[{"uid":"5277-4247","name":"Substream.js"},{"uid":"5277-4249","name":"ObjectMultiplex.js"},{"uid":"5277-4251","name":"index.js"}]},{"name":"onboarding/dist/metamask-onboarding.cjs.js","uid":"5277-4431"}]},{"name":"fast-safe-stringify/index.js","uid":"5277-4113"},{"name":"eth-rpc-errors/dist","children":[{"uid":"5277-4115","name":"classes.js"},{"uid":"5277-4121","name":"error-constants.js"},{"uid":"5277-4123","name":"utils.js"},{"uid":"5277-4127","name":"errors.js"},{"uid":"5277-4129","name":"index.js"}]},{"name":"json-rpc-engine/dist","children":[{"uid":"5277-4139","name":"getUniqueId.js"},{"uid":"5277-4141","name":"idRemapMiddleware.js"},{"uid":"5277-4145","name":"createAsyncMiddleware.js"},{"uid":"5277-4149","name":"createScaffoldMiddleware.js"},{"uid":"5277-4153","name":"JsonRpcEngine.js"},{"uid":"5277-4157","name":"mergeMiddleware.js"},{"uid":"5277-4159","name":"index.js"}]},{"name":"extension-port-stream/dist/index.js","uid":"5277-4179"},{"name":"detect-browser/index.js","uid":"5277-4183"},{"name":"process-nextick-args/index.js","uid":"5277-4199"},{"name":"readable-stream","children":[{"name":"node_modules","children":[{"name":"isarray/index.js","uid":"5277-4201"},{"name":"safe-buffer/index.js","uid":"5277-4207"},{"name":"string_decoder/lib/string_decoder.js","uid":"5277-4227"}]},{"name":"lib","children":[{"name":"internal/streams","children":[{"uid":"5277-4203","name":"stream-browser.js"},{"uid":"5277-4215","name":"BufferList.js"},{"uid":"5277-4217","name":"destroy.js"}]},{"uid":"5277-4221","name":"_stream_writable.js"},{"uid":"5277-4223","name":"_stream_duplex.js"},{"uid":"5277-4229","name":"_stream_readable.js"},{"uid":"5277-4231","name":"_stream_transform.js"},{"uid":"5277-4233","name":"_stream_passthrough.js"}]},{"uid":"5277-4235","name":"readable-browser.js"}]},{"name":"core-util-is/lib/util.js","uid":"5277-4211"},{"name":"util-deprecate/browser.js","uid":"5277-4219"},{"name":"wrappy/wrappy.js","uid":"5277-4239"},{"name":"once/once.js","uid":"5277-4241"},{"name":"end-of-stream/index.js","uid":"5277-4243"},{"name":"is-stream/index.js","uid":"5277-4253"},{"name":"json-rpc-middleware-stream","children":[{"name":"dist","children":[{"uid":"5277-4259","name":"createEngineStream.js"},{"uid":"5277-4267","name":"createStreamMiddleware.js"},{"uid":"5277-4269","name":"index.js"}]},{"name":"node_modules/@metamask/safe-event-emitter/index.js","uid":"5277-4265"}]},{"name":"pump/index.js","uid":"5277-4271"},{"name":"i18next","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-4301","name":"typeof.js"},{"uid":"5277-4303","name":"classCallCheck.js"},{"uid":"5277-4305","name":"toPrimitive.js"},{"uid":"5277-4307","name":"toPropertyKey.js"},{"uid":"5277-4309","name":"createClass.js"},{"uid":"5277-4311","name":"assertThisInitialized.js"},{"uid":"5277-4313","name":"setPrototypeOf.js"},{"uid":"5277-4315","name":"inherits.js"},{"uid":"5277-4317","name":"possibleConstructorReturn.js"},{"uid":"5277-4319","name":"getPrototypeOf.js"},{"uid":"5277-4321","name":"defineProperty.js"},{"uid":"5277-4323","name":"arrayWithHoles.js"},{"uid":"5277-4325","name":"iterableToArray.js"},{"uid":"5277-4327","name":"arrayLikeToArray.js"},{"uid":"5277-4329","name":"unsupportedIterableToArray.js"},{"uid":"5277-4331","name":"nonIterableRest.js"},{"uid":"5277-4333","name":"toArray.js"}]},{"name":"dist/esm/i18next.js","uid":"5277-4335"}]},{"name":"bowser/es5.js","uid":"5277-4401"},{"name":"i18next-browser-languagedetector","children":[{"name":"node_modules/@babel/runtime/helpers/esm","children":[{"uid":"5277-4481","name":"classCallCheck.js"},{"uid":"5277-4483","name":"typeof.js"},{"uid":"5277-4485","name":"toPrimitive.js"},{"uid":"5277-4487","name":"toPropertyKey.js"},{"uid":"5277-4489","name":"createClass.js"}]},{"name":"dist/esm/i18nextBrowserLanguageDetector.js","uid":"5277-4491"}]},{"name":"react","children":[{"name":"cjs","children":[{"uid":"5277-4497","name":"react.production.min.js"},{"uid":"5277-4501","name":"react.development.js"}]},{"uid":"5277-4503","name":"index.js"}]},{"name":"react-i18next","children":[{"name":"node_modules/@babel/runtime/helpers/extends.js","uid":"5277-4507"},{"name":"dist/es","children":[{"uid":"5277-4513","name":"unescape.js"},{"uid":"5277-4515","name":"defaults.js"},{"uid":"5277-4517","name":"initReactI18next.js"},{"uid":"5277-4519","name":"context.js"}]}]},{"name":"void-elements/index.js","uid":"5277-4509"},{"name":"html-parse-stringify/dist/html-parse-stringify.js","uid":"5277-4511"}]},{"uid":"5277-3897","name":"\u0000node-resolve:empty.js"},{"uid":"5277-3899","name":"\u0000\u0000node-resolve:empty.js?commonjs-proxy"},{"name":"-communication-layer/dist/react-native/es/metamask-sdk-communication-layer.js","uid":"5277-4097"},{"uid":"5277-4099","name":"\u0000tslib.js"},{"name":"src","children":[{"name":"services","children":[{"name":"SDKProvider","children":[{"name":"ChainManager/handleChainChanged.ts","uid":"5277-4291"},{"name":"ConnectionManager/handleDisconnect.ts","uid":"5277-4293"},{"name":"InitializationManager","children":[{"uid":"5277-4295","name":"initializeState.ts"},{"uid":"5277-4297","name":"initializeStateAsync.ts"}]}]},{"name":"MetaMaskSDK","children":[{"name":"ConnectionManager","children":[{"uid":"5277-4337","name":"connect.ts"},{"uid":"5277-4339","name":"resume.ts"},{"uid":"5277-4345","name":"terminate.ts"},{"uid":"5277-4541","name":"connectAndSign.ts"}]},{"name":"ProviderManager/connectWithExtensionProvider.ts","uid":"5277-4347"},{"name":"InitializerManager","children":[{"uid":"5277-4351","name":"handleAutoAndExtensionConnections.ts"},{"uid":"5277-4353","name":"initEventListeners.ts"},{"uid":"5277-4381","name":"initializeProviderAndEventListeners.ts"},{"uid":"5277-4383","name":"setupAnalytics.ts"},{"uid":"5277-4389","name":"setupDappMetadata.ts"},{"uid":"5277-4397","name":"setupExtensionPreferences.ts"},{"uid":"5277-4425","name":"setupPlatformManager.ts"},{"uid":"5277-4469","name":"setupRemoteConnectionAndInstaller.ts"},{"uid":"5277-4475","name":"setupStorage.ts"},{"uid":"5277-4477","name":"setupInfuraProvider.ts"},{"uid":"5277-4479","name":"setupReadOnlyRPCProviders.ts"},{"uid":"5277-4535","name":"initializeI18next.ts"},{"uid":"5277-4537","name":"performSDKInitialization.ts"},{"uid":"5277-4539","name":"initializeMetaMaskSDK.ts"}]}]},{"uid":"5277-4349","name":"Analytics.ts"},{"name":"RemoteCommunicationPostMessageStream","children":[{"uid":"5277-4357","name":"onMessage.ts"},{"uid":"5277-4361","name":"extractMethod.ts"},{"uid":"5277-4363","name":"write.ts"}]},{"uid":"5277-4359","name":"Ethereum.ts"},{"name":"rpc-requests/RPCRequestHandler.ts","uid":"5277-4375"},{"name":"PlatfformManager","children":[{"uid":"5277-4405","name":"disableWakeLock.ts"},{"uid":"5277-4407","name":"enableWakeLock.ts"},{"uid":"5277-4409","name":"getPlatformType.ts"},{"uid":"5277-4411","name":"isMetaMaskInstalled.ts"},{"uid":"5277-4413","name":"openDeeplink.ts"}]},{"name":"MetaMaskInstaller","children":[{"uid":"5277-4427","name":"checkInstallation.ts"},{"uid":"5277-4429","name":"redirectToProperInstall.ts"},{"uid":"5277-4433","name":"startDesktopOnboarding.ts"},{"uid":"5277-4435","name":"startInstaller.ts"}]},{"name":"RemoteConnection","children":[{"name":"ConnectionInitializer/initializeConnector.ts","uid":"5277-4447"},{"name":"ConnectionManager","children":[{"uid":"5277-4449","name":"connectWithDeeplink.ts"},{"uid":"5277-4453","name":"connectWithModalInstaller.ts"},{"uid":"5277-4461","name":"startConnection.ts"}]},{"name":"ModalManager","children":[{"uid":"5277-4451","name":"showInstallModal.ts"},{"uid":"5277-4455","name":"onOTPModalDisconnect.ts"},{"uid":"5277-4457","name":"waitForOTPAnswer.ts"},{"uid":"5277-4459","name":"reconnectWithModalOTP.ts"},{"uid":"5277-4465","name":"showActiveModal.ts"}]},{"name":"EventListeners/setupListeners.ts","uid":"5277-4463"},{"uid":"5277-4467","name":"RemoteConnection.ts"}]}]},{"name":"provider","children":[{"uid":"5277-4299","name":"SDKProvider.ts"},{"uid":"5277-4379","name":"initializeMobileProvider.ts"},{"uid":"5277-4391","name":"wrapExtensionProvider.ts"}]},{"uid":"5277-4341","name":"config.ts"},{"name":"types","children":[{"uid":"5277-4343","name":"ProviderUpdateType.ts"},{"uid":"5277-4403","name":"WakeLockStatus.ts"}]},{"uid":"5277-4355","name":"constants.ts"},{"name":"PostMessageStream","children":[{"uid":"5277-4365","name":"RemoteCommunicationPostMessageStream.ts"},{"uid":"5277-4367","name":"getPostMessageStream.ts"}]},{"name":"utils","children":[{"uid":"5277-4369","name":"wait.ts"},{"uid":"5277-4385","name":"extractFavicon.ts"},{"uid":"5277-4387","name":"getBase64FromUrl.ts"},{"uid":"5277-4393","name":"eip6963RequestProvider.ts"},{"uid":"5277-4395","name":"get-browser-extension.ts"},{"uid":"5277-4415","name":"hasNativeWakeLockSupport.ts"},{"uid":"5277-4417","name":"isOldIOS.ts"}]},{"name":"Platform","children":[{"uid":"5277-4419","name":"Media.ts"},{"uid":"5277-4421","name":"WakeLockManager.ts"},{"uid":"5277-4423","name":"PlatfformManager.ts"},{"uid":"5277-4437","name":"MetaMaskInstaller.ts"}]},{"name":"ui/InstallModal","children":[{"uid":"5277-4439","name":"InstallModal-nonweb.ts"},{"uid":"5277-4441","name":"installModal.ts"},{"uid":"5277-4443","name":"pendingModal-nodejs.ts"},{"uid":"5277-4445","name":"pendingModal.ts"}]},{"name":"storage-manager","children":[{"uid":"5277-4471","name":"StorageManagerAS.ts"},{"uid":"5277-4473","name":"getStorageManager.ts"}]},{"name":"locales","children":[{"uid":"5277-4521","name":"en.json"},{"uid":"5277-4523","name":"es.json"},{"uid":"5277-4525","name":"fr.json"},{"uid":"5277-4527","name":"he.json"},{"uid":"5277-4529","name":"it.json"},{"uid":"5277-4531","name":"pt.json"},{"uid":"5277-4533","name":"tr.json"}]},{"uid":"5277-4543","name":"sdk.ts"},{"uid":"5277-4545","name":"index.ts"}]},{"name":"node_modules/cross-fetch/dist/react-native-ponyfill.js","uid":"5277-4373"},{"uid":"5277-4377","name":"package.json"}]}],"isRoot":true},"nodeParts":{"5277-3877":{"renderedLength":943,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3876"},"5277-3879":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3878"},"5277-3881":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3880"},"5277-3883":{"renderedLength":22,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3882"},"5277-3885":{"renderedLength":5310,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3884"},"5277-3887":{"renderedLength":10597,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3886"},"5277-3889":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3888"},"5277-3891":{"renderedLength":1614,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3890"},"5277-3893":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3892"},"5277-3895":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3894"},"5277-3897":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3896"},"5277-3899":{"renderedLength":74,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3898"},"5277-3901":{"renderedLength":90650,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3900"},"5277-3903":{"renderedLength":265,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3902"},"5277-3905":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3904"},"5277-3907":{"renderedLength":1214,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3906"},"5277-3909":{"renderedLength":2436,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3908"},"5277-3911":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3910"},"5277-3913":{"renderedLength":1557,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3912"},"5277-3915":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3914"},"5277-3917":{"renderedLength":9190,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3916"},"5277-3919":{"renderedLength":37,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3918"},"5277-3921":{"renderedLength":837,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3920"},"5277-3923":{"renderedLength":23034,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3922"},"5277-3925":{"renderedLength":4603,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3924"},"5277-3927":{"renderedLength":10895,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3926"},"5277-3929":{"renderedLength":146,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3928"},"5277-3931":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3930"},"5277-3933":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3932"},"5277-3935":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3934"},"5277-3937":{"renderedLength":6579,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3936"},"5277-3939":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3938"},"5277-3941":{"renderedLength":2294,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3940"},"5277-3943":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3942"},"5277-3945":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3944"},"5277-3947":{"renderedLength":923,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3946"},"5277-3949":{"renderedLength":1560,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3948"},"5277-3951":{"renderedLength":2887,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3950"},"5277-3953":{"renderedLength":631,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3952"},"5277-3955":{"renderedLength":8344,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3954"},"5277-3957":{"renderedLength":730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3956"},"5277-3959":{"renderedLength":90,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3958"},"5277-3961":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3960"},"5277-3963":{"renderedLength":3546,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3962"},"5277-3965":{"renderedLength":1102,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3964"},"5277-3967":{"renderedLength":406,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3966"},"5277-3969":{"renderedLength":33475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3968"},"5277-3971":{"renderedLength":6619,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3970"},"5277-3973":{"renderedLength":2961,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3972"},"5277-3975":{"renderedLength":3127,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3974"},"5277-3977":{"renderedLength":3259,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3976"},"5277-3979":{"renderedLength":6233,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3978"},"5277-3981":{"renderedLength":2537,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3980"},"5277-3983":{"renderedLength":1705,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3982"},"5277-3985":{"renderedLength":3428,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3984"},"5277-3987":{"renderedLength":281,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3986"},"5277-3989":{"renderedLength":10888,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3988"},"5277-3991":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3990"},"5277-3993":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3992"},"5277-3995":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3994"},"5277-3997":{"renderedLength":475,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3996"},"5277-3999":{"renderedLength":1810,"gzipLength":0,"brotliLength":0,"metaUid":"5277-3998"},"5277-4001":{"renderedLength":21,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4000"},"5277-4003":{"renderedLength":1756,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4002"},"5277-4005":{"renderedLength":1629,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4004"},"5277-4007":{"renderedLength":647,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4006"},"5277-4009":{"renderedLength":1704,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4008"},"5277-4011":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4010"},"5277-4013":{"renderedLength":45902,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4012"},"5277-4015":{"renderedLength":1025,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4014"},"5277-4017":{"renderedLength":130,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4016"},"5277-4019":{"renderedLength":82,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4018"},"5277-4021":{"renderedLength":1408,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4020"},"5277-4023":{"renderedLength":457,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4022"},"5277-4025":{"renderedLength":478,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4024"},"5277-4027":{"renderedLength":2237,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4026"},"5277-4029":{"renderedLength":1219,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4028"},"5277-4031":{"renderedLength":1797,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4030"},"5277-4033":{"renderedLength":1594,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4032"},"5277-4035":{"renderedLength":3359,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4034"},"5277-4037":{"renderedLength":237,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4036"},"5277-4039":{"renderedLength":1599,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4038"},"5277-4041":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4040"},"5277-4043":{"renderedLength":3275,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4042"},"5277-4045":{"renderedLength":6281,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4044"},"5277-4047":{"renderedLength":6417,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4046"},"5277-4049":{"renderedLength":798,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4048"},"5277-4051":{"renderedLength":3446,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4050"},"5277-4053":{"renderedLength":922,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4052"},"5277-4055":{"renderedLength":316,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4054"},"5277-4057":{"renderedLength":507,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4056"},"5277-4059":{"renderedLength":11772,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4058"},"5277-4061":{"renderedLength":450,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4060"},"5277-4063":{"renderedLength":4526,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4062"},"5277-4065":{"renderedLength":3630,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4064"},"5277-4067":{"renderedLength":86,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4066"},"5277-4069":{"renderedLength":2438,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4068"},"5277-4071":{"renderedLength":20990,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4070"},"5277-4073":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4072"},"5277-4075":{"renderedLength":1820,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4074"},"5277-4077":{"renderedLength":1567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4076"},"5277-4079":{"renderedLength":2685,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4078"},"5277-4081":{"renderedLength":9979,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4080"},"5277-4083":{"renderedLength":115,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4082"},"5277-4085":{"renderedLength":24986,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4084"},"5277-4087":{"renderedLength":1376,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4086"},"5277-4089":{"renderedLength":10876,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4088"},"5277-4091":{"renderedLength":1272,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4090"},"5277-4093":{"renderedLength":42,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4092"},"5277-4095":{"renderedLength":659,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4094"},"5277-4097":{"renderedLength":44120,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4096"},"5277-4099":{"renderedLength":2755,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4098"},"5277-4101":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4100"},"5277-4103":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4102"},"5277-4105":{"renderedLength":28,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4104"},"5277-4107":{"renderedLength":2124,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4106"},"5277-4109":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4108"},"5277-4111":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4110"},"5277-4113":{"renderedLength":5882,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4112"},"5277-4115":{"renderedLength":2294,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4114"},"5277-4117":{"renderedLength":17,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4116"},"5277-4119":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4118"},"5277-4121":{"renderedLength":2564,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4120"},"5277-4123":{"renderedLength":4140,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4122"},"5277-4125":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4124"},"5277-4127":{"renderedLength":5728,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4126"},"5277-4129":{"renderedLength":1165,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4128"},"5277-4131":{"renderedLength":1284,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4130"},"5277-4133":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4132"},"5277-4135":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4134"},"5277-4137":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4136"},"5277-4139":{"renderedLength":389,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4138"},"5277-4141":{"renderedLength":572,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4140"},"5277-4143":{"renderedLength":33,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4142"},"5277-4145":{"renderedLength":2629,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4144"},"5277-4147":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4146"},"5277-4149":{"renderedLength":730,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4148"},"5277-4151":{"renderedLength":25,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4150"},"5277-4153":{"renderedLength":9544,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4152"},"5277-4155":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4154"},"5277-4157":{"renderedLength":416,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4156"},"5277-4159":{"renderedLength":929,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4158"},"5277-4161":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4160"},"5277-4163":{"renderedLength":3481,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4162"},"5277-4165":{"renderedLength":15,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4164"},"5277-4167":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4166"},"5277-4169":{"renderedLength":1401,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4168"},"5277-4171":{"renderedLength":3138,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4170"},"5277-4173":{"renderedLength":12503,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4172"},"5277-4175":{"renderedLength":43,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4174"},"5277-4177":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4176"},"5277-4179":{"renderedLength":2370,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4178"},"5277-4181":{"renderedLength":23,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4180"},"5277-4183":{"renderedLength":8458,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4182"},"5277-4185":{"renderedLength":32,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4184"},"5277-4187":{"renderedLength":22,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4186"},"5277-4189":{"renderedLength":2663,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4188"},"5277-4191":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4190"},"5277-4193":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4192"},"5277-4195":{"renderedLength":36,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4194"},"5277-4197":{"renderedLength":39,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4196"},"5277-4199":{"renderedLength":1152,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4198"},"5277-4201":{"renderedLength":128,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4200"},"5277-4203":{"renderedLength":46,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4202"},"5277-4205":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4204"},"5277-4207":{"renderedLength":1706,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4206"},"5277-4209":{"renderedLength":16,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4208"},"5277-4211":{"renderedLength":3018,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4210"},"5277-4213":{"renderedLength":31,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4212"},"5277-4215":{"renderedLength":2327,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4214"},"5277-4217":{"renderedLength":2153,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4216"},"5277-4219":{"renderedLength":1627,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4218"},"5277-4221":{"renderedLength":19543,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4220"},"5277-4223":{"renderedLength":2900,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4222"},"5277-4225":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4224"},"5277-4227":{"renderedLength":8747,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4226"},"5277-4229":{"renderedLength":31221,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4228"},"5277-4231":{"renderedLength":4260,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4230"},"5277-4233":{"renderedLength":458,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4232"},"5277-4235":{"renderedLength":417,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4234"},"5277-4237":{"renderedLength":27,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4236"},"5277-4239":{"renderedLength":917,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4238"},"5277-4241":{"renderedLength":984,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4240"},"5277-4243":{"renderedLength":2692,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4242"},"5277-4245":{"renderedLength":21,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4244"},"5277-4247":{"renderedLength":928,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4246"},"5277-4249":{"renderedLength":3126,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4248"},"5277-4251":{"renderedLength":92,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4250"},"5277-4253":{"renderedLength":661,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4252"},"5277-4255":{"renderedLength":14,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4254"},"5277-4257":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4256"},"5277-4259":{"renderedLength":1187,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4258"},"5277-4261":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4260"},"5277-4263":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4262"},"5277-4265":{"renderedLength":2078,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4264"},"5277-4267":{"renderedLength":3933,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4266"},"5277-4269":{"renderedLength":552,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4268"},"5277-4271":{"renderedLength":2248,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4270"},"5277-4273":{"renderedLength":6959,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4272"},"5277-4275":{"renderedLength":11887,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4274"},"5277-4277":{"renderedLength":165,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4276"},"5277-4279":{"renderedLength":2053,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4278"},"5277-4281":{"renderedLength":34,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4280"},"5277-4283":{"renderedLength":20,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4282"},"5277-4285":{"renderedLength":2567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4284"},"5277-4287":{"renderedLength":2141,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4286"},"5277-4289":{"renderedLength":1874,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4288"},"5277-4291":{"renderedLength":1852,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4290"},"5277-4293":{"renderedLength":2372,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4292"},"5277-4295":{"renderedLength":1080,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4294"},"5277-4297":{"renderedLength":4108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4296"},"5277-4299":{"renderedLength":2178,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4298"},"5277-4301":{"renderedLength":341,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4300"},"5277-4303":{"renderedLength":163,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4302"},"5277-4305":{"renderedLength":409,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4304"},"5277-4307":{"renderedLength":135,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4306"},"5277-4309":{"renderedLength":667,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4308"},"5277-4311":{"renderedLength":176,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4310"},"5277-4313":{"renderedLength":214,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4312"},"5277-4315":{"renderedLength":500,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4314"},"5277-4317":{"renderedLength":306,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4316"},"5277-4319":{"renderedLength":222,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4318"},"5277-4321":{"renderedLength":284,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4320"},"5277-4323":{"renderedLength":71,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4322"},"5277-4325":{"renderedLength":160,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4324"},"5277-4327":{"renderedLength":185,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4326"},"5277-4329":{"renderedLength":428,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4328"},"5277-4331":{"renderedLength":195,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4330"},"5277-4333":{"renderedLength":140,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4332"},"5277-4335":{"renderedLength":104975,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4334"},"5277-4337":{"renderedLength":1218,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4336"},"5277-4339":{"renderedLength":1090,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4338"},"5277-4341":{"renderedLength":876,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4340"},"5277-4343":{"renderedLength":285,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4342"},"5277-4345":{"renderedLength":2009,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4344"},"5277-4347":{"renderedLength":2420,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4346"},"5277-4349":{"renderedLength":1537,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4348"},"5277-4351":{"renderedLength":3108,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4350"},"5277-4353":{"renderedLength":1031,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4352"},"5277-4355":{"renderedLength":726,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4354"},"5277-4357":{"renderedLength":1260,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4356"},"5277-4359":{"renderedLength":2490,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4358"},"5277-4361":{"renderedLength":442,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4360"},"5277-4363":{"renderedLength":5525,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4362"},"5277-4365":{"renderedLength":1124,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4364"},"5277-4367":{"renderedLength":628,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4366"},"5277-4369":{"renderedLength":151,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4368"},"5277-4371":{"renderedLength":40,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4370"},"5277-4373":{"renderedLength":650,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4372"},"5277-4375":{"renderedLength":1226,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4374"},"5277-4377":{"renderedLength":4726,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4376"},"5277-4379":{"renderedLength":12034,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4378"},"5277-4381":{"renderedLength":1420,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4380"},"5277-4383":{"renderedLength":1299,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4382"},"5277-4385":{"renderedLength":529,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4384"},"5277-4387":{"renderedLength":418,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4386"},"5277-4389":{"renderedLength":1340,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4388"},"5277-4391":{"renderedLength":1458,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4390"},"5277-4393":{"renderedLength":1159,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4392"},"5277-4395":{"renderedLength":1746,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4394"},"5277-4397":{"renderedLength":3273,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4396"},"5277-4399":{"renderedLength":24,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4398"},"5277-4401":{"renderedLength":25967,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4400"},"5277-4403":{"renderedLength":245,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4402"},"5277-4405":{"renderedLength":288,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4404"},"5277-4407":{"renderedLength":830,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4406"},"5277-4409":{"renderedLength":483,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4408"},"5277-4411":{"renderedLength":557,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4410"},"5277-4413":{"renderedLength":1143,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4412"},"5277-4415":{"renderedLength":96,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4414"},"5277-4417":{"renderedLength":461,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4416"},"5277-4419":{"renderedLength":12518,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4418"},"5277-4421":{"renderedLength":6127,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4420"},"5277-4423":{"renderedLength":3329,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4422"},"5277-4425":{"renderedLength":1100,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4424"},"5277-4427":{"renderedLength":1210,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4426"},"5277-4429":{"renderedLength":2624,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4428"},"5277-4431":{"renderedLength":11607,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4430"},"5277-4433":{"renderedLength":980,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4432"},"5277-4435":{"renderedLength":1278,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4434"},"5277-4437":{"renderedLength":1179,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4436"},"5277-4439":{"renderedLength":138,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4438"},"5277-4441":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4440"},"5277-4443":{"renderedLength":487,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4442"},"5277-4445":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4444"},"5277-4447":{"renderedLength":1726,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4446"},"5277-4449":{"renderedLength":838,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4448"},"5277-4451":{"renderedLength":1033,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4450"},"5277-4453":{"renderedLength":2051,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4452"},"5277-4455":{"renderedLength":320,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4454"},"5277-4457":{"renderedLength":272,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4456"},"5277-4459":{"renderedLength":2862,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4458"},"5277-4461":{"renderedLength":2567,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4460"},"5277-4463":{"renderedLength":6482,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4462"},"5277-4465":{"renderedLength":803,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4464"},"5277-4467":{"renderedLength":3821,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4466"},"5277-4469":{"renderedLength":3010,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4468"},"5277-4471":{"renderedLength":2090,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4470"},"5277-4473":{"renderedLength":564,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4472"},"5277-4475":{"renderedLength":1088,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4474"},"5277-4477":{"renderedLength":3835,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4476"},"5277-4479":{"renderedLength":524,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4478"},"5277-4481":{"renderedLength":161,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4480"},"5277-4483":{"renderedLength":335,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4482"},"5277-4485":{"renderedLength":403,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4484"},"5277-4487":{"renderedLength":129,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4486"},"5277-4489":{"renderedLength":657,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4488"},"5277-4491":{"renderedLength":12139,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4490"},"5277-4493":{"renderedLength":26,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4492"},"5277-4495":{"renderedLength":30,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4494"},"5277-4497":{"renderedLength":7617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4496"},"5277-4499":{"renderedLength":38,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4498"},"5277-4501":{"renderedLength":92422,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4500"},"5277-4503":{"renderedLength":185,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4502"},"5277-4505":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4504"},"5277-4507":{"renderedLength":653,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4506"},"5277-4509":{"renderedLength":339,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4508"},"5277-4511":{"renderedLength":70,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4510"},"5277-4513":{"renderedLength":613,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4512"},"5277-4515":{"renderedLength":435,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4514"},"5277-4517":{"renderedLength":113,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4516"},"5277-4519":{"renderedLength":29,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4518"},"5277-4521":{"renderedLength":1706,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4520"},"5277-4523":{"renderedLength":1903,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4522"},"5277-4525":{"renderedLength":1936,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4524"},"5277-4527":{"renderedLength":2219,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4526"},"5277-4529":{"renderedLength":1881,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4528"},"5277-4531":{"renderedLength":1825,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4530"},"5277-4533":{"renderedLength":1814,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4532"},"5277-4535":{"renderedLength":2617,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4534"},"5277-4537":{"renderedLength":3309,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4536"},"5277-4539":{"renderedLength":1487,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4538"},"5277-4541":{"renderedLength":1256,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4540"},"5277-4543":{"renderedLength":5859,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4542"},"5277-4545":{"renderedLength":0,"gzipLength":0,"brotliLength":0,"metaUid":"5277-4544"}},"nodeMetas":{"5277-3876":{"id":"\u0000commonjsHelpers.js","moduleParts":{"metamask-sdk.js":"5277-3877"},"imported":[],"importedBy":[{"uid":"5277-4008"},{"uid":"5277-4012"},{"uid":"5277-4094"},{"uid":"5277-4288"},{"uid":"5277-4046"},{"uid":"5277-4128"},{"uid":"5277-4006"},{"uid":"5277-3998"},{"uid":"5277-3996"},{"uid":"5277-4034"},{"uid":"5277-4172"},{"uid":"5277-4278"},{"uid":"5277-4286"},{"uid":"5277-4274"},{"uid":"5277-4284"},{"uid":"5277-4272"},{"uid":"5277-4044"},{"uid":"5277-4114"},{"uid":"5277-4122"},{"uid":"5277-4126"},{"uid":"5277-4120"},{"uid":"5277-4400"},{"uid":"5277-4004"},{"uid":"5277-4002"},{"uid":"5277-3990"},{"uid":"5277-4042"},{"uid":"5277-4106"},{"uid":"5277-4130"},{"uid":"5277-4158"},{"uid":"5277-4162"},{"uid":"5277-4170"},{"uid":"5277-4178"},{"uid":"5277-4182"},{"uid":"5277-4188"},{"uid":"5277-4250"},{"uid":"5277-4252"},{"uid":"5277-4268"},{"uid":"5277-4270"},{"uid":"5277-4372"},{"uid":"5277-4430"},{"uid":"5277-3898"},{"uid":"5277-4112"},{"uid":"5277-4502"},{"uid":"5277-4506"},{"uid":"5277-4510"},{"uid":"5277-3884"},{"uid":"5277-3886"},{"uid":"5277-3988"},{"uid":"5277-4140"},{"uid":"5277-4144"},{"uid":"5277-4148"},{"uid":"5277-4138"},{"uid":"5277-4152"},{"uid":"5277-4156"},{"uid":"5277-4168"},{"uid":"5277-4248"},{"uid":"5277-4258"},{"uid":"5277-4266"},{"uid":"5277-4240"},{"uid":"5277-4242"},{"uid":"5277-4496"},{"uid":"5277-4500"},{"uid":"5277-4508"},{"uid":"5277-3986"},{"uid":"5277-4234"},{"uid":"5277-4246"},{"uid":"5277-4264"},{"uid":"5277-4238"},{"uid":"5277-4228"},{"uid":"5277-4220"},{"uid":"5277-4222"},{"uid":"5277-3908"},{"uid":"5277-3912"},{"uid":"5277-3928"},{"uid":"5277-3970"},{"uid":"5277-3978"},{"uid":"5277-3984"},{"uid":"5277-4214"},{"uid":"5277-4226"},{"uid":"5277-4230"},{"uid":"5277-4232"},{"uid":"5277-3968"},{"uid":"5277-4198"},{"uid":"5277-4200"},{"uid":"5277-4202"},{"uid":"5277-4206"},{"uid":"5277-4210"},{"uid":"5277-3920"},{"uid":"5277-4216"},{"uid":"5277-4218"},{"uid":"5277-3900"},{"uid":"5277-3902"},{"uid":"5277-3906"},{"uid":"5277-3916"},{"uid":"5277-3922"},{"uid":"5277-3924"},{"uid":"5277-3926"},{"uid":"5277-3966"},{"uid":"5277-3972"},{"uid":"5277-3974"},{"uid":"5277-3976"},{"uid":"5277-3980"},{"uid":"5277-3982"},{"uid":"5277-3936"},{"uid":"5277-3940"},{"uid":"5277-3958"},{"uid":"5277-3962"},{"uid":"5277-3964"},{"uid":"5277-3948"},{"uid":"5277-3952"},{"uid":"5277-3950"},{"uid":"5277-3956"},{"uid":"5277-3954"},{"uid":"5277-3946"}]},"5277-3878":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3879"},"imported":[],"importedBy":[{"uid":"5277-4008"}]},"5277-3880":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3881"},"imported":[],"importedBy":[{"uid":"5277-4006"}]},"5277-3882":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3883"},"imported":[],"importedBy":[{"uid":"5277-4004"}]},"5277-3884":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js","moduleParts":{"metamask-sdk.js":"5277-3885"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4634"},{"uid":"5277-4577"}],"importedBy":[{"uid":"5277-4611"}]},"5277-3886":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/index.js","moduleParts":{"metamask-sdk.js":"5277-3887"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4612"}]},"5277-3888":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3889"},"imported":[],"importedBy":[{"uid":"5277-3986"}]},"5277-3890":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json","moduleParts":{"metamask-sdk.js":"5277-3891"},"imported":[],"importedBy":[{"uid":"5277-4640"}]},"5277-3892":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3893"},"imported":[],"importedBy":[{"uid":"5277-3908"}]},"5277-3894":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-3895"},"imported":[],"importedBy":[{"uid":"5277-3900"}]},"5277-3896":{"id":"\u0000node-resolve:empty.js","moduleParts":{"metamask-sdk.js":"5277-3897"},"imported":[],"importedBy":[{"uid":"5277-3898"}]},"5277-3898":{"id":"\u0000\u0000node-resolve:empty.js?commonjs-proxy","moduleParts":{"metamask-sdk.js":"5277-3899"},"imported":[{"uid":"5277-3896"},{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4270"},{"uid":"5277-4228"},{"uid":"5277-3912"},{"uid":"5277-4214"},{"uid":"5277-3900"}]},"5277-3900":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js","moduleParts":{"metamask-sdk.js":"5277-3901"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3894"},{"uid":"5277-3898"}],"importedBy":[{"uid":"5277-4657"}]},"5277-3902":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-assert/index.js","moduleParts":{"metamask-sdk.js":"5277-3903"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4658"}]},"5277-3904":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3905"},"imported":[],"importedBy":[{"uid":"5277-3906"}]},"5277-3906":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js","moduleParts":{"metamask-sdk.js":"5277-3907"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3904"}],"importedBy":[{"uid":"5277-4659"}]},"5277-3908":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js","moduleParts":{"metamask-sdk.js":"5277-3909"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3892"},{"uid":"5277-4657"},{"uid":"5277-4658"},{"uid":"5277-4659"}],"importedBy":[{"uid":"5277-4641"}]},"5277-3910":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-3911"},"imported":[],"importedBy":[{"uid":"5277-3912"}]},"5277-3912":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js","moduleParts":{"metamask-sdk.js":"5277-3913"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3910"},{"uid":"5277-3898"}],"importedBy":[{"uid":"5277-4642"}]},"5277-3914":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3915"},"imported":[],"importedBy":[{"uid":"5277-3928"}]},"5277-3916":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/base.js","moduleParts":{"metamask-sdk.js":"5277-3917"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4657"},{"uid":"5277-4641"}],"importedBy":[{"uid":"5277-4660"}]},"5277-3918":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-3919"},"imported":[],"importedBy":[{"uid":"5277-3920"}]},"5277-3920":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js","moduleParts":{"metamask-sdk.js":"5277-3921"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3918"}],"importedBy":[{"uid":"5277-4654"}]},"5277-3922":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/short.js","moduleParts":{"metamask-sdk.js":"5277-3923"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4641"},{"uid":"5277-4657"},{"uid":"5277-4654"},{"uid":"5277-4660"}],"importedBy":[{"uid":"5277-4661"}]},"5277-3924":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/mont.js","moduleParts":{"metamask-sdk.js":"5277-3925"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4657"},{"uid":"5277-4654"},{"uid":"5277-4660"},{"uid":"5277-4641"}],"importedBy":[{"uid":"5277-4662"}]},"5277-3926":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/edwards.js","moduleParts":{"metamask-sdk.js":"5277-3927"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4641"},{"uid":"5277-4657"},{"uid":"5277-4654"},{"uid":"5277-4660"}],"importedBy":[{"uid":"5277-4663"}]},"5277-3928":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js","moduleParts":{"metamask-sdk.js":"5277-3929"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3914"},{"uid":"5277-4660"},{"uid":"5277-4661"},{"uid":"5277-4662"},{"uid":"5277-4663"}],"importedBy":[{"uid":"5277-4643"}]},"5277-3930":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3931"},"imported":[],"importedBy":[{"uid":"5277-3970"}]},"5277-3932":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3933"},"imported":[],"importedBy":[{"uid":"5277-3966"}]},"5277-3934":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3935"},"imported":[],"importedBy":[{"uid":"5277-3936"}]},"5277-3936":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js","moduleParts":{"metamask-sdk.js":"5277-3937"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3934"},{"uid":"5277-4658"},{"uid":"5277-4654"}],"importedBy":[{"uid":"5277-4670"}]},"5277-3938":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3939"},"imported":[],"importedBy":[{"uid":"5277-3940"}]},"5277-3940":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js","moduleParts":{"metamask-sdk.js":"5277-3941"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3938"},{"uid":"5277-4670"},{"uid":"5277-4658"}],"importedBy":[{"uid":"5277-4671"}]},"5277-3942":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3943"},"imported":[],"importedBy":[{"uid":"5277-3958"}]},"5277-3944":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3945"},"imported":[],"importedBy":[{"uid":"5277-3946"}]},"5277-3946":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js","moduleParts":{"metamask-sdk.js":"5277-3947"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3944"},{"uid":"5277-4670"}],"importedBy":[{"uid":"5277-4680"}]},"5277-3948":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/1.js","moduleParts":{"metamask-sdk.js":"5277-3949"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4670"},{"uid":"5277-4671"},{"uid":"5277-4680"}],"importedBy":[{"uid":"5277-4675"}]},"5277-3950":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/256.js","moduleParts":{"metamask-sdk.js":"5277-3951"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4670"},{"uid":"5277-4671"},{"uid":"5277-4680"},{"uid":"5277-4658"}],"importedBy":[{"uid":"5277-4677"}]},"5277-3952":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/224.js","moduleParts":{"metamask-sdk.js":"5277-3953"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4670"},{"uid":"5277-4677"}],"importedBy":[{"uid":"5277-4676"}]},"5277-3954":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/512.js","moduleParts":{"metamask-sdk.js":"5277-3955"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4670"},{"uid":"5277-4671"},{"uid":"5277-4658"}],"importedBy":[{"uid":"5277-4679"}]},"5277-3956":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/384.js","moduleParts":{"metamask-sdk.js":"5277-3957"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4670"},{"uid":"5277-4679"}],"importedBy":[{"uid":"5277-4678"}]},"5277-3958":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js","moduleParts":{"metamask-sdk.js":"5277-3959"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3942"},{"uid":"5277-4675"},{"uid":"5277-4676"},{"uid":"5277-4677"},{"uid":"5277-4678"},{"uid":"5277-4679"}],"importedBy":[{"uid":"5277-4672"}]},"5277-3960":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3961"},"imported":[],"importedBy":[{"uid":"5277-3962"}]},"5277-3962":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js","moduleParts":{"metamask-sdk.js":"5277-3963"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3960"},{"uid":"5277-4670"},{"uid":"5277-4671"}],"importedBy":[{"uid":"5277-4673"}]},"5277-3964":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/hmac.js","moduleParts":{"metamask-sdk.js":"5277-3965"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4670"},{"uid":"5277-4658"}],"importedBy":[{"uid":"5277-4674"}]},"5277-3966":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js","moduleParts":{"metamask-sdk.js":"5277-3967"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3932"},{"uid":"5277-4670"},{"uid":"5277-4671"},{"uid":"5277-4672"},{"uid":"5277-4673"},{"uid":"5277-4674"}],"importedBy":[{"uid":"5277-4664"}]},"5277-3968":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/precomputed/secp256k1.js","moduleParts":{"metamask-sdk.js":"5277-3969"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-3970"}]},"5277-3970":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js","moduleParts":{"metamask-sdk.js":"5277-3971"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3930"},{"uid":"5277-4664"},{"uid":"5277-4643"},{"uid":"5277-4641"},{"uid":"5277-3968"}],"importedBy":[{"uid":"5277-4644"}]},"5277-3972":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hmac-drbg/lib/hmac-drbg.js","moduleParts":{"metamask-sdk.js":"5277-3973"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4664"},{"uid":"5277-4659"},{"uid":"5277-4658"}],"importedBy":[{"uid":"5277-4665"}]},"5277-3974":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/key.js","moduleParts":{"metamask-sdk.js":"5277-3975"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4657"},{"uid":"5277-4641"}],"importedBy":[{"uid":"5277-4666"}]},"5277-3976":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/signature.js","moduleParts":{"metamask-sdk.js":"5277-3977"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4657"},{"uid":"5277-4641"}],"importedBy":[{"uid":"5277-4667"}]},"5277-3978":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/index.js","moduleParts":{"metamask-sdk.js":"5277-3979"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4657"},{"uid":"5277-4665"},{"uid":"5277-4641"},{"uid":"5277-4644"},{"uid":"5277-4642"},{"uid":"5277-4666"},{"uid":"5277-4667"}],"importedBy":[{"uid":"5277-4645"}]},"5277-3980":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/key.js","moduleParts":{"metamask-sdk.js":"5277-3981"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4641"}],"importedBy":[{"uid":"5277-4668"}]},"5277-3982":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/signature.js","moduleParts":{"metamask-sdk.js":"5277-3983"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4657"},{"uid":"5277-4641"}],"importedBy":[{"uid":"5277-4669"}]},"5277-3984":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/index.js","moduleParts":{"metamask-sdk.js":"5277-3985"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4664"},{"uid":"5277-4644"},{"uid":"5277-4641"},{"uid":"5277-4668"},{"uid":"5277-4669"}],"importedBy":[{"uid":"5277-4646"}]},"5277-3986":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-3987"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3888"},{"uid":"5277-4640"},{"uid":"5277-4641"},{"uid":"5277-4642"},{"uid":"5277-4643"},{"uid":"5277-4644"},{"uid":"5277-4645"},{"uid":"5277-4646"}],"importedBy":[{"uid":"5277-4635"}]},"5277-3988":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-3989"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4635"}],"importedBy":[{"uid":"5277-4613"}]},"5277-3990":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/elliptic.js","moduleParts":{"metamask-sdk.js":"5277-3991"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4612"},{"uid":"5277-4613"}],"importedBy":[{"uid":"5277-4578"}]},"5277-3992":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3993"},"imported":[],"importedBy":[{"uid":"5277-3998"}]},"5277-3994":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-3995"},"imported":[],"importedBy":[{"uid":"5277-3996"}]},"5277-3996":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js","moduleParts":{"metamask-sdk.js":"5277-3997"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3994"}],"importedBy":[{"uid":"5277-4552"}]},"5277-3998":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-3999"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3992"},{"uid":"5277-4577"},{"uid":"5277-4578"},{"uid":"5277-4552"}],"importedBy":[{"uid":"5277-4551"}]},"5277-4000":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4001"},"imported":[],"importedBy":[{"uid":"5277-4002"}]},"5277-4002":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js","moduleParts":{"metamask-sdk.js":"5277-4003"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4000"},{"uid":"5277-4611"},{"uid":"5277-4578"},{"uid":"5277-4551"},{"uid":"5277-4552"}],"importedBy":[{"uid":"5277-4576"}]},"5277-4004":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js","moduleParts":{"metamask-sdk.js":"5277-4005"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3882"},{"uid":"5277-4611"},{"uid":"5277-4578"},{"uid":"5277-4551"},{"uid":"5277-4576"}],"importedBy":[{"uid":"5277-4575"}]},"5277-4006":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js","moduleParts":{"metamask-sdk.js":"5277-4007"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3880"},{"uid":"5277-4575"},{"uid":"5277-4576"}],"importedBy":[{"uid":"5277-4550"}]},"5277-4008":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-4009"},"imported":[{"uid":"5277-3876"},{"uid":"5277-3878"},{"uid":"5277-4550"},{"uid":"5277-4551"},{"uid":"5277-4552"}],"importedBy":[{"uid":"5277-4096"}]},"5277-4010":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4011"},"imported":[],"importedBy":[{"uid":"5277-4012"}]},"5277-4012":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eventemitter2/lib/eventemitter2.js","moduleParts":{"metamask-sdk.js":"5277-4013"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4010"}],"importedBy":[{"uid":"5277-4096"},{"uid":"5277-4542"}]},"5277-4014":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/rng.js","moduleParts":{"metamask-sdk.js":"5277-4015"},"imported":[],"importedBy":[{"uid":"5277-4553"},{"uid":"5277-4022"}]},"5277-4016":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/regex.js","moduleParts":{"metamask-sdk.js":"5277-4017"},"imported":[],"importedBy":[{"uid":"5277-4018"}]},"5277-4018":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/validate.js","moduleParts":{"metamask-sdk.js":"5277-4019"},"imported":[{"uid":"5277-4016"}],"importedBy":[{"uid":"5277-4547"},{"uid":"5277-4557"},{"uid":"5277-4020"},{"uid":"5277-4558"}]},"5277-4020":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/stringify.js","moduleParts":{"metamask-sdk.js":"5277-4021"},"imported":[{"uid":"5277-4018"}],"importedBy":[{"uid":"5277-4547"},{"uid":"5277-4553"},{"uid":"5277-4022"},{"uid":"5277-4565"}]},"5277-4022":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v4.js","moduleParts":{"metamask-sdk.js":"5277-4023"},"imported":[{"uid":"5277-4014"},{"uid":"5277-4020"}],"importedBy":[{"uid":"5277-4547"}]},"5277-4024":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/commons.js","moduleParts":{"metamask-sdk.js":"5277-4025"},"imported":[],"importedBy":[{"uid":"5277-4026"},{"uid":"5277-4030"}]},"5277-4026":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/encodePacket.browser.js","moduleParts":{"metamask-sdk.js":"5277-4027"},"imported":[{"uid":"5277-4024"}],"importedBy":[{"uid":"5277-4032"}]},"5277-4028":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/contrib/base64-arraybuffer.js","moduleParts":{"metamask-sdk.js":"5277-4029"},"imported":[],"importedBy":[{"uid":"5277-4030"}]},"5277-4030":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/decodePacket.browser.js","moduleParts":{"metamask-sdk.js":"5277-4031"},"imported":[{"uid":"5277-4024"},{"uid":"5277-4028"}],"importedBy":[{"uid":"5277-4032"}]},"5277-4032":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-parser/build/esm/index.js","moduleParts":{"metamask-sdk.js":"5277-4033"},"imported":[{"uid":"5277-4026"},{"uid":"5277-4030"}],"importedBy":[{"uid":"5277-4070"},{"uid":"5277-4050"},{"uid":"5277-4058"},{"uid":"5277-4062"},{"uid":"5277-4064"}]},"5277-4034":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@socket.io/component-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-4035"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4579"}],"importedBy":[{"uid":"5277-4088"},{"uid":"5277-4084"},{"uid":"5277-4080"},{"uid":"5277-4070"},{"uid":"5277-4050"},{"uid":"5277-4058"}]},"5277-4036":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/globalThis.browser.js","moduleParts":{"metamask-sdk.js":"5277-4037"},"imported":[],"importedBy":[{"uid":"5277-4038"},{"uid":"5277-4060"},{"uid":"5277-4058"},{"uid":"5277-4056"}]},"5277-4038":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/util.js","moduleParts":{"metamask-sdk.js":"5277-4039"},"imported":[{"uid":"5277-4036"}],"importedBy":[{"uid":"5277-4072"},{"uid":"5277-4070"},{"uid":"5277-4050"},{"uid":"5277-4058"},{"uid":"5277-4062"}]},"5277-4040":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4041"},"imported":[],"importedBy":[{"uid":"5277-4046"}]},"5277-4042":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/node_modules/ms/index.js","moduleParts":{"metamask-sdk.js":"5277-4043"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4044"}]},"5277-4044":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/common.js","moduleParts":{"metamask-sdk.js":"5277-4045"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4042"}],"importedBy":[{"uid":"5277-4568"}]},"5277-4046":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/browser.js","moduleParts":{"metamask-sdk.js":"5277-4047"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4040"},{"uid":"5277-4568"}],"importedBy":[{"uid":"5277-4090"},{"uid":"5277-4074"},{"uid":"5277-4088"},{"uid":"5277-4084"},{"uid":"5277-4080"},{"uid":"5277-4070"},{"uid":"5277-4050"},{"uid":"5277-4058"},{"uid":"5277-4062"},{"uid":"5277-4064"}]},"5277-4048":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/contrib/parseqs.js","moduleParts":{"metamask-sdk.js":"5277-4049"},"imported":[],"importedBy":[{"uid":"5277-4070"},{"uid":"5277-4050"}]},"5277-4050":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transport.js","moduleParts":{"metamask-sdk.js":"5277-4051"},"imported":[{"uid":"5277-4032"},{"uid":"5277-4034"},{"uid":"5277-4038"},{"uid":"5277-4046"},{"uid":"5277-4048"}],"importedBy":[{"uid":"5277-4072"},{"uid":"5277-4058"},{"uid":"5277-4062"},{"uid":"5277-4064"}]},"5277-4052":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/contrib/yeast.js","moduleParts":{"metamask-sdk.js":"5277-4053"},"imported":[],"importedBy":[{"uid":"5277-4058"},{"uid":"5277-4062"}]},"5277-4054":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/contrib/has-cors.js","moduleParts":{"metamask-sdk.js":"5277-4055"},"imported":[],"importedBy":[{"uid":"5277-4056"}]},"5277-4056":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/xmlhttprequest.browser.js","moduleParts":{"metamask-sdk.js":"5277-4057"},"imported":[{"uid":"5277-4054"},{"uid":"5277-4036"}],"importedBy":[{"uid":"5277-4058"}]},"5277-4058":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/polling.js","moduleParts":{"metamask-sdk.js":"5277-4059"},"imported":[{"uid":"5277-4050"},{"uid":"5277-4046"},{"uid":"5277-4052"},{"uid":"5277-4032"},{"uid":"5277-4056"},{"uid":"5277-4034"},{"uid":"5277-4038"},{"uid":"5277-4036"}],"importedBy":[{"uid":"5277-4066"}]},"5277-4060":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/websocket-constructor.browser.js","moduleParts":{"metamask-sdk.js":"5277-4061"},"imported":[{"uid":"5277-4036"}],"importedBy":[{"uid":"5277-4072"},{"uid":"5277-4062"},{"uid":"5277-4064"}]},"5277-4062":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/websocket.js","moduleParts":{"metamask-sdk.js":"5277-4063"},"imported":[{"uid":"5277-4050"},{"uid":"5277-4052"},{"uid":"5277-4038"},{"uid":"5277-4060"},{"uid":"5277-4046"},{"uid":"5277-4032"}],"importedBy":[{"uid":"5277-4066"}]},"5277-4064":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/webtransport.js","moduleParts":{"metamask-sdk.js":"5277-4065"},"imported":[{"uid":"5277-4050"},{"uid":"5277-4060"},{"uid":"5277-4032"},{"uid":"5277-4046"}],"importedBy":[{"uid":"5277-4066"}]},"5277-4066":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/transports/index.js","moduleParts":{"metamask-sdk.js":"5277-4067"},"imported":[{"uid":"5277-4058"},{"uid":"5277-4062"},{"uid":"5277-4064"}],"importedBy":[{"uid":"5277-4072"},{"uid":"5277-4070"}]},"5277-4068":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/contrib/parseuri.js","moduleParts":{"metamask-sdk.js":"5277-4069"},"imported":[],"importedBy":[{"uid":"5277-4072"},{"uid":"5277-4070"}]},"5277-4070":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/socket.js","moduleParts":{"metamask-sdk.js":"5277-4071"},"imported":[{"uid":"5277-4066"},{"uid":"5277-4038"},{"uid":"5277-4048"},{"uid":"5277-4068"},{"uid":"5277-4046"},{"uid":"5277-4034"},{"uid":"5277-4032"}],"importedBy":[{"uid":"5277-4072"}]},"5277-4072":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/engine.io-client/build/esm-debug/index.js","moduleParts":{"metamask-sdk.js":"5277-4073"},"imported":[{"uid":"5277-4070"},{"uid":"5277-4050"},{"uid":"5277-4066"},{"uid":"5277-4038"},{"uid":"5277-4068"},{"uid":"5277-4060"}],"importedBy":[{"uid":"5277-4074"},{"uid":"5277-4088"}]},"5277-4074":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/url.js","moduleParts":{"metamask-sdk.js":"5277-4075"},"imported":[{"uid":"5277-4072"},{"uid":"5277-4046"}],"importedBy":[{"uid":"5277-4090"}]},"5277-4076":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm-debug/is-binary.js","moduleParts":{"metamask-sdk.js":"5277-4077"},"imported":[],"importedBy":[{"uid":"5277-4080"},{"uid":"5277-4078"}]},"5277-4078":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm-debug/binary.js","moduleParts":{"metamask-sdk.js":"5277-4079"},"imported":[{"uid":"5277-4076"}],"importedBy":[{"uid":"5277-4080"}]},"5277-4080":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-parser/build/esm-debug/index.js","moduleParts":{"metamask-sdk.js":"5277-4081"},"imported":[{"uid":"5277-4034"},{"uid":"5277-4078"},{"uid":"5277-4076"},{"uid":"5277-4046"}],"importedBy":[{"uid":"5277-4090"},{"uid":"5277-4088"},{"uid":"5277-4084"}]},"5277-4082":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/on.js","moduleParts":{"metamask-sdk.js":"5277-4083"},"imported":[],"importedBy":[{"uid":"5277-4088"},{"uid":"5277-4084"}]},"5277-4084":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/socket.js","moduleParts":{"metamask-sdk.js":"5277-4085"},"imported":[{"uid":"5277-4080"},{"uid":"5277-4082"},{"uid":"5277-4034"},{"uid":"5277-4046"}],"importedBy":[{"uid":"5277-4090"},{"uid":"5277-4088"}]},"5277-4086":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/contrib/backo2.js","moduleParts":{"metamask-sdk.js":"5277-4087"},"imported":[],"importedBy":[{"uid":"5277-4088"}]},"5277-4088":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/manager.js","moduleParts":{"metamask-sdk.js":"5277-4089"},"imported":[{"uid":"5277-4072"},{"uid":"5277-4084"},{"uid":"5277-4080"},{"uid":"5277-4082"},{"uid":"5277-4086"},{"uid":"5277-4034"},{"uid":"5277-4046"}],"importedBy":[{"uid":"5277-4090"}]},"5277-4090":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/socket.io-client/build/esm-debug/index.js","moduleParts":{"metamask-sdk.js":"5277-4091"},"imported":[{"uid":"5277-4074"},{"uid":"5277-4088"},{"uid":"5277-4084"},{"uid":"5277-4046"},{"uid":"5277-4080"}],"importedBy":[{"uid":"5277-4096"}]},"5277-4092":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/react-native-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4093"},"imported":[],"importedBy":[{"uid":"5277-4094"}]},"5277-4094":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/cross-fetch/dist/react-native-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-4095"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4092"}],"importedBy":[{"uid":"5277-4096"}]},"5277-4096":{"id":"-communication-layer/dist/react-native/es/metamask-sdk-communication-layer.js","moduleParts":{"metamask-sdk.js":"5277-4097"},"imported":[{"uid":"5277-4546"},{"uid":"5277-4008"},{"uid":"5277-4012"},{"uid":"5277-4547"},{"uid":"5277-4090"},{"uid":"5277-4094"}],"importedBy":[{"uid":"5277-4544"},{"uid":"5277-4344"},{"uid":"5277-4350"},{"uid":"5277-4352"},{"uid":"5277-4380"},{"uid":"5277-4536"},{"uid":"5277-4382"},{"uid":"5277-4396"},{"uid":"5277-4468"},{"uid":"5277-4348"},{"uid":"5277-4378"},{"uid":"5277-4422"},{"uid":"5277-4346"},{"uid":"5277-4408"},{"uid":"5277-4428"},{"uid":"5277-4364"},{"uid":"5277-4446"},{"uid":"5277-4452"},{"uid":"5277-4462"}]},"5277-4098":{"id":"\u0000tslib.js","moduleParts":{"metamask-sdk.js":"5277-4099"},"imported":[],"importedBy":[{"uid":"5277-4298"},{"uid":"5277-4542"},{"uid":"5277-4296"},{"uid":"5277-4540"},{"uid":"5277-4336"},{"uid":"5277-4338"},{"uid":"5277-4350"},{"uid":"5277-4538"},{"uid":"5277-4380"},{"uid":"5277-4536"},{"uid":"5277-4382"},{"uid":"5277-4388"},{"uid":"5277-4396"},{"uid":"5277-4424"},{"uid":"5277-4468"},{"uid":"5277-4474"},{"uid":"5277-4348"},{"uid":"5277-4378"},{"uid":"5277-4476"},{"uid":"5277-4478"},{"uid":"5277-4534"},{"uid":"5277-4386"},{"uid":"5277-4394"},{"uid":"5277-4436"},{"uid":"5277-4346"},{"uid":"5277-4374"},{"uid":"5277-4390"},{"uid":"5277-4420"},{"uid":"5277-4426"},{"uid":"5277-4428"},{"uid":"5277-4432"},{"uid":"5277-4434"},{"uid":"5277-4466"},{"uid":"5277-4470"},{"uid":"5277-4364"},{"uid":"5277-4362"},{"uid":"5277-4448"},{"uid":"5277-4452"},{"uid":"5277-4631"},{"uid":"5277-4460"},{"uid":"5277-4462"},{"uid":"5277-4458"},{"uid":"5277-4456"}]},"5277-4100":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4101"},"imported":[],"importedBy":[{"uid":"5277-4288"}]},"5277-4102":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4103"},"imported":[],"importedBy":[{"uid":"5277-4172"}]},"5277-4104":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4105"},"imported":[],"importedBy":[{"uid":"5277-4106"}]},"5277-4106":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-4107"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4104"},{"uid":"5277-4614"}],"importedBy":[{"uid":"5277-4580"}]},"5277-4108":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4109"},"imported":[],"importedBy":[{"uid":"5277-4128"}]},"5277-4110":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4111"},"imported":[],"importedBy":[{"uid":"5277-4114"}]},"5277-4112":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js","moduleParts":{"metamask-sdk.js":"5277-4113"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4596"}]},"5277-4114":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js","moduleParts":{"metamask-sdk.js":"5277-4115"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4110"},{"uid":"5277-4596"}],"importedBy":[{"uid":"5277-4569"}]},"5277-4116":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4117"},"imported":[],"importedBy":[{"uid":"5277-4122"}]},"5277-4118":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4119"},"imported":[],"importedBy":[{"uid":"5277-4120"}]},"5277-4120":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js","moduleParts":{"metamask-sdk.js":"5277-4121"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4118"}],"importedBy":[{"uid":"5277-4572"}]},"5277-4122":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-4123"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4116"},{"uid":"5277-4572"},{"uid":"5277-4569"}],"importedBy":[{"uid":"5277-4570"}]},"5277-4124":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4125"},"imported":[],"importedBy":[{"uid":"5277-4126"}]},"5277-4126":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js","moduleParts":{"metamask-sdk.js":"5277-4127"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4124"},{"uid":"5277-4569"},{"uid":"5277-4570"},{"uid":"5277-4572"}],"importedBy":[{"uid":"5277-4571"}]},"5277-4128":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-4129"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4108"},{"uid":"5277-4569"},{"uid":"5277-4570"},{"uid":"5277-4571"},{"uid":"5277-4572"}],"importedBy":[{"uid":"5277-4292"},{"uid":"5277-4581"}]},"5277-4130":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js","moduleParts":{"metamask-sdk.js":"5277-4131"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4582"}]},"5277-4132":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4133"},"imported":[],"importedBy":[{"uid":"5277-4158"}]},"5277-4134":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4135"},"imported":[],"importedBy":[{"uid":"5277-4140"}]},"5277-4136":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4137"},"imported":[],"importedBy":[{"uid":"5277-4138"}]},"5277-4138":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js","moduleParts":{"metamask-sdk.js":"5277-4139"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4136"}],"importedBy":[{"uid":"5277-4618"}]},"5277-4140":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-4141"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4134"},{"uid":"5277-4618"}],"importedBy":[{"uid":"5277-4615"}]},"5277-4142":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4143"},"imported":[],"importedBy":[{"uid":"5277-4144"}]},"5277-4144":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-4145"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4142"}],"importedBy":[{"uid":"5277-4616"}]},"5277-4146":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4147"},"imported":[],"importedBy":[{"uid":"5277-4148"}]},"5277-4148":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-4149"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4146"}],"importedBy":[{"uid":"5277-4617"}]},"5277-4150":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4151"},"imported":[],"importedBy":[{"uid":"5277-4152"}]},"5277-4152":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js","moduleParts":{"metamask-sdk.js":"5277-4153"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4150"},{"uid":"5277-4580"},{"uid":"5277-4581"}],"importedBy":[{"uid":"5277-4619"}]},"5277-4154":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4155"},"imported":[],"importedBy":[{"uid":"5277-4156"}]},"5277-4156":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-4157"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4154"},{"uid":"5277-4619"}],"importedBy":[{"uid":"5277-4620"}]},"5277-4158":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-4159"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4132"},{"uid":"5277-4615"},{"uid":"5277-4616"},{"uid":"5277-4617"},{"uid":"5277-4618"},{"uid":"5277-4619"},{"uid":"5277-4620"}],"importedBy":[{"uid":"5277-4583"}]},"5277-4160":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4161"},"imported":[],"importedBy":[{"uid":"5277-4162"}]},"5277-4162":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js","moduleParts":{"metamask-sdk.js":"5277-4163"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4160"}],"importedBy":[{"uid":"5277-4584"}]},"5277-4164":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4165"},"imported":[],"importedBy":[{"uid":"5277-4170"}]},"5277-4166":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4167"},"imported":[],"importedBy":[{"uid":"5277-4168"}]},"5277-4168":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-4169"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4166"},{"uid":"5277-4584"}],"importedBy":[{"uid":"5277-4621"}]},"5277-4170":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js","moduleParts":{"metamask-sdk.js":"5277-4171"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4164"},{"uid":"5277-4583"},{"uid":"5277-4581"},{"uid":"5277-4621"}],"importedBy":[{"uid":"5277-4585"}]},"5277-4172":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js","moduleParts":{"metamask-sdk.js":"5277-4173"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4102"},{"uid":"5277-4580"},{"uid":"5277-4581"},{"uid":"5277-4582"},{"uid":"5277-4583"},{"uid":"5277-4584"},{"uid":"5277-4585"}],"importedBy":[{"uid":"5277-4559"}]},"5277-4174":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4175"},"imported":[],"importedBy":[{"uid":"5277-4278"}]},"5277-4176":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4177"},"imported":[],"importedBy":[{"uid":"5277-4178"}]},"5277-4178":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-4179"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4176"},{"uid":"5277-4622"}],"importedBy":[{"uid":"5277-4586"}]},"5277-4180":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4181"},"imported":[],"importedBy":[{"uid":"5277-4182"}]},"5277-4182":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/index.js","moduleParts":{"metamask-sdk.js":"5277-4183"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4180"}],"importedBy":[{"uid":"5277-4587"}]},"5277-4184":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4185"},"imported":[],"importedBy":[{"uid":"5277-4274"}]},"5277-4186":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4187"},"imported":[],"importedBy":[{"uid":"5277-4188"}]},"5277-4188":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js","moduleParts":{"metamask-sdk.js":"5277-4189"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4186"},{"uid":"5277-4584"},{"uid":"5277-4585"}],"importedBy":[{"uid":"5277-4589"}]},"5277-4190":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4191"},"imported":[],"importedBy":[{"uid":"5277-4272"}]},"5277-4192":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4193"},"imported":[],"importedBy":[{"uid":"5277-4248"}]},"5277-4194":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4195"},"imported":[],"importedBy":[{"uid":"5277-4234"}]},"5277-4196":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4197"},"imported":[],"importedBy":[{"uid":"5277-4198"}]},"5277-4198":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js","moduleParts":{"metamask-sdk.js":"5277-4199"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4196"}],"importedBy":[{"uid":"5277-4649"}]},"5277-4200":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/isarray/index.js","moduleParts":{"metamask-sdk.js":"5277-4201"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4650"}]},"5277-4202":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/stream-browser.js","moduleParts":{"metamask-sdk.js":"5277-4203"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4614"}],"importedBy":[{"uid":"5277-4651"}]},"5277-4204":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4205"},"imported":[],"importedBy":[{"uid":"5277-4206"}]},"5277-4206":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js","moduleParts":{"metamask-sdk.js":"5277-4207"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4204"},{"uid":"5277-4634"}],"importedBy":[{"uid":"5277-4652"}]},"5277-4208":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4209"},"imported":[],"importedBy":[{"uid":"5277-4210"}]},"5277-4210":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js","moduleParts":{"metamask-sdk.js":"5277-4211"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4208"},{"uid":"5277-4634"}],"importedBy":[{"uid":"5277-4653"}]},"5277-4212":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4213"},"imported":[],"importedBy":[{"uid":"5277-4214"}]},"5277-4214":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/BufferList.js","moduleParts":{"metamask-sdk.js":"5277-4215"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4212"},{"uid":"5277-4652"},{"uid":"5277-3898"}],"importedBy":[{"uid":"5277-4228"}]},"5277-4216":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/destroy.js","moduleParts":{"metamask-sdk.js":"5277-4217"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4649"}],"importedBy":[{"uid":"5277-4655"}]},"5277-4218":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/util-deprecate/browser.js","moduleParts":{"metamask-sdk.js":"5277-4219"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4656"}]},"5277-4220":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_writable.js","moduleParts":{"metamask-sdk.js":"5277-4221"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4649"},{"uid":"5277-4653"},{"uid":"5277-4654"},{"uid":"5277-4656"},{"uid":"5277-4651"},{"uid":"5277-4652"},{"uid":"5277-4655"},{"uid":"5277-4222"}],"importedBy":[{"uid":"5277-4234"},{"uid":"5277-4222"}]},"5277-4222":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_duplex.js","moduleParts":{"metamask-sdk.js":"5277-4223"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4649"},{"uid":"5277-4653"},{"uid":"5277-4654"},{"uid":"5277-4228"},{"uid":"5277-4220"}],"importedBy":[{"uid":"5277-4234"},{"uid":"5277-4228"},{"uid":"5277-4220"},{"uid":"5277-4230"}]},"5277-4224":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4225"},"imported":[],"importedBy":[{"uid":"5277-4226"}]},"5277-4226":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/string_decoder/lib/string_decoder.js","moduleParts":{"metamask-sdk.js":"5277-4227"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4224"},{"uid":"5277-4652"}],"importedBy":[{"uid":"5277-4228"}]},"5277-4228":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_readable.js","moduleParts":{"metamask-sdk.js":"5277-4229"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4649"},{"uid":"5277-4650"},{"uid":"5277-4614"},{"uid":"5277-4651"},{"uid":"5277-4652"},{"uid":"5277-4653"},{"uid":"5277-4654"},{"uid":"5277-3898"},{"uid":"5277-4214"},{"uid":"5277-4655"},{"uid":"5277-4222"},{"uid":"5277-4226"}],"importedBy":[{"uid":"5277-4234"},{"uid":"5277-4222"}]},"5277-4230":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_transform.js","moduleParts":{"metamask-sdk.js":"5277-4231"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4222"},{"uid":"5277-4653"},{"uid":"5277-4654"}],"importedBy":[{"uid":"5277-4647"}]},"5277-4232":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_passthrough.js","moduleParts":{"metamask-sdk.js":"5277-4233"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4647"},{"uid":"5277-4653"},{"uid":"5277-4654"}],"importedBy":[{"uid":"5277-4648"}]},"5277-4234":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js","moduleParts":{"metamask-sdk.js":"5277-4235"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4194"},{"uid":"5277-4228"},{"uid":"5277-4220"},{"uid":"5277-4222"},{"uid":"5277-4647"},{"uid":"5277-4648"}],"importedBy":[{"uid":"5277-4636"}]},"5277-4236":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4237"},"imported":[],"importedBy":[{"uid":"5277-4240"}]},"5277-4238":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js","moduleParts":{"metamask-sdk.js":"5277-4239"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4639"}]},"5277-4240":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js","moduleParts":{"metamask-sdk.js":"5277-4241"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4236"},{"uid":"5277-4639"}],"importedBy":[{"uid":"5277-4626"}]},"5277-4242":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-4243"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4626"}],"importedBy":[{"uid":"5277-4627"}]},"5277-4244":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4245"},"imported":[],"importedBy":[{"uid":"5277-4246"}]},"5277-4246":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js","moduleParts":{"metamask-sdk.js":"5277-4247"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4244"},{"uid":"5277-4636"}],"importedBy":[{"uid":"5277-4637"}]},"5277-4248":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js","moduleParts":{"metamask-sdk.js":"5277-4249"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4192"},{"uid":"5277-4636"},{"uid":"5277-4627"},{"uid":"5277-4626"},{"uid":"5277-4637"}],"importedBy":[{"uid":"5277-4623"}]},"5277-4250":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-4251"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4623"}],"importedBy":[{"uid":"5277-4590"}]},"5277-4252":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js","moduleParts":{"metamask-sdk.js":"5277-4253"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4591"}]},"5277-4254":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4255"},"imported":[],"importedBy":[{"uid":"5277-4268"}]},"5277-4256":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4257"},"imported":[],"importedBy":[{"uid":"5277-4258"}]},"5277-4258":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js","moduleParts":{"metamask-sdk.js":"5277-4259"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4256"},{"uid":"5277-4636"}],"importedBy":[{"uid":"5277-4624"}]},"5277-4260":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4261"},"imported":[],"importedBy":[{"uid":"5277-4266"}]},"5277-4262":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4263"},"imported":[],"importedBy":[{"uid":"5277-4264"}]},"5277-4264":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js","moduleParts":{"metamask-sdk.js":"5277-4265"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4262"},{"uid":"5277-4614"}],"importedBy":[{"uid":"5277-4638"}]},"5277-4266":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js","moduleParts":{"metamask-sdk.js":"5277-4267"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4260"},{"uid":"5277-4638"},{"uid":"5277-4636"}],"importedBy":[{"uid":"5277-4625"}]},"5277-4268":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-4269"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4254"},{"uid":"5277-4624"},{"uid":"5277-4625"}],"importedBy":[{"uid":"5277-4592"}]},"5277-4270":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js","moduleParts":{"metamask-sdk.js":"5277-4271"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4626"},{"uid":"5277-4627"},{"uid":"5277-3898"}],"importedBy":[{"uid":"5277-4593"}]},"5277-4272":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js","moduleParts":{"metamask-sdk.js":"5277-4273"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4190"},{"uid":"5277-4590"},{"uid":"5277-4591"},{"uid":"5277-4592"},{"uid":"5277-4593"},{"uid":"5277-4584"},{"uid":"5277-4585"},{"uid":"5277-4559"}],"importedBy":[{"uid":"5277-4564"}]},"5277-4274":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-4275"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4184"},{"uid":"5277-4581"},{"uid":"5277-4589"},{"uid":"5277-4584"},{"uid":"5277-4585"},{"uid":"5277-4564"}],"importedBy":[{"uid":"5277-4562"}]},"5277-4276":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json","moduleParts":{"metamask-sdk.js":"5277-4277"},"imported":[],"importedBy":[{"uid":"5277-4588"}]},"5277-4278":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js","moduleParts":{"metamask-sdk.js":"5277-4279"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4174"},{"uid":"5277-4586"},{"uid":"5277-4587"},{"uid":"5277-4562"},{"uid":"5277-4564"},{"uid":"5277-4585"},{"uid":"5277-4588"}],"importedBy":[{"uid":"5277-4560"}]},"5277-4280":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4281"},"imported":[],"importedBy":[{"uid":"5277-4286"}]},"5277-4282":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4283"},"imported":[],"importedBy":[{"uid":"5277-4284"}]},"5277-4284":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js","moduleParts":{"metamask-sdk.js":"5277-4285"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4282"}],"importedBy":[{"uid":"5277-4563"}]},"5277-4286":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js","moduleParts":{"metamask-sdk.js":"5277-4287"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4280"},{"uid":"5277-4562"},{"uid":"5277-4563"}],"importedBy":[{"uid":"5277-4561"}]},"5277-4288":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/index.js","moduleParts":{"metamask-sdk.js":"5277-4289"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4100"},{"uid":"5277-4559"},{"uid":"5277-4560"},{"uid":"5277-4561"},{"uid":"5277-4562"},{"uid":"5277-4563"},{"uid":"5277-4564"}],"importedBy":[{"uid":"5277-4298"},{"uid":"5277-4358"}]},"5277-4290":{"id":"/src/services/SDKProvider/ChainManager/handleChainChanged.ts","moduleParts":{"metamask-sdk.js":"5277-4291"},"imported":[],"importedBy":[{"uid":"5277-4298"}]},"5277-4292":{"id":"/src/services/SDKProvider/ConnectionManager/handleDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-4293"},"imported":[{"uid":"5277-4128"}],"importedBy":[{"uid":"5277-4298"}]},"5277-4294":{"id":"/src/services/SDKProvider/InitializationManager/initializeState.ts","moduleParts":{"metamask-sdk.js":"5277-4295"},"imported":[],"importedBy":[{"uid":"5277-4298"}]},"5277-4296":{"id":"/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts","moduleParts":{"metamask-sdk.js":"5277-4297"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4298"}]},"5277-4298":{"id":"/src/provider/SDKProvider.ts","moduleParts":{"metamask-sdk.js":"5277-4299"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4288"},{"uid":"5277-4290"},{"uid":"5277-4292"},{"uid":"5277-4294"},{"uid":"5277-4296"}],"importedBy":[{"uid":"5277-4544"},{"uid":"5277-4358"}]},"5277-4300":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-4301"},"imported":[],"importedBy":[{"uid":"5277-4334"},{"uid":"5277-4316"},{"uid":"5277-4306"},{"uid":"5277-4304"}]},"5277-4302":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-4303"},"imported":[],"importedBy":[{"uid":"5277-4334"}]},"5277-4304":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-4305"},"imported":[{"uid":"5277-4300"}],"importedBy":[{"uid":"5277-4306"}]},"5277-4306":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-4307"},"imported":[{"uid":"5277-4300"},{"uid":"5277-4304"}],"importedBy":[{"uid":"5277-4308"},{"uid":"5277-4320"}]},"5277-4308":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-4309"},"imported":[{"uid":"5277-4306"}],"importedBy":[{"uid":"5277-4334"}]},"5277-4310":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/assertThisInitialized.js","moduleParts":{"metamask-sdk.js":"5277-4311"},"imported":[],"importedBy":[{"uid":"5277-4334"},{"uid":"5277-4316"}]},"5277-4312":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/setPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-4313"},"imported":[],"importedBy":[{"uid":"5277-4314"}]},"5277-4314":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/inherits.js","moduleParts":{"metamask-sdk.js":"5277-4315"},"imported":[{"uid":"5277-4312"}],"importedBy":[{"uid":"5277-4334"}]},"5277-4316":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/possibleConstructorReturn.js","moduleParts":{"metamask-sdk.js":"5277-4317"},"imported":[{"uid":"5277-4300"},{"uid":"5277-4310"}],"importedBy":[{"uid":"5277-4334"}]},"5277-4318":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/getPrototypeOf.js","moduleParts":{"metamask-sdk.js":"5277-4319"},"imported":[],"importedBy":[{"uid":"5277-4334"}]},"5277-4320":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/defineProperty.js","moduleParts":{"metamask-sdk.js":"5277-4321"},"imported":[{"uid":"5277-4306"}],"importedBy":[{"uid":"5277-4334"}]},"5277-4322":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayWithHoles.js","moduleParts":{"metamask-sdk.js":"5277-4323"},"imported":[],"importedBy":[{"uid":"5277-4332"}]},"5277-4324":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/iterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-4325"},"imported":[],"importedBy":[{"uid":"5277-4332"}]},"5277-4326":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js","moduleParts":{"metamask-sdk.js":"5277-4327"},"imported":[],"importedBy":[{"uid":"5277-4328"}]},"5277-4328":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js","moduleParts":{"metamask-sdk.js":"5277-4329"},"imported":[{"uid":"5277-4326"}],"importedBy":[{"uid":"5277-4332"}]},"5277-4330":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/nonIterableRest.js","moduleParts":{"metamask-sdk.js":"5277-4331"},"imported":[],"importedBy":[{"uid":"5277-4332"}]},"5277-4332":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/node_modules/@babel/runtime/helpers/esm/toArray.js","moduleParts":{"metamask-sdk.js":"5277-4333"},"imported":[{"uid":"5277-4322"},{"uid":"5277-4324"},{"uid":"5277-4328"},{"uid":"5277-4330"}],"importedBy":[{"uid":"5277-4334"}]},"5277-4334":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next/dist/esm/i18next.js","moduleParts":{"metamask-sdk.js":"5277-4335"},"imported":[{"uid":"5277-4300"},{"uid":"5277-4302"},{"uid":"5277-4308"},{"uid":"5277-4310"},{"uid":"5277-4314"},{"uid":"5277-4316"},{"uid":"5277-4318"},{"uid":"5277-4320"},{"uid":"5277-4332"}],"importedBy":[{"uid":"5277-4542"}]},"5277-4336":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connect.ts","moduleParts":{"metamask-sdk.js":"5277-4337"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4548"}]},"5277-4338":{"id":"/src/services/MetaMaskSDK/ConnectionManager/resume.ts","moduleParts":{"metamask-sdk.js":"5277-4339"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4548"}]},"5277-4340":{"id":"/src/config.ts","moduleParts":{"metamask-sdk.js":"5277-4341"},"imported":[],"importedBy":[{"uid":"5277-4540"},{"uid":"5277-4344"},{"uid":"5277-4350"},{"uid":"5277-4396"},{"uid":"5277-4378"},{"uid":"5277-4346"},{"uid":"5277-4390"},{"uid":"5277-4470"},{"uid":"5277-4362"}]},"5277-4342":{"id":"/src/types/ProviderUpdateType.ts","moduleParts":{"metamask-sdk.js":"5277-4343"},"imported":[],"importedBy":[{"uid":"5277-4544"},{"uid":"5277-4344"},{"uid":"5277-4536"},{"uid":"5277-4378"},{"uid":"5277-4346"}]},"5277-4344":{"id":"/src/services/MetaMaskSDK/ConnectionManager/terminate.ts","moduleParts":{"metamask-sdk.js":"5277-4345"},"imported":[{"uid":"5277-4096"},{"uid":"5277-4340"},{"uid":"5277-4342"}],"importedBy":[{"uid":"5277-4548"}]},"5277-4346":{"id":"/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-4347"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4340"},{"uid":"5277-4342"}],"importedBy":[{"uid":"5277-4573"}]},"5277-4348":{"id":"/src/services/Analytics.ts","moduleParts":{"metamask-sdk.js":"5277-4349"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"}],"importedBy":[{"uid":"5277-4350"},{"uid":"5277-4382"}]},"5277-4350":{"id":"/src/services/MetaMaskSDK/InitializerManager/handleAutoAndExtensionConnections.ts","moduleParts":{"metamask-sdk.js":"5277-4351"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4340"},{"uid":"5277-4573"},{"uid":"5277-4348"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4352":{"id":"/src/services/MetaMaskSDK/InitializerManager/initEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-4353"},"imported":[{"uid":"5277-4096"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4380"}]},"5277-4354":{"id":"/src/constants.ts","moduleParts":{"metamask-sdk.js":"5277-4355"},"imported":[],"importedBy":[{"uid":"5277-4378"},{"uid":"5277-4392"},{"uid":"5277-4356"},{"uid":"5277-4362"},{"uid":"5277-4448"},{"uid":"5277-4452"},{"uid":"5277-4460"},{"uid":"5277-4458"}]},"5277-4356":{"id":"/src/services/RemoteCommunicationPostMessageStream/onMessage.ts","moduleParts":{"metamask-sdk.js":"5277-4357"},"imported":[{"uid":"5277-4546"},{"uid":"5277-4354"}],"importedBy":[{"uid":"5277-4364"}]},"5277-4358":{"id":"/src/services/Ethereum.ts","moduleParts":{"metamask-sdk.js":"5277-4359"},"imported":[{"uid":"5277-4288"},{"uid":"5277-4298"}],"importedBy":[{"uid":"5277-4396"},{"uid":"5277-4378"},{"uid":"5277-4410"},{"uid":"5277-4432"},{"uid":"5277-4466"},{"uid":"5277-4362"},{"uid":"5277-4631"},{"uid":"5277-4460"},{"uid":"5277-4462"},{"uid":"5277-4458"}]},"5277-4360":{"id":"/src/services/RemoteCommunicationPostMessageStream/extractMethod.ts","moduleParts":{"metamask-sdk.js":"5277-4361"},"imported":[{"uid":"5277-4546"}],"importedBy":[{"uid":"5277-4362"}]},"5277-4362":{"id":"/src/services/RemoteCommunicationPostMessageStream/write.ts","moduleParts":{"metamask-sdk.js":"5277-4363"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4340"},{"uid":"5277-4354"},{"uid":"5277-4358"},{"uid":"5277-4360"}],"importedBy":[{"uid":"5277-4364"}]},"5277-4364":{"id":"/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-4365"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4628"},{"uid":"5277-4096"},{"uid":"5277-4356"},{"uid":"5277-4362"}],"importedBy":[{"uid":"5277-4366"}]},"5277-4366":{"id":"/src/PostMessageStream/getPostMessageStream.ts","moduleParts":{"metamask-sdk.js":"5277-4367"},"imported":[{"uid":"5277-4364"}],"importedBy":[{"uid":"5277-4378"}]},"5277-4368":{"id":"/src/utils/wait.ts","moduleParts":{"metamask-sdk.js":"5277-4369"},"imported":[],"importedBy":[{"uid":"5277-4378"},{"uid":"5277-4434"}]},"5277-4370":{"id":"\u0000/node_modules/cross-fetch/dist/react-native-ponyfill.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4371"},"imported":[],"importedBy":[{"uid":"5277-4372"}]},"5277-4372":{"id":"/node_modules/cross-fetch/dist/react-native-ponyfill.js","moduleParts":{"metamask-sdk.js":"5277-4373"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4370"}],"importedBy":[{"uid":"5277-4374"}]},"5277-4374":{"id":"/src/services/rpc-requests/RPCRequestHandler.ts","moduleParts":{"metamask-sdk.js":"5277-4375"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4372"}],"importedBy":[{"uid":"5277-4378"}]},"5277-4376":{"id":"/package.json","moduleParts":{"metamask-sdk.js":"5277-4377"},"imported":[],"importedBy":[{"uid":"5277-4378"},{"uid":"5277-4446"}]},"5277-4378":{"id":"/src/provider/initializeMobileProvider.ts","moduleParts":{"metamask-sdk.js":"5277-4379"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4366"},{"uid":"5277-4340"},{"uid":"5277-4354"},{"uid":"5277-4358"},{"uid":"5277-4342"},{"uid":"5277-4368"},{"uid":"5277-4374"},{"uid":"5277-4376"}],"importedBy":[{"uid":"5277-4380"}]},"5277-4380":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeProviderAndEventListeners.ts","moduleParts":{"metamask-sdk.js":"5277-4381"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4378"},{"uid":"5277-4352"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4382":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.ts","moduleParts":{"metamask-sdk.js":"5277-4383"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4348"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4384":{"id":"/src/utils/extractFavicon.ts","moduleParts":{"metamask-sdk.js":"5277-4385"},"imported":[],"importedBy":[{"uid":"5277-4388"}]},"5277-4386":{"id":"/src/utils/getBase64FromUrl.ts","moduleParts":{"metamask-sdk.js":"5277-4387"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4388"}]},"5277-4388":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.ts","moduleParts":{"metamask-sdk.js":"5277-4389"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4384"},{"uid":"5277-4386"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4390":{"id":"/src/provider/wrapExtensionProvider.ts","moduleParts":{"metamask-sdk.js":"5277-4391"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4340"}],"importedBy":[{"uid":"5277-4394"}]},"5277-4392":{"id":"/src/utils/eip6963RequestProvider.ts","moduleParts":{"metamask-sdk.js":"5277-4393"},"imported":[{"uid":"5277-4354"}],"importedBy":[{"uid":"5277-4394"}]},"5277-4394":{"id":"/src/utils/get-browser-extension.ts","moduleParts":{"metamask-sdk.js":"5277-4395"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4390"},{"uid":"5277-4392"}],"importedBy":[{"uid":"5277-4396"}]},"5277-4396":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts","moduleParts":{"metamask-sdk.js":"5277-4397"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4340"},{"uid":"5277-4394"},{"uid":"5277-4358"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4398":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/es5.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4399"},"imported":[],"importedBy":[{"uid":"5277-4400"}]},"5277-4400":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/es5.js","moduleParts":{"metamask-sdk.js":"5277-4401"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4398"}],"importedBy":[{"uid":"5277-4422"},{"uid":"5277-4630"}]},"5277-4402":{"id":"/src/types/WakeLockStatus.ts","moduleParts":{"metamask-sdk.js":"5277-4403"},"imported":[],"importedBy":[{"uid":"5277-4422"},{"uid":"5277-4404"},{"uid":"5277-4406"}]},"5277-4404":{"id":"/src/services/PlatfformManager/disableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-4405"},"imported":[{"uid":"5277-4402"}],"importedBy":[{"uid":"5277-4422"}]},"5277-4406":{"id":"/src/services/PlatfformManager/enableWakeLock.ts","moduleParts":{"metamask-sdk.js":"5277-4407"},"imported":[{"uid":"5277-4422"},{"uid":"5277-4402"}],"importedBy":[{"uid":"5277-4422"}]},"5277-4408":{"id":"/src/services/PlatfformManager/getPlatformType.ts","moduleParts":{"metamask-sdk.js":"5277-4409"},"imported":[{"uid":"5277-4096"}],"importedBy":[{"uid":"5277-4422"}]},"5277-4410":{"id":"/src/services/PlatfformManager/isMetaMaskInstalled.ts","moduleParts":{"metamask-sdk.js":"5277-4411"},"imported":[{"uid":"5277-4358"}],"importedBy":[{"uid":"5277-4422"}]},"5277-4412":{"id":"/src/services/PlatfformManager/openDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-4413"},"imported":[{"uid":"5277-4422"}],"importedBy":[{"uid":"5277-4422"}]},"5277-4414":{"id":"/src/utils/hasNativeWakeLockSupport.ts","moduleParts":{"metamask-sdk.js":"5277-4415"},"imported":[],"importedBy":[{"uid":"5277-4420"}]},"5277-4416":{"id":"/src/utils/isOldIOS.ts","moduleParts":{"metamask-sdk.js":"5277-4417"},"imported":[],"importedBy":[{"uid":"5277-4420"}]},"5277-4418":{"id":"/src/Platform/Media.ts","moduleParts":{"metamask-sdk.js":"5277-4419"},"imported":[],"importedBy":[{"uid":"5277-4420"}]},"5277-4420":{"id":"/src/Platform/WakeLockManager.ts","moduleParts":{"metamask-sdk.js":"5277-4421"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4414"},{"uid":"5277-4416"},{"uid":"5277-4418"}],"importedBy":[{"uid":"5277-4422"}]},"5277-4422":{"id":"/src/Platform/PlatfformManager.ts","moduleParts":{"metamask-sdk.js":"5277-4423"},"imported":[{"uid":"5277-4096"},{"uid":"5277-4400"},{"uid":"5277-4404"},{"uid":"5277-4406"},{"uid":"5277-4408"},{"uid":"5277-4410"},{"uid":"5277-4412"},{"uid":"5277-4402"},{"uid":"5277-4420"}],"importedBy":[{"uid":"5277-4424"},{"uid":"5277-4406"},{"uid":"5277-4412"}]},"5277-4424":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupPlatformManager.ts","moduleParts":{"metamask-sdk.js":"5277-4425"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4422"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4426":{"id":"/src/services/MetaMaskInstaller/checkInstallation.ts","moduleParts":{"metamask-sdk.js":"5277-4427"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4436"}]},"5277-4428":{"id":"/src/services/MetaMaskInstaller/redirectToProperInstall.ts","moduleParts":{"metamask-sdk.js":"5277-4429"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"}],"importedBy":[{"uid":"5277-4436"}]},"5277-4430":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/onboarding/dist/metamask-onboarding.cjs.js","moduleParts":{"metamask-sdk.js":"5277-4431"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4630"}],"importedBy":[{"uid":"5277-4432"}]},"5277-4432":{"id":"/src/services/MetaMaskInstaller/startDesktopOnboarding.ts","moduleParts":{"metamask-sdk.js":"5277-4433"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4430"},{"uid":"5277-4358"}],"importedBy":[{"uid":"5277-4436"}]},"5277-4434":{"id":"/src/services/MetaMaskInstaller/startInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-4435"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4368"}],"importedBy":[{"uid":"5277-4436"}]},"5277-4436":{"id":"/src/Platform/MetaMaskInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-4437"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4426"},{"uid":"5277-4428"},{"uid":"5277-4432"},{"uid":"5277-4434"}],"importedBy":[{"uid":"5277-4468"}]},"5277-4438":{"id":"/src/ui/InstallModal/InstallModal-nonweb.ts","moduleParts":{"metamask-sdk.js":"5277-4439"},"imported":[],"importedBy":[{"uid":"5277-4440"}]},"5277-4440":{"id":"/src/ui/InstallModal/installModal.ts","moduleParts":{"metamask-sdk.js":"5277-4441"},"imported":[{"uid":"5277-4438"}],"importedBy":[{"uid":"5277-4466"}]},"5277-4442":{"id":"/src/ui/InstallModal/pendingModal-nodejs.ts","moduleParts":{"metamask-sdk.js":"5277-4443"},"imported":[],"importedBy":[{"uid":"5277-4444"}]},"5277-4444":{"id":"/src/ui/InstallModal/pendingModal.ts","moduleParts":{"metamask-sdk.js":"5277-4445"},"imported":[{"uid":"5277-4442"}],"importedBy":[{"uid":"5277-4466"}]},"5277-4446":{"id":"/src/services/RemoteConnection/ConnectionInitializer/initializeConnector.ts","moduleParts":{"metamask-sdk.js":"5277-4447"},"imported":[{"uid":"5277-4096"},{"uid":"5277-4376"}],"importedBy":[{"uid":"5277-4606"}]},"5277-4448":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithDeeplink.ts","moduleParts":{"metamask-sdk.js":"5277-4449"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4354"}],"importedBy":[{"uid":"5277-4607"},{"uid":"5277-4460"}]},"5277-4450":{"id":"/src/services/RemoteConnection/ModalManager/showInstallModal.ts","moduleParts":{"metamask-sdk.js":"5277-4451"},"imported":[],"importedBy":[{"uid":"5277-4609"},{"uid":"5277-4452"}]},"5277-4452":{"id":"/src/services/RemoteConnection/ConnectionManager/connectWithModalInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-4453"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4450"},{"uid":"5277-4354"}],"importedBy":[{"uid":"5277-4607"},{"uid":"5277-4460"}]},"5277-4454":{"id":"/src/services/RemoteConnection/ModalManager/onOTPModalDisconnect.ts","moduleParts":{"metamask-sdk.js":"5277-4455"},"imported":[],"importedBy":[{"uid":"5277-4458"}]},"5277-4456":{"id":"/src/services/RemoteConnection/ModalManager/waitForOTPAnswer.ts","moduleParts":{"metamask-sdk.js":"5277-4457"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4458"}]},"5277-4458":{"id":"/src/services/RemoteConnection/ModalManager/reconnectWithModalOTP.ts","moduleParts":{"metamask-sdk.js":"5277-4459"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4358"},{"uid":"5277-4354"},{"uid":"5277-4454"},{"uid":"5277-4456"}],"importedBy":[{"uid":"5277-4609"},{"uid":"5277-4460"}]},"5277-4460":{"id":"/src/services/RemoteConnection/ConnectionManager/startConnection.ts","moduleParts":{"metamask-sdk.js":"5277-4461"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4354"},{"uid":"5277-4358"},{"uid":"5277-4458"},{"uid":"5277-4448"},{"uid":"5277-4452"}],"importedBy":[{"uid":"5277-4607"}]},"5277-4462":{"id":"/src/services/RemoteConnection/EventListeners/setupListeners.ts","moduleParts":{"metamask-sdk.js":"5277-4463"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4358"}],"importedBy":[{"uid":"5277-4608"}]},"5277-4464":{"id":"/src/services/RemoteConnection/ModalManager/showActiveModal.ts","moduleParts":{"metamask-sdk.js":"5277-4465"},"imported":[],"importedBy":[{"uid":"5277-4609"}]},"5277-4466":{"id":"/src/services/RemoteConnection/RemoteConnection.ts","moduleParts":{"metamask-sdk.js":"5277-4467"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4440"},{"uid":"5277-4444"},{"uid":"5277-4358"},{"uid":"5277-4606"},{"uid":"5277-4607"},{"uid":"5277-4608"},{"uid":"5277-4609"}],"importedBy":[{"uid":"5277-4574"}]},"5277-4468":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.ts","moduleParts":{"metamask-sdk.js":"5277-4469"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4436"},{"uid":"5277-4574"},{"uid":"5277-4573"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4470":{"id":"/src/storage-manager/StorageManagerAS.ts","moduleParts":{"metamask-sdk.js":"5277-4471"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4610"},{"uid":"5277-4340"}],"importedBy":[{"uid":"5277-4472"}]},"5277-4472":{"id":"/src/storage-manager/getStorageManager.ts","moduleParts":{"metamask-sdk.js":"5277-4473"},"imported":[{"uid":"5277-4470"}],"importedBy":[{"uid":"5277-4474"}]},"5277-4474":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupStorage.ts","moduleParts":{"metamask-sdk.js":"5277-4475"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4472"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4536"}]},"5277-4476":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupInfuraProvider.ts","moduleParts":{"metamask-sdk.js":"5277-4477"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4536"}]},"5277-4478":{"id":"/src/services/MetaMaskSDK/InitializerManager/setupReadOnlyRPCProviders.ts","moduleParts":{"metamask-sdk.js":"5277-4479"},"imported":[{"uid":"5277-4098"}],"importedBy":[{"uid":"5277-4536"}]},"5277-4480":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/classCallCheck.js","moduleParts":{"metamask-sdk.js":"5277-4481"},"imported":[],"importedBy":[{"uid":"5277-4490"}]},"5277-4482":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/typeof.js","moduleParts":{"metamask-sdk.js":"5277-4483"},"imported":[],"importedBy":[{"uid":"5277-4486"},{"uid":"5277-4484"}]},"5277-4484":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPrimitive.js","moduleParts":{"metamask-sdk.js":"5277-4485"},"imported":[{"uid":"5277-4482"}],"importedBy":[{"uid":"5277-4486"}]},"5277-4486":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js","moduleParts":{"metamask-sdk.js":"5277-4487"},"imported":[{"uid":"5277-4482"},{"uid":"5277-4484"}],"importedBy":[{"uid":"5277-4488"}]},"5277-4488":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/node_modules/@babel/runtime/helpers/esm/createClass.js","moduleParts":{"metamask-sdk.js":"5277-4489"},"imported":[{"uid":"5277-4486"}],"importedBy":[{"uid":"5277-4490"}]},"5277-4490":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/i18next-browser-languagedetector/dist/esm/i18nextBrowserLanguageDetector.js","moduleParts":{"metamask-sdk.js":"5277-4491"},"imported":[{"uid":"5277-4480"},{"uid":"5277-4488"}],"importedBy":[{"uid":"5277-4534"}]},"5277-4492":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4493"},"imported":[],"importedBy":[{"uid":"5277-4502"}]},"5277-4494":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js?commonjs-exports","moduleParts":{"metamask-sdk.js":"5277-4495"},"imported":[],"importedBy":[{"uid":"5277-4496"}]},"5277-4496":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.production.min.js","moduleParts":{"metamask-sdk.js":"5277-4497"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4494"}],"importedBy":[{"uid":"5277-4502"}]},"5277-4498":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4499"},"imported":[],"importedBy":[{"uid":"5277-4500"}]},"5277-4500":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/cjs/react.development.js","moduleParts":{"metamask-sdk.js":"5277-4501"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4498"}],"importedBy":[{"uid":"5277-4502"}]},"5277-4502":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react/index.js","moduleParts":{"metamask-sdk.js":"5277-4503"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4492"},{"uid":"5277-4496"},{"uid":"5277-4500"}],"importedBy":[{"uid":"5277-4597"},{"uid":"5277-4598"},{"uid":"5277-4599"},{"uid":"5277-4600"},{"uid":"5277-4602"},{"uid":"5277-4603"},{"uid":"5277-4604"},{"uid":"5277-4518"}]},"5277-4504":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/node_modules/@babel/runtime/helpers/extends.js?commonjs-module","moduleParts":{"metamask-sdk.js":"5277-4505"},"imported":[],"importedBy":[{"uid":"5277-4506"}]},"5277-4506":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/node_modules/@babel/runtime/helpers/extends.js","moduleParts":{"metamask-sdk.js":"5277-4507"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4504"}],"importedBy":[{"uid":"5277-4598"}]},"5277-4508":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/void-elements/index.js","moduleParts":{"metamask-sdk.js":"5277-4509"},"imported":[{"uid":"5277-3876"}],"importedBy":[{"uid":"5277-4633"}]},"5277-4510":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/html-parse-stringify/dist/html-parse-stringify.js","moduleParts":{"metamask-sdk.js":"5277-4511"},"imported":[{"uid":"5277-3876"},{"uid":"5277-4633"}],"importedBy":[{"uid":"5277-4598"}]},"5277-4512":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/unescape.js","moduleParts":{"metamask-sdk.js":"5277-4513"},"imported":[],"importedBy":[{"uid":"5277-4514"}]},"5277-4514":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/defaults.js","moduleParts":{"metamask-sdk.js":"5277-4515"},"imported":[{"uid":"5277-4512"}],"importedBy":[{"uid":"5277-4594"},{"uid":"5277-4598"},{"uid":"5277-4516"},{"uid":"5277-4518"}]},"5277-4516":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/initReactI18next.js","moduleParts":{"metamask-sdk.js":"5277-4517"},"imported":[{"uid":"5277-4514"},{"uid":"5277-4605"}],"importedBy":[{"uid":"5277-4594"},{"uid":"5277-4518"}]},"5277-4518":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/context.js","moduleParts":{"metamask-sdk.js":"5277-4519"},"imported":[{"uid":"5277-4502"},{"uid":"5277-4514"},{"uid":"5277-4605"},{"uid":"5277-4516"}],"importedBy":[{"uid":"5277-4594"},{"uid":"5277-4597"},{"uid":"5277-4599"},{"uid":"5277-4602"},{"uid":"5277-4603"},{"uid":"5277-4604"}]},"5277-4520":{"id":"/src/locales/en.json","moduleParts":{"metamask-sdk.js":"5277-4521"},"imported":[],"importedBy":[{"uid":"5277-4534"}]},"5277-4522":{"id":"/src/locales/es.json","moduleParts":{"metamask-sdk.js":"5277-4523"},"imported":[],"importedBy":[{"uid":"5277-4534"}]},"5277-4524":{"id":"/src/locales/fr.json","moduleParts":{"metamask-sdk.js":"5277-4525"},"imported":[],"importedBy":[{"uid":"5277-4534"}]},"5277-4526":{"id":"/src/locales/he.json","moduleParts":{"metamask-sdk.js":"5277-4527"},"imported":[],"importedBy":[{"uid":"5277-4534"}]},"5277-4528":{"id":"/src/locales/it.json","moduleParts":{"metamask-sdk.js":"5277-4529"},"imported":[],"importedBy":[{"uid":"5277-4534"}]},"5277-4530":{"id":"/src/locales/pt.json","moduleParts":{"metamask-sdk.js":"5277-4531"},"imported":[],"importedBy":[{"uid":"5277-4534"}]},"5277-4532":{"id":"/src/locales/tr.json","moduleParts":{"metamask-sdk.js":"5277-4533"},"imported":[],"importedBy":[{"uid":"5277-4534"}]},"5277-4534":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeI18next.ts","moduleParts":{"metamask-sdk.js":"5277-4535"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4490"},{"uid":"5277-4594"},{"uid":"5277-4520"},{"uid":"5277-4522"},{"uid":"5277-4524"},{"uid":"5277-4526"},{"uid":"5277-4528"},{"uid":"5277-4530"},{"uid":"5277-4532"}],"importedBy":[{"uid":"5277-4536"}]},"5277-4536":{"id":"/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts","moduleParts":{"metamask-sdk.js":"5277-4537"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4096"},{"uid":"5277-4342"},{"uid":"5277-4350"},{"uid":"5277-4380"},{"uid":"5277-4382"},{"uid":"5277-4388"},{"uid":"5277-4396"},{"uid":"5277-4424"},{"uid":"5277-4468"},{"uid":"5277-4474"},{"uid":"5277-4476"},{"uid":"5277-4478"},{"uid":"5277-4534"}],"importedBy":[{"uid":"5277-4549"},{"uid":"5277-4538"}]},"5277-4538":{"id":"/src/services/MetaMaskSDK/InitializerManager/initializeMetaMaskSDK.ts","moduleParts":{"metamask-sdk.js":"5277-4539"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4536"}],"importedBy":[{"uid":"5277-4549"}]},"5277-4540":{"id":"/src/services/MetaMaskSDK/ConnectionManager/connectAndSign.ts","moduleParts":{"metamask-sdk.js":"5277-4541"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4340"}],"importedBy":[{"uid":"5277-4542"}]},"5277-4542":{"id":"/src/sdk.ts","moduleParts":{"metamask-sdk.js":"5277-4543"},"imported":[{"uid":"5277-4098"},{"uid":"5277-4012"},{"uid":"5277-4334"},{"uid":"5277-4548"},{"uid":"5277-4549"},{"uid":"5277-4540"}],"importedBy":[{"uid":"5277-4544"}]},"5277-4544":{"id":"/src/index.ts","moduleParts":{"metamask-sdk.js":"5277-4545"},"imported":[{"uid":"5277-4096"},{"uid":"5277-4298"},{"uid":"5277-4542"},{"uid":"5277-4342"}],"importedBy":[],"isEntry":true},"5277-4546":{"id":"buffer","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4096"},{"uid":"5277-4356"},{"uid":"5277-4360"},{"uid":"5277-4634"}],"isExternal":true},"5277-4547":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/index.js","moduleParts":{},"imported":[{"uid":"5277-4553"},{"uid":"5277-4554"},{"uid":"5277-4022"},{"uid":"5277-4555"},{"uid":"5277-4556"},{"uid":"5277-4557"},{"uid":"5277-4018"},{"uid":"5277-4020"},{"uid":"5277-4558"}],"importedBy":[{"uid":"5277-4096"}]},"5277-4548":{"id":"/src/services/MetaMaskSDK/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-4336"},{"uid":"5277-4338"},{"uid":"5277-4344"}],"importedBy":[{"uid":"5277-4542"}]},"5277-4549":{"id":"/src/services/MetaMaskSDK/InitializerManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-4350"},{"uid":"5277-4352"},{"uid":"5277-4538"},{"uid":"5277-4380"},{"uid":"5277-4536"},{"uid":"5277-4382"},{"uid":"5277-4388"},{"uid":"5277-4396"},{"uid":"5277-4424"},{"uid":"5277-4468"},{"uid":"5277-4474"}],"importedBy":[{"uid":"5277-4542"}]},"5277-4550":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4006"}],"importedBy":[{"uid":"5277-4008"}]},"5277-4551":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3998"}],"importedBy":[{"uid":"5277-4008"},{"uid":"5277-4004"},{"uid":"5277-4002"}]},"5277-4552":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/consts.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3996"}],"importedBy":[{"uid":"5277-4008"},{"uid":"5277-3998"},{"uid":"5277-4002"}]},"5277-4553":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v1.js","moduleParts":{},"imported":[{"uid":"5277-4014"},{"uid":"5277-4020"}],"importedBy":[{"uid":"5277-4547"}]},"5277-4554":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v3.js","moduleParts":{},"imported":[{"uid":"5277-4565"},{"uid":"5277-4566"}],"importedBy":[{"uid":"5277-4547"}]},"5277-4555":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v5.js","moduleParts":{},"imported":[{"uid":"5277-4565"},{"uid":"5277-4567"}],"importedBy":[{"uid":"5277-4547"}]},"5277-4556":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/nil.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4547"}]},"5277-4557":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/version.js","moduleParts":{},"imported":[{"uid":"5277-4018"}],"importedBy":[{"uid":"5277-4547"}]},"5277-4558":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/parse.js","moduleParts":{},"imported":[{"uid":"5277-4018"}],"importedBy":[{"uid":"5277-4547"},{"uid":"5277-4565"}]},"5277-4559":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/BaseProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4172"}],"importedBy":[{"uid":"5277-4288"},{"uid":"5277-4272"}]},"5277-4560":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/createExternalExtensionProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4278"}],"importedBy":[{"uid":"5277-4288"}]},"5277-4561":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/initializeInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4286"}],"importedBy":[{"uid":"5277-4288"}]},"5277-4562":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/MetaMaskInpageProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4274"}],"importedBy":[{"uid":"5277-4288"},{"uid":"5277-4278"},{"uid":"5277-4286"}]},"5277-4563":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/shimWeb3.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4284"}],"importedBy":[{"uid":"5277-4288"},{"uid":"5277-4286"}]},"5277-4564":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/StreamProvider.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4272"}],"importedBy":[{"uid":"5277-4288"},{"uid":"5277-4278"},{"uid":"5277-4274"}]},"5277-4565":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/v35.js","moduleParts":{},"imported":[{"uid":"5277-4020"},{"uid":"5277-4558"}],"importedBy":[{"uid":"5277-4554"},{"uid":"5277-4555"}]},"5277-4566":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/md5.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4554"}]},"5277-4567":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/uuid/dist/esm-browser/sha1.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4555"}]},"5277-4568":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/debug/src/common.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4044"}],"importedBy":[{"uid":"5277-4046"}]},"5277-4569":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/classes.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4114"}],"importedBy":[{"uid":"5277-4128"},{"uid":"5277-4122"},{"uid":"5277-4126"}]},"5277-4570":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4122"}],"importedBy":[{"uid":"5277-4128"},{"uid":"5277-4126"}]},"5277-4571":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/errors.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4126"}],"importedBy":[{"uid":"5277-4128"}]},"5277-4572":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/error-constants.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4120"}],"importedBy":[{"uid":"5277-4128"},{"uid":"5277-4122"},{"uid":"5277-4126"}]},"5277-4573":{"id":"/src/services/MetaMaskSDK/ProviderManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-4346"}],"importedBy":[{"uid":"5277-4350"},{"uid":"5277-4468"}]},"5277-4574":{"id":"/src/services/RemoteConnection/index.ts","moduleParts":{},"imported":[{"uid":"5277-4466"}],"importedBy":[{"uid":"5277-4468"}]},"5277-4575":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PrivateKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4004"}],"importedBy":[{"uid":"5277-4006"}]},"5277-4576":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/dist/keys/PublicKey.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4002"}],"importedBy":[{"uid":"5277-4006"},{"uid":"5277-4004"}]},"5277-4577":{"id":"\u0000crypto?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-4595"}],"importedBy":[{"uid":"5277-3998"},{"uid":"5277-3884"}]},"5277-4578":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/elliptic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3990"}],"importedBy":[{"uid":"5277-3998"},{"uid":"5277-4004"},{"uid":"5277-4002"}]},"5277-4579":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@socket.io/component-emitter/index.js?commonjs-exports","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4034"}]},"5277-4580":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4106"}],"importedBy":[{"uid":"5277-4172"},{"uid":"5277-4152"}]},"5277-4581":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eth-rpc-errors/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4128"}],"importedBy":[{"uid":"5277-4172"},{"uid":"5277-4274"},{"uid":"5277-4170"},{"uid":"5277-4152"}]},"5277-4582":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/node_modules/fast-deep-equal/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4130"}],"importedBy":[{"uid":"5277-4172"}]},"5277-4583":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4158"}],"importedBy":[{"uid":"5277-4172"},{"uid":"5277-4170"}]},"5277-4584":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/messages.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4162"}],"importedBy":[{"uid":"5277-4172"},{"uid":"5277-4274"},{"uid":"5277-4272"},{"uid":"5277-4188"},{"uid":"5277-4168"}]},"5277-4585":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4170"}],"importedBy":[{"uid":"5277-4172"},{"uid":"5277-4278"},{"uid":"5277-4274"},{"uid":"5277-4272"},{"uid":"5277-4188"}]},"5277-4586":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/extension-port-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4178"}],"importedBy":[{"uid":"5277-4278"}]},"5277-4587":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/detect-browser/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4182"}],"importedBy":[{"uid":"5277-4278"}]},"5277-4588":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/extension-provider/external-extension-config.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4276"}],"importedBy":[{"uid":"5277-4278"}]},"5277-4589":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/siteMetadata.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4188"}],"importedBy":[{"uid":"5277-4274"}]},"5277-4590":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4250"}],"importedBy":[{"uid":"5277-4272"}]},"5277-4591":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/is-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4252"}],"importedBy":[{"uid":"5277-4272"}]},"5277-4592":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4268"}],"importedBy":[{"uid":"5277-4272"}]},"5277-4593":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/pump/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4270"}],"importedBy":[{"uid":"5277-4272"}]},"5277-4594":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/index.js","moduleParts":{},"imported":[{"uid":"5277-4597"},{"uid":"5277-4598"},{"uid":"5277-4599"},{"uid":"5277-4600"},{"uid":"5277-4601"},{"uid":"5277-4602"},{"uid":"5277-4603"},{"uid":"5277-4604"},{"uid":"5277-4516"},{"uid":"5277-4514"},{"uid":"5277-4605"},{"uid":"5277-4518"}],"importedBy":[{"uid":"5277-4534"}]},"5277-4595":{"id":"crypto","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4577"}],"isExternal":true},"5277-4596":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/fast-safe-stringify/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4112"}],"importedBy":[{"uid":"5277-4114"}]},"5277-4597":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Trans.js","moduleParts":{},"imported":[{"uid":"5277-4502"},{"uid":"5277-4598"},{"uid":"5277-4518"}],"importedBy":[{"uid":"5277-4594"}]},"5277-4598":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/TransWithoutContext.js","moduleParts":{},"imported":[{"uid":"5277-4506"},{"uid":"5277-4502"},{"uid":"5277-4510"},{"uid":"5277-4629"},{"uid":"5277-4514"},{"uid":"5277-4605"}],"importedBy":[{"uid":"5277-4594"},{"uid":"5277-4597"}]},"5277-4599":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useTranslation.js","moduleParts":{},"imported":[{"uid":"5277-4502"},{"uid":"5277-4518"},{"uid":"5277-4629"}],"importedBy":[{"uid":"5277-4594"},{"uid":"5277-4600"},{"uid":"5277-4601"}]},"5277-4600":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withTranslation.js","moduleParts":{},"imported":[{"uid":"5277-4502"},{"uid":"5277-4599"},{"uid":"5277-4629"}],"importedBy":[{"uid":"5277-4594"}]},"5277-4601":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/Translation.js","moduleParts":{},"imported":[{"uid":"5277-4599"}],"importedBy":[{"uid":"5277-4594"}]},"5277-4602":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/I18nextProvider.js","moduleParts":{},"imported":[{"uid":"5277-4502"},{"uid":"5277-4518"}],"importedBy":[{"uid":"5277-4594"}]},"5277-4603":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/withSSR.js","moduleParts":{},"imported":[{"uid":"5277-4502"},{"uid":"5277-4604"},{"uid":"5277-4518"},{"uid":"5277-4629"}],"importedBy":[{"uid":"5277-4594"}]},"5277-4604":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/useSSR.js","moduleParts":{},"imported":[{"uid":"5277-4502"},{"uid":"5277-4518"}],"importedBy":[{"uid":"5277-4594"},{"uid":"5277-4603"}]},"5277-4605":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/i18nInstance.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4594"},{"uid":"5277-4598"},{"uid":"5277-4516"},{"uid":"5277-4518"}]},"5277-4606":{"id":"/src/services/RemoteConnection/ConnectionInitializer/index.ts","moduleParts":{},"imported":[{"uid":"5277-4446"}],"importedBy":[{"uid":"5277-4466"}]},"5277-4607":{"id":"/src/services/RemoteConnection/ConnectionManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-4448"},{"uid":"5277-4452"},{"uid":"5277-4631"},{"uid":"5277-4460"}],"importedBy":[{"uid":"5277-4466"}]},"5277-4608":{"id":"/src/services/RemoteConnection/EventListeners/index.ts","moduleParts":{},"imported":[{"uid":"5277-4462"}],"importedBy":[{"uid":"5277-4466"}]},"5277-4609":{"id":"/src/services/RemoteConnection/ModalManager/index.ts","moduleParts":{},"imported":[{"uid":"5277-4458"},{"uid":"5277-4464"},{"uid":"5277-4450"}],"importedBy":[{"uid":"5277-4466"}]},"5277-4610":{"id":"@react-native-async-storage/async-storage","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4470"}],"isExternal":true},"5277-4611":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/futoin-hkdf/hkdf.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3884"}],"importedBy":[{"uid":"5277-4004"},{"uid":"5277-4002"}]},"5277-4612":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3886"}],"importedBy":[{"uid":"5277-3990"}]},"5277-4613":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/eciesjs/node_modules/secp256k1/lib/elliptic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3988"}],"importedBy":[{"uid":"5277-3990"}]},"5277-4614":{"id":"\u0000events?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-4632"}],"importedBy":[{"uid":"5277-4106"},{"uid":"5277-4264"},{"uid":"5277-4228"},{"uid":"5277-4202"}]},"5277-4615":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/idRemapMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4140"}],"importedBy":[{"uid":"5277-4158"}]},"5277-4616":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createAsyncMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4144"}],"importedBy":[{"uid":"5277-4158"}]},"5277-4617":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/createScaffoldMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4148"}],"importedBy":[{"uid":"5277-4158"}]},"5277-4618":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/getUniqueId.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4138"}],"importedBy":[{"uid":"5277-4158"},{"uid":"5277-4140"}]},"5277-4619":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/JsonRpcEngine.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4152"}],"importedBy":[{"uid":"5277-4158"},{"uid":"5277-4156"}]},"5277-4620":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-engine/dist/mergeMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4156"}],"importedBy":[{"uid":"5277-4158"}]},"5277-4621":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/providers/dist/middleware/createRpcWarningMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4168"}],"importedBy":[{"uid":"5277-4170"}]},"5277-4622":{"id":"\u0000stream?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-4628"}],"importedBy":[{"uid":"5277-4178"}]},"5277-4623":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/ObjectMultiplex.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4248"}],"importedBy":[{"uid":"5277-4250"}]},"5277-4624":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createEngineStream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4258"}],"importedBy":[{"uid":"5277-4268"}]},"5277-4625":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/dist/createStreamMiddleware.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4266"}],"importedBy":[{"uid":"5277-4268"}]},"5277-4626":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/once/once.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4240"}],"importedBy":[{"uid":"5277-4270"},{"uid":"5277-4248"},{"uid":"5277-4242"}]},"5277-4627":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/end-of-stream/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4242"}],"importedBy":[{"uid":"5277-4270"},{"uid":"5277-4248"}]},"5277-4628":{"id":"stream","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4364"},{"uid":"5277-4622"}],"isExternal":true},"5277-4629":{"id":"/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/react-i18next/dist/es/utils.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4598"},{"uid":"5277-4599"},{"uid":"5277-4600"},{"uid":"5277-4603"}]},"5277-4630":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/bowser/es5.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4400"}],"importedBy":[{"uid":"5277-4430"}]},"5277-4631":{"id":"/src/services/RemoteConnection/ConnectionManager/handleDisconnect.ts","moduleParts":{},"imported":[{"uid":"5277-4098"},{"uid":"5277-4358"}],"importedBy":[{"uid":"5277-4607"}]},"5277-4632":{"id":"events","moduleParts":{},"imported":[],"importedBy":[{"uid":"5277-4614"}],"isExternal":true},"5277-4633":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/void-elements/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4508"}],"importedBy":[{"uid":"5277-4510"}]},"5277-4634":{"id":"\u0000buffer?commonjs-external","moduleParts":{},"imported":[{"uid":"5277-4546"}],"importedBy":[{"uid":"5277-3884"},{"uid":"5277-4206"},{"uid":"5277-4210"}]},"5277-4635":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3986"}],"importedBy":[{"uid":"5277-3988"}]},"5277-4636":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/readable-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4234"}],"importedBy":[{"uid":"5277-4248"},{"uid":"5277-4258"},{"uid":"5277-4266"},{"uid":"5277-4246"}]},"5277-4637":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/@metamask/object-multiplex/dist/Substream.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4246"}],"importedBy":[{"uid":"5277-4248"}]},"5277-4638":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/json-rpc-middleware-stream/node_modules/@metamask/safe-event-emitter/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4264"}],"importedBy":[{"uid":"5277-4266"}]},"5277-4639":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/wrappy/wrappy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4238"}],"importedBy":[{"uid":"5277-4240"}]},"5277-4640":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/package.json?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3890"}],"importedBy":[{"uid":"5277-3986"}]},"5277-4641":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3908"}],"importedBy":[{"uid":"5277-3986"},{"uid":"5277-3970"},{"uid":"5277-3978"},{"uid":"5277-3984"},{"uid":"5277-3916"},{"uid":"5277-3922"},{"uid":"5277-3924"},{"uid":"5277-3926"},{"uid":"5277-3974"},{"uid":"5277-3976"},{"uid":"5277-3980"},{"uid":"5277-3982"}]},"5277-4642":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/brorand/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3912"}],"importedBy":[{"uid":"5277-3986"},{"uid":"5277-3978"}]},"5277-4643":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3928"}],"importedBy":[{"uid":"5277-3986"},{"uid":"5277-3970"}]},"5277-4644":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curves.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3970"}],"importedBy":[{"uid":"5277-3986"},{"uid":"5277-3978"},{"uid":"5277-3984"}]},"5277-4645":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3978"}],"importedBy":[{"uid":"5277-3986"}]},"5277-4646":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3984"}],"importedBy":[{"uid":"5277-3986"}]},"5277-4647":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_transform.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4230"}],"importedBy":[{"uid":"5277-4234"},{"uid":"5277-4232"}]},"5277-4648":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/_stream_passthrough.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4232"}],"importedBy":[{"uid":"5277-4234"}]},"5277-4649":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/process-nextick-args/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4198"}],"importedBy":[{"uid":"5277-4228"},{"uid":"5277-4220"},{"uid":"5277-4222"},{"uid":"5277-4216"}]},"5277-4650":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/isarray/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4200"}],"importedBy":[{"uid":"5277-4228"}]},"5277-4651":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/stream-browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4202"}],"importedBy":[{"uid":"5277-4228"},{"uid":"5277-4220"}]},"5277-4652":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/node_modules/safe-buffer/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4206"}],"importedBy":[{"uid":"5277-4228"},{"uid":"5277-4220"},{"uid":"5277-4214"},{"uid":"5277-4226"}]},"5277-4653":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/core-util-is/lib/util.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4210"}],"importedBy":[{"uid":"5277-4228"},{"uid":"5277-4220"},{"uid":"5277-4222"},{"uid":"5277-4230"},{"uid":"5277-4232"}]},"5277-4654":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/inherits/inherits_browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3920"}],"importedBy":[{"uid":"5277-4228"},{"uid":"5277-4220"},{"uid":"5277-4222"},{"uid":"5277-4230"},{"uid":"5277-4232"},{"uid":"5277-3922"},{"uid":"5277-3924"},{"uid":"5277-3926"},{"uid":"5277-3936"}]},"5277-4655":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/readable-stream/lib/internal/streams/destroy.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4216"}],"importedBy":[{"uid":"5277-4228"},{"uid":"5277-4220"}]},"5277-4656":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/util-deprecate/browser.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-4218"}],"importedBy":[{"uid":"5277-4220"}]},"5277-4657":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/node_modules/bn.js/lib/bn.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3900"}],"importedBy":[{"uid":"5277-3908"},{"uid":"5277-3978"},{"uid":"5277-3916"},{"uid":"5277-3922"},{"uid":"5277-3924"},{"uid":"5277-3926"},{"uid":"5277-3974"},{"uid":"5277-3976"},{"uid":"5277-3982"}]},"5277-4658":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-assert/index.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3902"}],"importedBy":[{"uid":"5277-3908"},{"uid":"5277-3972"},{"uid":"5277-3936"},{"uid":"5277-3940"},{"uid":"5277-3964"},{"uid":"5277-3950"},{"uid":"5277-3954"}]},"5277-4659":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/minimalistic-crypto-utils/lib/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3906"}],"importedBy":[{"uid":"5277-3908"},{"uid":"5277-3972"}]},"5277-4660":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/base.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3916"}],"importedBy":[{"uid":"5277-3928"},{"uid":"5277-3922"},{"uid":"5277-3924"},{"uid":"5277-3926"}]},"5277-4661":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/short.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3922"}],"importedBy":[{"uid":"5277-3928"}]},"5277-4662":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/mont.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3924"}],"importedBy":[{"uid":"5277-3928"}]},"5277-4663":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/curve/edwards.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3926"}],"importedBy":[{"uid":"5277-3928"}]},"5277-4664":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3966"}],"importedBy":[{"uid":"5277-3970"},{"uid":"5277-3984"},{"uid":"5277-3972"}]},"5277-4665":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hmac-drbg/lib/hmac-drbg.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3972"}],"importedBy":[{"uid":"5277-3978"}]},"5277-4666":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/key.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3974"}],"importedBy":[{"uid":"5277-3978"}]},"5277-4667":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/ec/signature.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3976"}],"importedBy":[{"uid":"5277-3978"}]},"5277-4668":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/key.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3980"}],"importedBy":[{"uid":"5277-3984"}]},"5277-4669":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/elliptic/lib/elliptic/eddsa/signature.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3982"}],"importedBy":[{"uid":"5277-3984"}]},"5277-4670":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/utils.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3936"}],"importedBy":[{"uid":"5277-3966"},{"uid":"5277-3940"},{"uid":"5277-3962"},{"uid":"5277-3964"},{"uid":"5277-3948"},{"uid":"5277-3952"},{"uid":"5277-3950"},{"uid":"5277-3956"},{"uid":"5277-3954"},{"uid":"5277-3946"}]},"5277-4671":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/common.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3940"}],"importedBy":[{"uid":"5277-3966"},{"uid":"5277-3962"},{"uid":"5277-3948"},{"uid":"5277-3950"},{"uid":"5277-3954"}]},"5277-4672":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3958"}],"importedBy":[{"uid":"5277-3966"}]},"5277-4673":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/ripemd.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3962"}],"importedBy":[{"uid":"5277-3966"}]},"5277-4674":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/hmac.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3964"}],"importedBy":[{"uid":"5277-3966"}]},"5277-4675":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/1.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3948"}],"importedBy":[{"uid":"5277-3958"}]},"5277-4676":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/224.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3952"}],"importedBy":[{"uid":"5277-3958"}]},"5277-4677":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/256.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3950"}],"importedBy":[{"uid":"5277-3958"},{"uid":"5277-3952"}]},"5277-4678":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/384.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3956"}],"importedBy":[{"uid":"5277-3958"}]},"5277-4679":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/512.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3954"}],"importedBy":[{"uid":"5277-3958"},{"uid":"5277-3956"}]},"5277-4680":{"id":"\u0000/Volumes/FD/Projects/metamask/metamask-sdk/node_modules/hash.js/lib/hash/sha/common.js?commonjs-proxy","moduleParts":{},"imported":[{"uid":"5277-3946"}],"importedBy":[{"uid":"5277-3948"},{"uid":"5277-3950"}]}},"env":{"rollup":"3.29.4"},"options":{"gzip":false,"brotli":false,"sourcemap":false}};
+
+    const run = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      const chartNode = document.querySelector("main");
+      drawChart.default(chartNode, data, width, height);
+    };
+
+    window.addEventListener('resize', run);
+
+    document.addEventListener('DOMContentLoaded', run);
+    /*-->*/
+  </script>
+</body>
+</html>
+

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && rollup -c --bundleConfigAsCjs",
+    "build:dev": "rimraf dist && NODE_ENV=dev rollup -c --bundleConfigAsCjs",
     "build:post-tsc": "echo 'N/A'",
     "build:pre-tsc": "echo 'N/A'",
     "clean": "rimraf ./dist",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,10 +59,11 @@
     "i18next-browser-languagedetector": "^7.1.0",
     "obj-multiplex": "^1.0.0",
     "pump": "^3.0.0",
-    "qrcode-terminal": "^0.12.0",
+    "qrcode-terminal-nooctal": "^0.12.1",
     "react-i18next": "^13.2.2",
     "react-native-webview": "^11.26.0",
     "readable-stream": "^2.3.7",
+    "rollup-plugin-visualizer": "^5.9.2",
     "socket.io-client": "^4.5.1",
     "util": "^0.12.4",
     "uuid": "^8.3.2"

--- a/packages/sdk/rollup.config.js
+++ b/packages/sdk/rollup.config.js
@@ -7,6 +7,7 @@ import jscc from 'rollup-plugin-jscc';
 import terser from '@rollup/plugin-terser';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 const packageJson = require('./package.json');
 
@@ -57,7 +58,7 @@ const config = [
       terser(),
       // Visualize the bundle to analyze its composition and size
       isDev && visualizer({
-        filename: `bundle_stats/browser-es-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/browser-es-stats-${packageJson.version}.html`,
       }),
     ],
   },
@@ -98,7 +99,7 @@ const config = [
       terser(),
       // Visualize the bundle to analyze its composition and size
       isDev && visualizer({
-        filename: `bundle_stats/browser-umd-iife-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/browser-umd-iife-stats-${packageJson.version}.html`,
       }),
     ],
   },
@@ -128,7 +129,7 @@ const config = [
       json(),
       terser(),
       isDev && visualizer({
-        filename: `bundle_stats/react-native-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/react-native-stats-${packageJson.version}.html`,
       }),
     ],
   },
@@ -170,7 +171,7 @@ const config = [
       json(),
       terser(),
       isDev && visualizer({
-        filename: `bundle_stats/node-stats-${pkgJson.version}.html`,
+        filename: `bundle_stats/node-stats-${packageJson.version}.html`,
       }),
     ],
   },

--- a/packages/sdk/src/types/globals.d.ts
+++ b/packages/sdk/src/types/globals.d.ts
@@ -1,0 +1,1 @@
+declare module 'qrcode-terminal-nooctal';

--- a/packages/sdk/src/ui/InstallModal/InstallModal-nodejs.test.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-nodejs.test.ts
@@ -1,7 +1,7 @@
 import { generate } from 'qrcode-terminal';
 import InstallModal from './InstallModal-nodejs';
 
-jest.mock('qrcode-terminal', () => ({
+jest.mock('qrcode-terminal-nooctal', () => ({
   generate: jest.fn((_, __, callback) => callback('Mocked QR Code')),
 }));
 

--- a/packages/sdk/src/ui/InstallModal/InstallModal-nodejs.test.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-nodejs.test.ts
@@ -1,4 +1,4 @@
-import { generate } from 'qrcode-terminal';
+import { generate } from 'qrcode-terminal-nooctal';
 import InstallModal from './InstallModal-nodejs';
 
 jest.mock('qrcode-terminal-nooctal', () => ({

--- a/packages/sdk/src/ui/InstallModal/InstallModal-nodejs.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-nodejs.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const qrcode = require('qrcode-terminal');
+const qrcode = require('qrcode-terminal-nooctal');
 
 const InstallModal = ({ link }: { link: string; debug?: boolean }) => {
   qrcode.generate(link, { small: true }, (qr: unknown) => console.log(qr));

--- a/yarn.lock
+++ b/yarn.lock
@@ -5162,7 +5162,7 @@ __metadata:
     obj-multiplex: ^1.0.0
     prettier: ^2.3.0
     pump: ^3.0.0
-    qrcode-terminal: ^0.12.0
+    qrcode-terminal-nooctal: ^0.12.1
     react-i18next: ^13.2.2
     react-native-webview: ^11.26.0
     readable-stream: ^2.3.7
@@ -5174,6 +5174,7 @@ __metadata:
     rollup-plugin-node-globals: ^1.4.0
     rollup-plugin-polyfill-node: ^0.11.0
     rollup-plugin-typescript2: ^0.31.2
+    rollup-plugin-visualizer: ^5.9.2
     socket.io-client: ^4.5.1
     ts-jest: ^29.0.3
     ts-node: ^10.9.1
@@ -5302,17 +5303,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/env@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/env@npm:13.2.4"
+  checksum: 4123e08a79e66d6144006972027a9ceb8f3fdd782c4a869df1eb3b91b59ad9f4a44082d3f8e421f4df5214c6bc7190b52b94881369452d65eb4580485f33b9e6
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:13.4.11-canary.0":
   version: 13.4.11-canary.0
   resolution: "@next/env@npm:13.4.11-canary.0"
   checksum: b215771c1a1f9cbd2e3a66e0ef1dc4188a24f452bc6c8c9c704e7e1f065f7fcf96ab12eb5efa68ded35179862e3a5027b012671c3731a945ab6461f0166456e7
-  languageName: node
-  linkType: hard
-
-"@next/env@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/env@npm:14.0.1"
-  checksum: 1fab6732f877c3702fce12396f16046f9b7a59c70b0d0b3db713995eed431706d12175530709d21c613682865ce82ef965a5719a43d6bc84142462a8ed558cda
   languageName: node
   linkType: hard
 
@@ -5325,6 +5326,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-android-arm-eabi@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-android-arm-eabi@npm:13.2.4"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@next/swc-android-arm64@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-android-arm64@npm:13.2.4"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-arm64@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-darwin-arm64@npm:13.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-arm64@npm:13.4.11-canary.0":
   version: 13.4.11-canary.0
   resolution: "@next/swc-darwin-arm64@npm:13.4.11-canary.0"
@@ -5332,10 +5354,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-darwin-arm64@npm:14.0.1"
-  conditions: os=darwin & cpu=arm64
+"@next/swc-darwin-x64@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-darwin-x64@npm:13.2.4"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5346,10 +5368,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-darwin-x64@npm:14.0.1"
-  conditions: os=darwin & cpu=x64
+"@next/swc-freebsd-x64@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-freebsd-x64@npm:13.2.4"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm-gnueabihf@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-linux-arm-gnueabihf@npm:13.2.4"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-gnu@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-linux-arm64-gnu@npm:13.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -5360,10 +5396,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-linux-arm64-gnu@npm:14.0.1"
-  conditions: os=linux & cpu=arm64 & libc=glibc
+"@next/swc-linux-arm64-musl@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-linux-arm64-musl@npm:13.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -5374,10 +5410,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-linux-arm64-musl@npm:14.0.1"
-  conditions: os=linux & cpu=arm64 & libc=musl
+"@next/swc-linux-x64-gnu@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-linux-x64-gnu@npm:13.2.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -5388,10 +5424,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-linux-x64-gnu@npm:14.0.1"
-  conditions: os=linux & cpu=x64 & libc=glibc
+"@next/swc-linux-x64-musl@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-linux-x64-musl@npm:13.2.4"
+  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -5402,10 +5438,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-linux-x64-musl@npm:14.0.1"
-  conditions: os=linux & cpu=x64 & libc=musl
+"@next/swc-win32-arm64-msvc@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-win32-arm64-msvc@npm:13.2.4"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -5416,10 +5452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-win32-arm64-msvc@npm:14.0.1"
-  conditions: os=win32 & cpu=arm64
+"@next/swc-win32-ia32-msvc@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-win32-ia32-msvc@npm:13.2.4"
+  conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
@@ -5430,23 +5466,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-win32-ia32-msvc@npm:14.0.1"
-  conditions: os=win32 & cpu=ia32
+"@next/swc-win32-x64-msvc@npm:13.2.4":
+  version: 13.2.4
+  resolution: "@next/swc-win32-x64-msvc@npm:13.2.4"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@next/swc-win32-x64-msvc@npm:13.4.11-canary.0":
   version: 13.4.11-canary.0
   resolution: "@next/swc-win32-x64-msvc@npm:13.4.11-canary.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@next/swc-win32-x64-msvc@npm:14.0.1":
-  version: 14.0.1
-  resolution: "@next/swc-win32-x64-msvc@npm:14.0.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6563,21 +6592,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/helpers@npm:0.4.14":
+  version: 0.4.14
+  resolution: "@swc/helpers@npm:0.4.14"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: 273fd3f3fc461a92f3790cc551ea054745c6d6959afbe1232e6d7aa1c722bbc114d308aab96bef5c78fc0303c85c7b472ef00e2253251cc89737f3b1af56e5a5
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:0.5.1":
   version: 0.5.1
   resolution: "@swc/helpers@npm:0.5.1"
   dependencies:
     tslib: ^2.4.0
   checksum: 71e0e27234590435e4c62b97ef5e796f88e786841a38c7116a5e27a3eafa7b9ead7cdec5249b32165902076de78446945311c973e59bddf77c1e24f33a8f272a
-  languageName: node
-  linkType: hard
-
-"@swc/helpers@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@swc/helpers@npm:0.5.2"
-  dependencies:
-    tslib: ^2.4.0
-  checksum: 51d7e3d8bd56818c49d6bfbd715f0dbeedc13cf723af41166e45c03e37f109336bbcb57a1f2020f4015957721aeb21e1a7fff281233d797ff7d3dd1f447fa258
   languageName: node
   linkType: hard
 
@@ -13133,7 +13162,7 @@ __metadata:
     eslint-config-next: 13.2.4
     ethers: 5.7.2
     jest: ^29.6.4
-    next: ^14.0.1
+    next: 13.2.4
     preact: ^10.13.1
     prettier: ^3.0.3
     react: 18.2.0
@@ -22115,35 +22144,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^14.0.1":
-  version: 14.0.1
-  resolution: "next@npm:14.0.1"
+"next@npm:13.2.4":
+  version: 13.2.4
+  resolution: "next@npm:13.2.4"
   dependencies:
-    "@next/env": 14.0.1
-    "@next/swc-darwin-arm64": 14.0.1
-    "@next/swc-darwin-x64": 14.0.1
-    "@next/swc-linux-arm64-gnu": 14.0.1
-    "@next/swc-linux-arm64-musl": 14.0.1
-    "@next/swc-linux-x64-gnu": 14.0.1
-    "@next/swc-linux-x64-musl": 14.0.1
-    "@next/swc-win32-arm64-msvc": 14.0.1
-    "@next/swc-win32-ia32-msvc": 14.0.1
-    "@next/swc-win32-x64-msvc": 14.0.1
-    "@swc/helpers": 0.5.2
-    busboy: 1.6.0
+    "@next/env": 13.2.4
+    "@next/swc-android-arm-eabi": 13.2.4
+    "@next/swc-android-arm64": 13.2.4
+    "@next/swc-darwin-arm64": 13.2.4
+    "@next/swc-darwin-x64": 13.2.4
+    "@next/swc-freebsd-x64": 13.2.4
+    "@next/swc-linux-arm-gnueabihf": 13.2.4
+    "@next/swc-linux-arm64-gnu": 13.2.4
+    "@next/swc-linux-arm64-musl": 13.2.4
+    "@next/swc-linux-x64-gnu": 13.2.4
+    "@next/swc-linux-x64-musl": 13.2.4
+    "@next/swc-win32-arm64-msvc": 13.2.4
+    "@next/swc-win32-ia32-msvc": 13.2.4
+    "@next/swc-win32-x64-msvc": 13.2.4
+    "@swc/helpers": 0.4.14
     caniuse-lite: ^1.0.30001406
-    postcss: 8.4.31
+    postcss: 8.4.14
     styled-jsx: 5.1.1
-    watchpack: 2.4.0
   peerDependencies:
-    "@opentelemetry/api": ^1.1.0
+    "@opentelemetry/api": ^1.4.0
+    fibers: ">= 3.1.0"
+    node-sass: ^6.0.0 || ^7.0.0
     react: ^18.2.0
     react-dom: ^18.2.0
     sass: ^1.3.0
   dependenciesMeta:
+    "@next/swc-android-arm-eabi":
+      optional: true
+    "@next/swc-android-arm64":
+      optional: true
     "@next/swc-darwin-arm64":
       optional: true
     "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-freebsd-x64":
+      optional: true
+    "@next/swc-linux-arm-gnueabihf":
       optional: true
     "@next/swc-linux-arm64-gnu":
       optional: true
@@ -22162,11 +22203,15 @@ __metadata:
   peerDependenciesMeta:
     "@opentelemetry/api":
       optional: true
+    fibers:
+      optional: true
+    node-sass:
+      optional: true
     sass:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: d142407f47012eb57ba3932f91453960c79d7df2fef03ded581f32195b98a4378e13c49709f498a112d142109a8edd73f40357ee102a6bd4d7b1f76de9f0877a
+  checksum: 8531dee41b60181b582f5ee80858907b102f083ef8808ff9352d589dd39e6b3a96f7a11b3776a03eef3a28430cff768336fa2e3ff2c6f8fcd699fbc891749051
   languageName: node
   linkType: hard
 
@@ -24326,17 +24371,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
-  dependencies:
-    nanoid: ^3.3.6
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 1d8611341b073143ad90486fcdfeab49edd243377b1f51834dc4f6d028e82ce5190e4f11bb2633276864503654fb7cab28e67abdc0fbf9d1f88cad4a0ff0beea
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^7.0.35":
   version: 7.0.39
   resolution: "postcss@npm:7.0.39"
@@ -24950,12 +24984,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qrcode-terminal@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "qrcode-terminal@npm:0.12.0"
+"qrcode-terminal-nooctal@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "qrcode-terminal-nooctal@npm:0.12.1"
   bin:
-    qrcode-terminal: ./bin/qrcode-terminal.js
-  checksum: 51638d11d080e06ef79ef2d5cfe911202159e48d2873d6a80a3c5489b4b767acf4754811ceba4e113db8f41f61a06c163bcb17e6e18e6b34e04a7a5155dac974
+    qrcode-terminal: bin/qrcode-terminal.js
+  checksum: 1071c4be2bfa07b3956ad0a63c87452ced0b5180a9dc19f224fc3dd69bb24ad687a7af365acdde0f876ddf89dc1a4beadba88d89c7c5c5cbf2ef3efaef64736e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Allow the package to work with nodejs strictmode.
I had to fork / republish the qrcode-terminal dependency and remove all the legacy octal that were not permitted in strictmode.
- Add visualizer to keep track of bundle history