### PR TITLE
feat(examples): adds an example for switch and addChain to the web3on…

### DIFF
--- a/packages/examples/with-web3onboard/src/App.css
+++ b/packages/examples/with-web3onboard/src/App.css
@@ -40,3 +40,7 @@
 .read-the-docs {
   color: #888;
 }
+
+#confirmation {
+  display: none;
+}

--- a/packages/examples/with-web3onboard/src/App.tsx
+++ b/packages/examples/with-web3onboard/src/App.tsx
@@ -162,7 +162,7 @@ function App() {
       const error = err as RPCError;
       console.log(typeof error)
       console.log(error);
-      if (error.code === -32603) {
+      if (error.code === -32603 || error.code === 4902) {
         const confirmation = document.getElementById('confirmation');
         confirmation!.style.display = 'block';
       }

--- a/packages/examples/with-web3onboard/src/App.tsx
+++ b/packages/examples/with-web3onboard/src/App.tsx
@@ -3,6 +3,11 @@ import { init, useConnectWallet } from '@web3-onboard/react';
 
 import './App.css';
 
+interface RPCError {
+  code: number;
+  message: string;
+}
+
 const chains = [
   {
     id: '0x1',
@@ -122,6 +127,48 @@ function App() {
     }
   }
 
+  const addEthereumChain = async () => {
+    wallet.provider
+      .request({
+        method: 'wallet_addEthereumChain',
+        params: [
+          {
+            chainId: '0x89',
+            chainName: 'Polygon',
+            blockExplorerUrls: ['https://polygonscan.com'],
+            nativeCurrency: { symbol: 'MATIC', decimals: 18 },
+            rpcUrls: ['https://polygon-rpc.com/'],
+          },
+        ],
+      })
+      .then(() => {
+        const confirmation = document.getElementById('confirmation');
+        confirmation!.style.display = 'block';
+        confirmation!.innerText = "Polygon has been added to MetaMask.";
+      })
+      .catch((error: unknown) => {
+        console.log(`error: `, error);
+      });
+  }
+
+  const switchChain = async (hexChainId: string) => {
+    try {
+      const result = await wallet.provider.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: hexChainId }], // chainId must be in hexadecimal numbers
+      });
+      console.log(`result: `, result)
+    } catch (err: unknown) {
+      const error = err as RPCError;
+      console.log(typeof error)
+      console.log(error);
+      if (error.code === -32603) {
+        const confirmation = document.getElementById('confirmation');
+        confirmation!.style.display = 'block';
+      }
+    }
+  }
+
   return (
     <>
     <div>
@@ -137,6 +184,13 @@ function App() {
         {connecting ? 'connecting' : wallet ? 'disconnect' : 'connect'}
       </button>
       <button  title='test sign' onClick={handleTestSign}>Test Sign</button>
+      <div>
+        <button title='Add Polygon' id={'addPolygonButton'} onClick={() => switchChain('0x89')}>Switch to Polygon</button>
+        <div id={'confirmation'}>
+          <p>MetaMask doesn't have Polygon, do you want to add it?</p>
+          <button title='Add Polygon' id={'addPolygonButtonConfirmation'} onClick={addEthereumChain}>Add Polygon</button>
+        </div>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
Adds to the web3onboard example calls for `wallet_switchEthereumChain` and `wallet_addEthereumChain`.

Video:

https://github.com/MetaMask/metamask-sdk/assets/104831203/5007a21b-9ec2-4540-83de-ed426b2a7a4d

