### PR TITLE
feat: allow editing otherpublickey for faster connection recovery

### DIFF
--- a/packages/sdk-communication-layer/src/KeyExchange.test.ts
+++ b/packages/sdk-communication-layer/src/KeyExchange.test.ts
@@ -1,0 +1,33 @@
+import EventEmitter2 from 'eventemitter2';
+import { KeyExchange } from './KeyExchange';
+import { CommunicationLayer } from './types/CommunicationLayer';
+
+jest.mock('./ECIES');
+jest.mock('./types/CommunicationLayer'); // Assuming CommunicationLayer is a class that can be mocked.
+
+describe('KeyExchange', () => {
+  let keyExchange: KeyExchange;
+  let mockCommunicationLayer: jest.Mocked<CommunicationLayer>;
+
+  beforeEach(() => {
+    // Create a mock CommunicationLayer instance
+    mockCommunicationLayer =
+      new EventEmitter2() as jest.Mocked<CommunicationLayer>;
+
+    // Initialize the KeyExchange instance with the mocked CommunicationLayer
+    keyExchange = new KeyExchange({
+      communicationLayer: mockCommunicationLayer,
+      context: 'testContext',
+      sendPublicKey: true,
+      ecies: {},
+      logging: { keyExchangeLayer: true },
+    });
+  });
+
+  it('should properly initialize', () => {
+    expect(keyExchange).toBeInstanceOf(KeyExchange);
+    // Additional checks for properties can be done here.
+  });
+
+  // More tests will go here...
+});

--- a/packages/sdk-communication-layer/src/KeyExchange.ts
+++ b/packages/sdk-communication-layer/src/KeyExchange.ts
@@ -242,6 +242,10 @@ export class KeyExchange extends EventEmitter2 {
     return this.myPublicKey;
   }
 
+  getOtherPublicKey() {
+    return this.otherPublicKey;
+  }
+
   setOtherPublicKey(otherPubKey: string) {
     if (this.debug) {
       console.debug(`KeyExchange::setOtherPubKey()`, otherPubKey);

--- a/packages/sdk-communication-layer/src/RemoteCommunication.ts
+++ b/packages/sdk-communication-layer/src/RemoteCommunication.ts
@@ -318,6 +318,17 @@ export class RemoteCommunication extends EventEmitter2 {
     this.state.communicationLayer?.resetKeys();
   }
 
+  setOtherPublicKey(otherPublicKey: string) {
+    const keyExchange = this.state.communicationLayer?.getKeyExchange();
+    if (!keyExchange) {
+      throw new Error('KeyExchange is not initialized.');
+    }
+
+    if (keyExchange.getOtherPublicKey() !== otherPublicKey) {
+      keyExchange.setOtherPublicKey(otherPublicKey);
+    }
+  }
+
   pause() {
     if (this.state.debug) {
       console.debug(

--- a/packages/sdk-communication-layer/src/SocketService.ts
+++ b/packages/sdk-communication-layer/src/SocketService.ts
@@ -161,6 +161,10 @@ export class SocketService extends EventEmitter2 implements CommunicationLayer {
     return keyCheck(this);
   }
 
+  getKeyExchange() {
+    return this.state.keyExchange as KeyExchange;
+  }
+
   sendMessage(message: CommunicationLayerMessage): void {
     return handleSendMessage(this, message);
   }

--- a/packages/sdk-communication-layer/src/types/CommunicationLayer.ts
+++ b/packages/sdk-communication-layer/src/types/CommunicationLayer.ts
@@ -1,4 +1,5 @@
 import { EventEmitter2 } from 'eventemitter2';
+import { KeyExchange } from '../KeyExchange';
 import { Channel } from './Channel';
 import { CommunicationLayerMessage } from './CommunicationLayerMessage';
 import { ConnectToChannelOptions } from './ConnectToChannelOptions';
@@ -17,4 +18,5 @@ export interface CommunicationLayer extends EventEmitter2 {
   isConnected(): boolean;
   resume(): void;
   disconnect(options?: DisconnectOptions): void;
+  getKeyExchange(): KeyExchange;
 }


### PR DESCRIPTION
Because of the nature of session persistence where both side can update their public keys independently while disconnected, this mechanism allow to update the dapp public key on the wallet via a deeplink instead of re-creating a full key exchange on the network.