### PR TITLE
Release 42.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "41.0.0",
+  "version": "42.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-communication-layer/CHANGELOG.md
+++ b/packages/sdk-communication-layer/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+### Uncategorized
+- Revert "Release 41.0.0" ([#535](https://github.com/MetaMask/metamask-sdk/pull/535))
+- Release 41.0.0 ([#534](https://github.com/MetaMask/metamask-sdk/pull/534))
+
 ## [0.12.3]
 ### Uncategorized
 - feat: add the option to add dapp icon in base64 format ([#521](https://github.com/MetaMask/metamask-sdk/pull/521))
@@ -126,7 +131,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.3...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.13.0...HEAD
+[0.13.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.3...@metamask/sdk-communication-layer@0.13.0
 [0.12.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.2...@metamask/sdk-communication-layer@0.12.3
 [0.12.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.1...@metamask/sdk-communication-layer@0.12.2
 [0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.12.0...@metamask/sdk-communication-layer@0.12.1

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+### Uncategorized
+- Release 41.0.0 ([#540](https://github.com/MetaMask/metamask-sdk/pull/540))
+
 ## [0.12.2]
 ### Added
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))
@@ -79,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub actions workflows ([#102](https://github.com/MetaMask/metamask-sdk/pull/102))
 - [FEAT] Yarn v3 migration ([#100](https://github.com/MetaMask/metamask-sdk/pull/100))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.12.2...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.13.0...HEAD
+[0.13.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.12.2...@metamask/sdk-install-modal-web@0.13.0
 [0.12.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.12.1...@metamask/sdk-install-modal-web@0.12.2
 [0.12.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.12.0...@metamask/sdk-install-modal-web@0.12.1
 [0.12.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.11.1...@metamask/sdk-install-modal-web@0.12.0

--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-install-modal-web",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "MetaMask SDK Install Modal for Web",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-lab/CHANGELOG.md
+++ b/packages/sdk-lab/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4]
+### Uncategorized
+- fix: storage UI and devreact ([#545](https://github.com/MetaMask/metamask-sdk/pull/545))
+
 ## [0.1.3]
 ### Added
 - feat: build setup for ui and lab ([#537](https://github.com/MetaMask/metamask-sdk/pull/537))
@@ -30,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: linting changelog issue after updating scripts ([#509](https://github.com/MetaMask/metamask-sdk/pull/509))
 - fix: invalid changelog linter script ([#506](https://github.com/MetaMask/metamask-sdk/pull/506))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-lab@0.1.3...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-lab@0.1.4...HEAD
+[0.1.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-lab@0.1.3...@metamask/sdk-lab@0.1.4
 [0.1.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-lab@0.1.2...@metamask/sdk-lab@0.1.3
 [0.1.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-lab@0.1.1...@metamask/sdk-lab@0.1.2
 [0.1.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-lab@0.1.1

--- a/packages/sdk-lab/package.json
+++ b/packages/sdk-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-lab",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MetaMask SDK lab -- alpha components for sdk development",
   "module": "dist/esm/index.js",
   "types": "dist/esm/src/index.d.ts",

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+### Uncategorized
+- feat: add sdk instance to window scope to prevent double init ([#546](https://github.com/MetaMask/metamask-sdk/pull/546))
+
 ## [0.12.4]
 ### Added
 - feat: build setup for ui and lab ([#537](https://github.com/MetaMask/metamask-sdk/pull/537))
@@ -81,7 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.13.0...HEAD
+[0.13.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.4...@metamask/sdk-react-ui@0.13.0
 [0.12.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.3...@metamask/sdk-react-ui@0.12.4
 [0.12.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.2...@metamask/sdk-react-ui@0.12.3
 [0.12.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.12.1...@metamask/sdk-react-ui@0.12.2

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+### Uncategorized
+- fix: storage UI and devreact ([#545](https://github.com/MetaMask/metamask-sdk/pull/545))
+
 ## [0.12.4]
 ### Added
 - feat: build setup for ui and lab ([#537](https://github.com/MetaMask/metamask-sdk/pull/537))
@@ -112,7 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.13.0...HEAD
+[0.13.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.4...@metamask/sdk-react@0.13.0
 [0.12.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.3...@metamask/sdk-react@0.12.4
 [0.12.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.2...@metamask/sdk-react@0.12.3
 [0.12.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.12.1...@metamask/sdk-react@0.12.2

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-ui/CHANGELOG.md
+++ b/packages/sdk-ui/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4]
+### Uncategorized
+- fix: storybook setup ([#547](https://github.com/MetaMask/metamask-sdk/pull/547))
+- fix: storage UI and devreact ([#545](https://github.com/MetaMask/metamask-sdk/pull/545))
+
 ## [0.1.3]
 ### Added
 - feat: build setup for ui and lab ([#537](https://github.com/MetaMask/metamask-sdk/pull/537))
@@ -32,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))
 - fix: linting changelog issue after updating scripts ([#509](https://github.com/MetaMask/metamask-sdk/pull/509))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.1.3...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.1.4...HEAD
+[0.1.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.1.3...@metamask/sdk-ui@0.1.4
 [0.1.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.1.2...@metamask/sdk-ui@0.1.3
 [0.1.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.1.1...@metamask/sdk-ui@0.1.2
 [0.1.1]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-ui@0.1.1

--- a/packages/sdk-ui/package.json
+++ b/packages/sdk-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MetaMask SDK cross-platform ui library",
   "module": "dist/esm/index.js",
   "types": "dist/esm/dist/src/index.d.ts",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+### Uncategorized
+- feat: add sdk instance to window scope to prevent double init ([#546](https://github.com/MetaMask/metamask-sdk/pull/546))
+- fix: transfer the extracted favicon to base64 format in setupDappMetadata ([#536](https://github.com/MetaMask/metamask-sdk/pull/536))
+
 ## [0.12.4]
 ### Uncategorized
 - sdk ui release version
@@ -208,7 +213,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.13.0...HEAD
+[0.13.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.4...@metamask/sdk@0.13.0
 [0.12.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.3...@metamask/sdk@0.12.4
 [0.12.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.2...@metamask/sdk@0.12.3
 [0.12.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.12.1...@metamask/sdk@0.12.2

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk [0.13.0]
### Added
- feat: add sdk instance to window scope to prevent double init ([#546](https://github.com/MetaMask/metamask-sdk/pull/546))
- fix: transfer the extracted favicon to base64 format in setupDappMetadata ([#536](https://github.com/MetaMask/metamask-sdk/pull/536))

## sdk-react [0.13.0]
### Added
- fix: compatibility with storage UI and devreact ([#545](https://github.com/MetaMask/metamask-sdk/pull/545))

## sdk-lab [0.1.4]
### Added
- fix: storage UI and devreact ([#545](https://github.com/MetaMask/metamask-sdk/pull/545))

## sdk-ui [0.1.4]
### Added
- fix: storybook setup ([#547](https://github.com/MetaMask/metamask-sdk/pull/547))
- fix: storage UI and devreact ([#545](https://github.com/MetaMask/metamask-sdk/pull/545))
