### PR TITLE
feat: propagate extension events

### DIFF
--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -25,3 +25,11 @@ export const RPC_METHODS = {
   ETH_ACCOUNTS: 'eth_accounts',
   ETH_CHAINID: 'eth_chainId',
 };
+
+export const EXTENSION_EVENTS = {
+  CHAIN_CHANGED: 'chainChanged',
+  ACCOUNTS_CHANGED: 'accountsChanged',
+  DISCONNECT: 'disconnect',
+  CONNECT: 'connect',
+  CONNECTED: 'connected',
+};

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -320,6 +320,14 @@ export class MetaMaskSDK extends EventEmitter2 {
     return this.activeProvider;
   }
 
+  getMobileProvider(): SDKProvider {
+    if (!this.sdkProvider) {
+      throw new Error(`SDK state invalid -- undefined mobile provider`);
+    }
+
+    return this.sdkProvider;
+  }
+
   getUniversalLink() {
     const universalLink = this.remoteConnection?.getUniversalLink();
 

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
@@ -45,6 +45,42 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
       });
 
       window.extension = metamaskBrowserExtension;
+
+      // Propagate browser extension events onto the main provider since some clients only subscribe to the main mobile provider.
+      metamaskBrowserExtension.on('chainChanged', (chainId) => {
+        if (developerMode) {
+          console.debug('PROPAGATE chainChanged', chainId);
+        }
+        instance.getMobileProvider().emit('chainChanged', chainId);
+      });
+
+      metamaskBrowserExtension.on('accountsChanged', (accounts) => {
+        if (developerMode) {
+          console.debug('PROPAGATE accountsChanged', accounts);
+        }
+        instance.getMobileProvider().emit('accountsChanged', accounts);
+      });
+
+      metamaskBrowserExtension.on('disconnect', (error) => {
+        if (developerMode) {
+          console.debug('PROPAGATE disconnect', error);
+        }
+        instance.getMobileProvider().emit('disconnect', error);
+      });
+
+      metamaskBrowserExtension.on('connect', (args) => {
+        if (developerMode) {
+          console.debug('PROPAGATE connect', args);
+        }
+        instance.getMobileProvider().emit('connect', args);
+      });
+
+      metamaskBrowserExtension.on('connected', (args) => {
+        if (developerMode) {
+          console.debug('PROPAGATE connected', args);
+        }
+        instance.getMobileProvider().emit('connected', args);
+      });
     } catch (err) {
       // Ignore error if metamask extension not found
       delete window.extension;

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
@@ -1,5 +1,5 @@
 import { TrackingEvents } from '@metamask/sdk-communication-layer';
-import { STORAGE_PROVIDER_TYPE } from '../../../config';
+import { EXTENSION_EVENTS, STORAGE_PROVIDER_TYPE } from '../../../config';
 import { MetaMaskSDK } from '../../../sdk';
 import { getBrowserExtension } from '../../../utils/get-browser-extension';
 import { Ethereum } from '../../Ethereum';
@@ -47,39 +47,49 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
       window.extension = metamaskBrowserExtension;
 
       // Propagate browser extension events onto the main provider since some clients only subscribe to the main mobile provider.
-      metamaskBrowserExtension.on('chainChanged', (chainId) => {
+      metamaskBrowserExtension.on(EXTENSION_EVENTS.CHAIN_CHANGED, (chainId) => {
         if (developerMode) {
           console.debug('PROPAGATE chainChanged', chainId);
         }
-        instance.getMobileProvider().emit('chainChanged', chainId);
+
+        instance
+          .getMobileProvider()
+          .emit(EXTENSION_EVENTS.CHAIN_CHANGED, chainId);
       });
 
-      metamaskBrowserExtension.on('accountsChanged', (accounts) => {
-        if (developerMode) {
-          console.debug('PROPAGATE accountsChanged', accounts);
-        }
-        instance.getMobileProvider().emit('accountsChanged', accounts);
-      });
+      metamaskBrowserExtension.on(
+        EXTENSION_EVENTS.ACCOUNTS_CHANGED,
+        (accounts) => {
+          if (developerMode) {
+            console.debug('PROPAGATE accountsChanged', accounts);
+          }
 
-      metamaskBrowserExtension.on('disconnect', (error) => {
+          instance
+            .getMobileProvider()
+            .emit(EXTENSION_EVENTS.ACCOUNTS_CHANGED, accounts);
+        },
+      );
+
+      metamaskBrowserExtension.on(EXTENSION_EVENTS.DISCONNECT, (error) => {
         if (developerMode) {
           console.debug('PROPAGATE disconnect', error);
         }
-        instance.getMobileProvider().emit('disconnect', error);
+
+        instance.getMobileProvider().emit(EXTENSION_EVENTS.DISCONNECT, error);
       });
 
-      metamaskBrowserExtension.on('connect', (args) => {
+      metamaskBrowserExtension.on(EXTENSION_EVENTS.CONNECT, (args) => {
         if (developerMode) {
           console.debug('PROPAGATE connect', args);
         }
-        instance.getMobileProvider().emit('connect', args);
+        instance.getMobileProvider().emit(EXTENSION_EVENTS.CONNECT, args);
       });
 
-      metamaskBrowserExtension.on('connected', (args) => {
+      metamaskBrowserExtension.on(EXTENSION_EVENTS.CONNECTED, (args) => {
         if (developerMode) {
           console.debug('PROPAGATE connected', args);
         }
-        instance.getMobileProvider().emit('connected', args);
+        instance.getMobileProvider().emit(EXTENSION_EVENTS.CONNECTED, args);
       });
     } catch (err) {
       // Ignore error if metamask extension not found


### PR DESCRIPTION
Some client seem to only connect on the main provider before switching to extension and thus would miss extension chain events. This PR consolidate all events onto the main provider to fix that issue.

- Expose the mobile provider directly from sdk