### PR TITLE
feat: sdk option openDeepLink with dynamic url 

### DIFF
--- a/packages/devreactnative/App.tsx
+++ b/packages/devreactnative/App.tsx
@@ -39,10 +39,12 @@ LogBox.ignoreLogs([
 let canOpenLink = true;
 const serverUrl = COMM_SERVER_URL ?? DEFAULT_SERVER_URL;
 
+const useDeeplink = true;
+
 const sdk = new MetaMaskSDK({
-  openDeeplink: (link: string) => {
-    if (canOpenLink) {
+  openDeeplink: (link: string, target?: string) => {
       console.debug(`App::openDeepLink() ${link}`);
+    if (canOpenLink) {
       Linking.openURL(link);
     } else {
       console.debug(
@@ -58,7 +60,7 @@ const sdk = new MetaMaskSDK({
   infuraAPIKey: INFURA_API_KEY ?? undefined,
   timer: BackgroundTimer,
   enableDebug: true,
-  useDeeplink: true,
+  useDeeplink,
   dappMetadata: {
     url: 'devreactnative',
     name: 'devreactnative',

--- a/packages/sdk/src/services/PlatfformManager/openDeeplink.ts
+++ b/packages/sdk/src/services/PlatfformManager/openDeeplink.ts
@@ -22,7 +22,10 @@ export function openDeeplink(
 
   try {
     if (state.preferredOpenLink) {
-      state.preferredOpenLink(universalLink, target);
+      state.preferredOpenLink(
+        state.useDeeplink ? deeplink : universalLink,
+        target,
+      );
       return;
     }
 


### PR DESCRIPTION
When using sdk with a custom url opening function `openDeeplink option`, it would only send the universal link url as parameter.
```ts
const sdk = new MetaMaskSDK({
  openDeeplink: (link: string, target?: string) => {
      console.debug(`App::openDeepLink() ${link}`);
    if (canOpenLink) {
      Linking.openURL(link);
    } else {
      console.debug(
        'useBlockchainProiver::openDeepLink app is not active - skip link',
        link,
      );
    }
  },
```
With this PR, the value of the link will be dynamic based on the sdk `useDeeplink` option.