### PR TITLE
feat: qrcode deeplinks

### DIFF
--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -203,6 +203,7 @@ export class MetaMaskSDK extends EventEmitter2 {
       forceInjectProvider: false,
       enableDebug: true,
       shouldShimWeb3: true,
+      useDeeplink: false,
       dappMetadata: {
         name: '',
         url: '',

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
@@ -231,8 +231,8 @@ describe('write function', () => {
       );
 
       expect(mockOpenDeeplink).toHaveBeenCalledWith(
-        'https://metamask.app.link/connect?channelId=some_channel_id&pubkey=&comm=socket&t=q',
-        'metamask://connect?channelId=some_channel_id&pubkey=&comm=socket&t=q',
+        'https://metamask.app.link/connect?channelId=some_channel_id&pubkey=&comm=socket&t=d',
+        'metamask://connect?channelId=some_channel_id&pubkey=&comm=socket&t=d',
         '_self',
       );
     });
@@ -249,8 +249,8 @@ describe('write function', () => {
       );
 
       expect(mockOpenDeeplink).toHaveBeenCalledWith(
-        'https://metamask.app.link/connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket&t=q',
-        'metamask://connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket&t=q',
+        'https://metamask.app.link/connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket&t=d',
+        'metamask://connect?redirect=true&channelId=some_channel_id&pubkey=&comm=socket&t=d',
         '_self',
       );
     });

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -91,7 +91,7 @@ export async function write(
     const pubKey = instance.state.remote?.getKeyInfo()?.ecies.public ?? '';
 
     const urlParams = encodeURI(
-      `channelId=${channelId}&pubkey=${pubKey}&comm=socket&t=q`,
+      `channelId=${channelId}&pubkey=${pubKey}&comm=socket&t=d`,
     );
 
     if (METHODS_TO_REDIRECT[targetMethod]) {

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
@@ -1,4 +1,7 @@
-import { METAMASK_CONNECT_BASE_URL } from '../../../constants';
+import {
+  METAMASK_CONNECT_BASE_URL,
+  METAMASK_DEEPLINK_BASE,
+} from '../../../constants';
 import { Ethereum } from '../../Ethereum';
 import { reconnectWithModalOTP } from '../ModalManager/reconnectWithModalOTP';
 import {
@@ -51,10 +54,19 @@ export async function startConnection(
   const linkParams = encodeURI(
     `channelId=${channelId}&comm=${
       state.communicationLayerPreference ?? ''
-    }&pubkey=${pubKey}`,
+    }&pubkey=${pubKey}&t=q`,
   );
-  const universalLink = `${METAMASK_CONNECT_BASE_URL}?${linkParams}`;
-  state.universalLink = universalLink;
+
+  const qrcodeLink = `${
+    state.useDeeplink ? METAMASK_DEEPLINK_BASE : METAMASK_CONNECT_BASE_URL
+  }?${linkParams}`;
+  state.qrcodeLink = qrcodeLink;
+
+  if (state.developerMode) {
+    console.debug(
+      `RemoteConnection::startConnection() qrcodeLink=${qrcodeLink}`,
+    );
+  }
 
   // first handle secure connection
   if (state.platformManager?.isSecure()) {

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/showActiveModal.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/showActiveModal.test.ts
@@ -19,7 +19,8 @@ describe('showActiveModal', () => {
       installModal: {
         mount: mockInstallModalMount,
       },
-      universalLink: 'http://example.com',
+      useDeeplink: false,
+      qrcodeLink: 'http://example.com',
     } as unknown as RemoteConnectionState;
   });
 
@@ -45,12 +46,12 @@ describe('showActiveModal', () => {
     showActiveModal(state);
 
     expect(mockPendingModalMount).not.toHaveBeenCalled();
-    expect(mockInstallModalMount).toHaveBeenCalledWith(state.universalLink);
+    expect(mockInstallModalMount).toHaveBeenCalledWith(state.qrcodeLink);
   });
 
   it('should mount the installModal without universalLink if it is not defined', () => {
     state.pendingModal = undefined;
-    state.universalLink = undefined;
+    state.qrcodeLink = undefined;
 
     showActiveModal(state);
 

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/showActiveModal.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/showActiveModal.ts
@@ -18,6 +18,6 @@ export function showActiveModal(state: RemoteConnectionState): void {
     // only display the modal if the connection is not authorized
     state.pendingModal.mount?.();
   } else if (state.installModal) {
-    state.installModal.mount?.(state.universalLink || '');
+    state.installModal.mount?.(state.qrcodeLink || '');
   }
 }

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.test.ts
@@ -25,7 +25,9 @@ describe('RemoteConnection', () => {
   beforeEach(() => {
     options = {
       communicationLayerPreference: CommunicationLayerPreference.SOCKET,
-      sdk: {} as MetaMaskSDK,
+      sdk: {
+        options: {},
+      } as MetaMaskSDK,
       platformManager: {} as PlatformManager,
       modals: {},
     } as unknown as RemoteConnectionProps;
@@ -70,7 +72,7 @@ describe('RemoteConnection', () => {
 
     it('should return the universal link if connection is started', () => {
       const connection = new RemoteConnection(options);
-      connection.state.universalLink = 'http://example.com';
+      connection.state.qrcodeLink = 'http://example.com';
       expect(connection.getUniversalLink()).toBe('http://example.com');
     });
   });

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -75,7 +75,8 @@ export interface RemoteConnectionProps {
 
 export interface RemoteConnectionState {
   connector?: RemoteCommunication;
-  universalLink?: string;
+  qrcodeLink?: string;
+  useDeeplink?: boolean;
   developerMode: boolean;
   analytics?: Analytics;
   authorized: boolean;
@@ -103,7 +104,7 @@ export class RemoteConnection implements ProviderService {
 
   public state: RemoteConnectionState = {
     connector: undefined,
-    universalLink: undefined,
+    qrcodeLink: undefined,
     analytics: undefined,
     developerMode: false,
     authorized: false,
@@ -121,6 +122,7 @@ export class RemoteConnection implements ProviderService {
       options.logging?.developerMode === true || options.logging?.sdk === true;
     this.state.developerMode = developerMode;
     this.state.analytics = options.analytics;
+    this.state.useDeeplink = options.sdk.options.useDeeplink;
     this.state.communicationLayerPreference =
       options.communicationLayerPreference;
     this.state.platformManager = options.platformManager;
@@ -152,10 +154,10 @@ export class RemoteConnection implements ProviderService {
   }
 
   getUniversalLink() {
-    if (!this.state.universalLink) {
+    if (!this.state.qrcodeLink) {
       throw new Error('connection not started. run startConnection() first.');
     }
-    return this.state.universalLink;
+    return this.state.qrcodeLink;
   }
 
   getChannelConfig(): ChannelConfig | undefined {


### PR DESCRIPTION
Previously, the QRCode url would only contain the universal link regardless of the initialization preferences since it doesn't open an actual deeplink. This can lead to inconsistency on the wallet and thus better aligning the url with the actual deeplink schema.
- Allow switching between deeplink / universal link even when qrcode is selected.
- Add t={q|d} to differentiate on the wallet for the correct origin and prevent bypass when scanning from camera.