### PR TITLE
feat: disable favicon in dappmetadata

### DIFF
--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/initCommunicationLayer.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/initCommunicationLayer.ts
@@ -93,7 +93,7 @@ export function initCommunicationLayer({
     url,
     title,
     source: state.dappMetadata?.source,
-    icon: state.dappMetadata?.base64Icon,
+    // icon: state.dappMetadata?.base64Icon, // TODO re-enable and replace with url
     platform: state.platformType,
     apiVersion: packageJson.version,
   };


### PR DESCRIPTION
Disable sending favicon as base64 because it is slower to encrypt on some device as well as inefficient during limited connection exchange between devices.
Instead the dapp should set the url in the metadata and the wallet will extract the favicon from the url.