### PR TITLE
fix: add missing wagmi provider wrapper dependencies

### DIFF
--- a/packages/sdk-react-ui/src/MetaMaskUIProvider.tsx
+++ b/packages/sdk-react-ui/src/MetaMaskUIProvider.tsx
@@ -75,7 +75,7 @@ const WagmiWrapper = ({
     }
 
     return connectors;
-  }, [ready, sdk]);
+  }, [ready, sdk, networks, debug, connectors]);
 
   const config = createConfig({ publicClient, connectors: validConnectors })
 


### PR DESCRIPTION
Make sure the list of valid connectors update with changing chains and connectors.