### PR TITLE
Release 38.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "37.0.0",
+  "version": "38.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-communication-layer/CHANGELOG.md
+++ b/packages/sdk-communication-layer/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1]
+### Uncategorized
+- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
+- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
+- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
+- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
+- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
+
 ## [0.12.0]
 ### Added
 - feat: set minimum required coverage to 50/100 ([#473](https://github.com/MetaMask/metamask-sdk/pull/473))
@@ -108,7 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.1...HEAD
+[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.0...@metamask/sdk-communication-layer@0.12.1
 [0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.11.1...@metamask/sdk-communication-layer@0.12.0
 [0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.11.0...@metamask/sdk-communication-layer@0.11.1
 [0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.10.1...@metamask/sdk-communication-layer@0.11.0

--- a/packages/sdk-communication-layer/CHANGELOG.md
+++ b/packages/sdk-communication-layer/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.1]
-### Uncategorized
-- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
-- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
-- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
-- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
+### Added
 - feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
 
 ## [0.12.0]

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -7,12 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.1]
-### Uncategorized
-- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
-- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
-- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
-- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
-- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
+### Added
+- Force align package version to sdk
 
 ## [0.12.0]
 ### Added

--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1]
+### Uncategorized
+- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
+- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
+- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
+- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
+- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
+
 ## [0.12.0]
 ### Added
 - Force align package version to sdk
@@ -71,7 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub actions workflows ([#102](https://github.com/MetaMask/metamask-sdk/pull/102))
 - [FEAT] Yarn v3 migration ([#100](https://github.com/MetaMask/metamask-sdk/pull/100))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.12.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.12.1...HEAD
+[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.12.0...@metamask/sdk-install-modal-web@0.12.1
 [0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.11.1...@metamask/sdk-install-modal-web@0.12.0
 [0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.11.0...@metamask/sdk-install-modal-web@0.11.1
 [0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.10.0...@metamask/sdk-install-modal-web@0.11.0

--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-install-modal-web",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "MetaMask SDK Install Modal for Web",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -66,17 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.1...HEAD
-[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.0...@metamask/sdk-react-ui@0.12.1
-[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.2...@metamask/sdk-react-ui@0.12.0
-[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.1...@metamask/sdk-react-ui@0.11.2
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.0...@metamask/sdk-react-ui@0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.1...@metamask/sdk-react-ui@0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.0...@metamask/sdk-react-ui@0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.9.0...@metamask/sdk-react-ui@0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.8.0...@metamask/sdk-react-ui@0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.7.0...@metamask/sdk-react-ui@0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.2...@metamask/sdk-react-ui@0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.1...@metamask/sdk-react-ui@0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.0...@metamask/sdk-react-ui@0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react-ui@0.6.0
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.2...v0.12.0
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...v0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.6.0

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1]
+### Uncategorized
+- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
+- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
+- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
+- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
+- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
+
 ## [0.12.0]
 ### Added
 - align version with sdk
@@ -58,16 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.12.0...HEAD
-[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.2...v0.12.0
-[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...v0.11.2
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.6.0
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.1...HEAD
+[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.0...@metamask/sdk-react-ui@0.12.1
+[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.2...@metamask/sdk-react-ui@0.12.0
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.1...@metamask/sdk-react-ui@0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.11.0...@metamask/sdk-react-ui@0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.1...@metamask/sdk-react-ui@0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.10.0...@metamask/sdk-react-ui@0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.9.0...@metamask/sdk-react-ui@0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.8.0...@metamask/sdk-react-ui@0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.7.0...@metamask/sdk-react-ui@0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.2...@metamask/sdk-react-ui@0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.1...@metamask/sdk-react-ui@0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.6.0...@metamask/sdk-react-ui@0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react-ui@0.6.0

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1]
+### Uncategorized
+- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
+- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
+- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
+- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
+- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
+
 ## [0.12.0]
 ### Added
 - feat: set minimum required coverage to 50/100 ([#473](https://github.com/MetaMask/metamask-sdk/pull/473))
@@ -86,20 +94,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.12.0...HEAD
-[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.2...v0.12.0
-[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...v0.11.2
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.6...v0.6.0
-[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.4...v0.5.6
-[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.3...v0.5.4
-[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/v0.3.1...v0.5.3
-[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.3.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.1...HEAD
+[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.0...@metamask/sdk-react@0.12.1
+[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.2...@metamask/sdk-react@0.12.0
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.1...@metamask/sdk-react@0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.0...@metamask/sdk-react@0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.1...@metamask/sdk-react@0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.0...@metamask/sdk-react@0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.9.0...@metamask/sdk-react@0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.8.0...@metamask/sdk-react@0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.7.0...@metamask/sdk-react@0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.2...@metamask/sdk-react@0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.1...@metamask/sdk-react@0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.0...@metamask/sdk-react@0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.6...@metamask/sdk-react@0.6.0
+[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.4...@metamask/sdk-react@0.5.6
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.3...@metamask/sdk-react@0.5.4
+[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.3.1...@metamask/sdk-react@0.5.3
+[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react@0.3.1

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -8,11 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.1]
 ### Uncategorized
-- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
-- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
-- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
-- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
-- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
+- align version with sdk
 
 ## [0.12.0]
 ### Added
@@ -94,21 +90,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.1...HEAD
-[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.0...@metamask/sdk-react@0.12.1
-[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.2...@metamask/sdk-react@0.12.0
-[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.1...@metamask/sdk-react@0.11.2
-[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.11.0...@metamask/sdk-react@0.11.1
-[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.1...@metamask/sdk-react@0.11.0
-[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.10.0...@metamask/sdk-react@0.10.1
-[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.9.0...@metamask/sdk-react@0.10.0
-[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.8.0...@metamask/sdk-react@0.9.0
-[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.7.0...@metamask/sdk-react@0.8.0
-[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.2...@metamask/sdk-react@0.7.0
-[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.1...@metamask/sdk-react@0.6.2
-[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.6.0...@metamask/sdk-react@0.6.1
-[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.6...@metamask/sdk-react@0.6.0
-[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.4...@metamask/sdk-react@0.5.6
-[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.5.3...@metamask/sdk-react@0.5.4
-[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.3.1...@metamask/sdk-react@0.5.3
-[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react@0.3.1
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.2...v0.12.0
+[0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.1...v0.11.2
+[0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/metamask-sdk/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.6...v0.6.0
+[0.5.6]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.4...v0.5.6
+[0.5.4]: https://github.com/MetaMask/metamask-sdk/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/MetaMask/metamask-sdk/compare/v0.3.1...v0.5.3
+[0.3.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/v0.3.1

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1]
+### Uncategorized
+- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
+- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
+- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
+- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
+- feat: propagate extension events ([#493](https://github.com/MetaMask/metamask-sdk/pull/493))
+- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
+- feat: add backward v3 json compatibility on i18n ([#483](https://github.com/MetaMask/metamask-sdk/pull/483))
+
 ## [0.12.0]
 ### Added
 - feat: update onboard package ([#475](https://github.com/MetaMask/metamask-sdk/pull/475))
@@ -183,7 +193,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.1...HEAD
+[0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.0...@metamask/sdk@0.12.1
 [0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.11.2...@metamask/sdk@0.12.0
 [0.11.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.11.1...@metamask/sdk@0.11.2
 [0.11.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.11.0...@metamask/sdk@0.11.1

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.1]
-### Uncategorized
-- Revert "feat: release 38.0.0" ([#504](https://github.com/MetaMask/metamask-sdk/pull/504))
-- feat: release 38.0.0 ([#502](https://github.com/MetaMask/metamask-sdk/pull/502))
-- Revert "Release 38.0.0" ([#499](https://github.com/MetaMask/metamask-sdk/pull/499))
-- Release 38.0.0 ([#497](https://github.com/MetaMask/metamask-sdk/pull/497))
+### Added
 - feat: propagate extension events ([#493](https://github.com/MetaMask/metamask-sdk/pull/493))
 - feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
 - feat: add backward v3 json compatibility on i18n ([#483](https://github.com/MetaMask/metamask-sdk/pull/483))

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk [0.12.1]
### Added
- feat: propagate extension events ([#493](https://github.com/MetaMask/metamask-sdk/pull/493))
- feat: metamask/sdk-ui initial setup ([#487](https://github.com/MetaMask/metamask-sdk/pull/487))
- feat: add backward v3 json compatibility on i18n ([#483](https://github.com/MetaMask/metamask-sdk/pull/483))