### PR TITLE
Release 36.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "35.0.0",
+  "version": "36.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2]
+### Uncategorized
+- fix: add missing wagmi provider wrapper dependencies ([#459](https://github.com/MetaMask/metamask-sdk/pull/459))
+
 ## [0.11.1]
 ### Added
 - align version with sdk
@@ -50,14 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...HEAD
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.6.0
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.2...HEAD
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.1...@metamask/sdk-react-ui@0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.0...@metamask/sdk-react-ui@0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.1...@metamask/sdk-react-ui@0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.0...@metamask/sdk-react-ui@0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.9.0...@metamask/sdk-react-ui@0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.8.0...@metamask/sdk-react-ui@0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.7.0...@metamask/sdk-react-ui@0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.2...@metamask/sdk-react-ui@0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.1...@metamask/sdk-react-ui@0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.0...@metamask/sdk-react-ui@0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react-ui@0.6.0

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.11.2]
-### Uncategorized
+### Added
 - fix: add missing wagmi provider wrapper dependencies ([#459](https://github.com/MetaMask/metamask-sdk/pull/459))
 
 ## [0.11.1]
@@ -54,15 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.2...HEAD
-[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.1...@metamask/sdk-react-ui@0.11.2
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.0...@metamask/sdk-react-ui@0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.1...@metamask/sdk-react-ui@0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.0...@metamask/sdk-react-ui@0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.9.0...@metamask/sdk-react-ui@0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.8.0...@metamask/sdk-react-ui@0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.7.0...@metamask/sdk-react-ui@0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.2...@metamask/sdk-react-ui@0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.1...@metamask/sdk-react-ui@0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.0...@metamask/sdk-react-ui@0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react-ui@0.6.0
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...v0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.6.0

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2]
+
 ## [0.11.1]
 ### Added
 - align version with sdk
@@ -76,18 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...HEAD
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.6...v0.6.0
-[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.4...v0.5.6
-[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.3...v0.5.4
-[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/v0.3.1...v0.5.3
-[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.3.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.2...HEAD
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.1...@metamask/sdk-react@0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.0...@metamask/sdk-react@0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.1...@metamask/sdk-react@0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.0...@metamask/sdk-react@0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.9.0...@metamask/sdk-react@0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.8.0...@metamask/sdk-react@0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.7.0...@metamask/sdk-react@0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.2...@metamask/sdk-react@0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.1...@metamask/sdk-react@0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.0...@metamask/sdk-react@0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.6...@metamask/sdk-react@0.6.0
+[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.4...@metamask/sdk-react@0.5.6
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.3...@metamask/sdk-react@0.5.4
+[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.3.1...@metamask/sdk-react@0.5.3
+[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react@0.3.1

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.11.2]
+### Uncategorized
+- align version with sdk
 
 ## [0.11.1]
 ### Added
@@ -78,19 +80,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.2...HEAD
-[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.1...@metamask/sdk-react@0.11.2
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.0...@metamask/sdk-react@0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.1...@metamask/sdk-react@0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.0...@metamask/sdk-react@0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.9.0...@metamask/sdk-react@0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.8.0...@metamask/sdk-react@0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.7.0...@metamask/sdk-react@0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.2...@metamask/sdk-react@0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.1...@metamask/sdk-react@0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.0...@metamask/sdk-react@0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.6...@metamask/sdk-react@0.6.0
-[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.4...@metamask/sdk-react@0.5.6
-[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.3...@metamask/sdk-react@0.5.4
-[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.3.1...@metamask/sdk-react@0.5.3
-[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react@0.3.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...v0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.6...v0.6.0
+[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.4...v0.5.6
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/v0.3.1...v0.5.3
+[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.3.1

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.11.2]
+### Uncategorized
+- align version with sdk-react* packages
 
 ## [0.11.1]
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2]
+
 ## [0.11.1]
 ### Added
 - build: improve sdk bundle to work with nodejs strictmode ([#457](https://github.com/MetaMask/metamask-sdk/pull/457))
@@ -167,7 +169,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.11.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.11.2...HEAD
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.11.1...@metamask/sdk@0.11.2
 [0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.11.0...@metamask/sdk@0.11.1
 [0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.10.1...@metamask/sdk@0.11.0
 [0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.10.0...@metamask/sdk@0.10.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk-react-ui [0.11.2]
### Added
- fix: add missing wagmi provider wrapper dependencies ([#459](https://github.com/MetaMask/metamask-sdk/pull/459))
