### PR TITLE
chore: change favicon from base64 format to url

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.test.ts
@@ -47,20 +47,6 @@ describe('setupDappMetadata', () => {
     expect(instance.dappMetadata).toStrictEqual(instance.options.dappMetadata);
   });
 
-  it('should set base64Icon to faviconBase64Icon if it does not start with http:// or https://', async () => {
-    instance.options.dappMetadata = {
-      iconUrl: 'ftp://example.com/favicon.ico',
-      url: 'https://example.com',
-    };
-
-    await setupDappMetadata(instance);
-
-    expect(instance.dappMetadata?.base64Icon).toBe('faviconBase64Icon');
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'Invalid dappMetadata.iconUrl: URL must start with http:// or https://',
-    );
-  });
-
   it('should set iconUrl to undenied if it does not start with http:// or https:// and favicon is undefined', async () => {
     instance.options.dappMetadata = {
       iconUrl: 'ftp://example.com/favicon.ico',
@@ -93,14 +79,21 @@ describe('setupDappMetadata', () => {
     );
   });
 
-  it('should set base64Icon to the extracted favicon if iconUrl and base64Icon are not provided', async () => {
+  it('should set iconUrl to the extracted favicon if iconUrl and base64Icon are not provided', async () => {
     instance.options.dappMetadata = {
       url: 'https://example.com',
     };
 
+    global.window = {
+      location: {
+        protocol: 'https:',
+        host: 'example.com/',
+      },
+    } as any;
+
     await setupDappMetadata(instance);
 
-    expect(instance.dappMetadata?.base64Icon).toBe('faviconBase64Icon');
+    expect(instance.dappMetadata?.iconUrl).toBe('https://example.com/favicon');
   });
 
   it('should not throw an error if dappMetadata is not provided', () => {

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupDappMetadata.ts
@@ -1,4 +1,3 @@
-import { getBase64FromUrl } from '../../../utils/getBase64FromUrl';
 import { MetaMaskSDK } from '../../../sdk';
 import { extractFavicon } from '../../../utils/extractFavicon';
 
@@ -64,18 +63,9 @@ export async function setupDappMetadata(instance: MetaMaskSDK) {
       !options.dappMetadata.iconUrl &&
       !options.dappMetadata.base64Icon
     ) {
-      try {
-        const faviconUri = await getBase64FromUrl(favicon);
-        if (faviconUri.length < BASE_64_ICON_MAX_LENGTH) {
-          options.dappMetadata.base64Icon = faviconUri;
-        } else {
-          console.warn(
-            'Invalid dappMetadata.base64Icon: Base64-encoded icon string length must be less than 163400 characters',
-          );
-        }
-      } catch (error) {
-        // do nothing
-      }
+      const faviconUrl = `${window.location.protocol}//${window.location.host}${favicon}`;
+
+      options.dappMetadata.iconUrl = faviconUrl;
     }
   }
   // eslint-disable-next-line require-atomic-updates


### PR DESCRIPTION
Change favicon from `base64` format to `url` format.