### PR TITLE
feat: default to use deeplinks instead of universal links

### DIFF
--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -204,7 +204,7 @@ export class MetaMaskSDK extends EventEmitter2 {
       forceInjectProvider: false,
       enableDebug: true,
       shouldShimWeb3: true,
-      useDeeplink: false,
+      useDeeplink: true,
       dappMetadata: {
         name: '',
         url: '',


### PR DESCRIPTION
feat: default to use deeplinks instead of universal links 