### PR TITLE
feat: add backward v3 json compatibility on i18n

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/initializeI18next.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/initializeI18next.ts
@@ -32,6 +32,7 @@ export async function initializeI18next(instance: MetaMaskSDK) {
     .use(LanguageDetector)
     .init({
       debug: i18nOptions.debug ?? false,
+      compatibilityJSON: 'v3',
       fallbackLng: 'en',
       interpolation: {
         escapeValue: false,


### PR DESCRIPTION
Set `      compatibilityJSON: 'v3', ` on i18n to avoid having to polyfills on react native.