### PR TITLE
feat: release 39.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "38.0.0",
+  "version": "39.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-communication-layer/CHANGELOG.md
+++ b/packages/sdk-communication-layer/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.2]
+### Uncategorized
+- chore: trigger release ([#524](https://github.com/MetaMask/metamask-sdk/pull/524))
+- chore: trigger release ([#523](https://github.com/MetaMask/metamask-sdk/pull/523))
+- feat: release 39.0.0 ([#520](https://github.com/MetaMask/metamask-sdk/pull/520))
+
 ### Added
 - feat: add the option to add iconUrl to the dappMetadata ([#511](https://github.com/MetaMask/metamask-sdk/pull/511))
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.2]
+### Uncategorized
+- chore: trigger release ([#524](https://github.com/MetaMask/metamask-sdk/pull/524))
+- chore: trigger release ([#523](https://github.com/MetaMask/metamask-sdk/pull/523))
+- feat: release 39.0.0 ([#520](https://github.com/MetaMask/metamask-sdk/pull/520))
+
 ### Added
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))
 

--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-install-modal-web",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "MetaMask SDK Install Modal for Web",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-lab/CHANGELOG.md
+++ b/packages/sdk-lab/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.1.1]
+### Uncategorized
+- chore: trigger release ([#524](https://github.com/MetaMask/metamask-sdk/pull/524))
+- chore: trigger release ([#523](https://github.com/MetaMask/metamask-sdk/pull/523))
+- Release 39.0.0 ([#522](https://github.com/MetaMask/metamask-sdk/pull/522))
+- feat: release 39.0.0 ([#520](https://github.com/MetaMask/metamask-sdk/pull/520))
+
 ### Added
 - chore: enable sdk-ui and sdk-lab to v0.1.0 ([#518](https://github.com/MetaMask/metamask-sdk/pull/518))
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))

--- a/packages/sdk-lab/package.json
+++ b/packages/sdk-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-lab",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MetaMask SDK lab -- alpha components for sdk development",
   "main": "src/index.ts",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.2]
+### Uncategorized
+- chore: trigger release ([#524](https://github.com/MetaMask/metamask-sdk/pull/524))
+- chore: trigger release ([#523](https://github.com/MetaMask/metamask-sdk/pull/523))
+- feat: release 39.0.0 ([#520](https://github.com/MetaMask/metamask-sdk/pull/520))
+
 ### Added
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))
 - fix: linting changelog issue after updating scripts ([#509](https://github.com/MetaMask/metamask-sdk/pull/509))

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.2]
+### Uncategorized
+- chore: trigger release ([#524](https://github.com/MetaMask/metamask-sdk/pull/524))
+- chore: trigger release ([#523](https://github.com/MetaMask/metamask-sdk/pull/523))
+- feat: release 39.0.0 ([#520](https://github.com/MetaMask/metamask-sdk/pull/520))
+
 ### Added
 - feat: add processing state when computing balance ([#519](https://github.com/MetaMask/metamask-sdk/pull/519))
 - feat: design system part2 ([#517](https://github.com/MetaMask/metamask-sdk/pull/517))

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-ui/CHANGELOG.md
+++ b/packages/sdk-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.1.1]
+### Uncategorized
+- chore: trigger release ([#524](https://github.com/MetaMask/metamask-sdk/pull/524))
+- chore: trigger release ([#523](https://github.com/MetaMask/metamask-sdk/pull/523))
+- Release 39.0.0 ([#522](https://github.com/MetaMask/metamask-sdk/pull/522))
+- feat: release 39.0.0 ([#520](https://github.com/MetaMask/metamask-sdk/pull/520))
+
 ### Added
 - chore: enable sdk-ui and sdk-lab to v0.1.0 ([#518](https://github.com/MetaMask/metamask-sdk/pull/518))
 - feat: design system part2 ([#517](https://github.com/MetaMask/metamask-sdk/pull/517))

--- a/packages/sdk-ui/package.json
+++ b/packages/sdk-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "MetaMask SDK cross-platform ui library",
   "main": "src/index.ts",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.12.2]
+### Uncategorized
+- chore: trigger release ([#524](https://github.com/MetaMask/metamask-sdk/pull/524))
+- chore: trigger release ([#523](https://github.com/MetaMask/metamask-sdk/pull/523))
+- feat: release 39.0.0 ([#520](https://github.com/MetaMask/metamask-sdk/pull/520))
+
 ### Added
 - feat: add the option to add iconUrl to the dappMetadata ([#511](https://github.com/MetaMask/metamask-sdk/pull/511))
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk [0.12.2]
### Added
- feat: add the option to add iconUrl to the dappMetadata ([#511](https://github.com/MetaMask/metamask-sdk/pull/511))
- feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))

## sdk-communication-layer [0.12.2]
### Added
- feat: add the option to add iconUrl to the dappMetadata ([#511](https://github.com/MetaMask/metamask-sdk/pull/511))
- feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))

## sdk-react [0.12.2]
### Added
- feat: add processing state when computing balance ([#519](https://github.com/MetaMask/metamask-sdk/pull/519))
- feat: design system part2 ([#517](https://github.com/MetaMask/metamask-sdk/pull/517))
- feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))
- fix: linting changelog issue after updating scripts ([#509](https://github.com/MetaMask/metamask-sdk/pull/509))
- fix: invalid changelog linter script ([#506](https://github.com/MetaMask/metamask-sdk/pull/506))

## sdk-react-ui [0.12.2]
### Added
- feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))
- fix: linting changelog issue after updating scripts ([#509](https://github.com/MetaMask/metamask-sdk/pull/509))
- fix: invalid changelog linter script ([#506](https://github.com/MetaMask/metamask-sdk/pull/506))
