### PR TITLE
feat: account reset issue on _init event

### DIFF
--- a/packages/sdk-react/src/EventsHandlers/useHandleInitializedEvent.test.tsx
+++ b/packages/sdk-react/src/EventsHandlers/useHandleInitializedEvent.test.tsx
@@ -41,9 +41,6 @@ describe('useHandleInitializedEvent', () => {
       "MetaMaskProvider::provider on '_initialized' event.",
     );
     expect(eventHandlerProps.setConnecting).toHaveBeenCalledWith(false);
-    expect(eventHandlerProps.setAccount).toHaveBeenCalledWith(
-      eventHandlerProps.activeProvider.selectedAddress,
-    );
     expect(eventHandlerProps.setConnected).toHaveBeenCalledWith(true);
     expect(eventHandlerProps.setError).toHaveBeenCalledWith(undefined);
   });
@@ -61,9 +58,6 @@ describe('useHandleInitializedEvent', () => {
 
     expect(console.debug).not.toHaveBeenCalled();
     expect(eventHandlerProps.setConnecting).toHaveBeenCalledWith(false);
-    expect(eventHandlerProps.setAccount).toHaveBeenCalledWith(
-      eventHandlerProps.activeProvider.selectedAddress,
-    );
     expect(eventHandlerProps.setConnected).toHaveBeenCalledWith(true);
     expect(eventHandlerProps.setError).toHaveBeenCalledWith(undefined);
   });
@@ -78,7 +72,6 @@ describe('useHandleInitializedEvent', () => {
     result.current();
 
     expect(eventHandlerProps.setConnecting).toHaveBeenCalledWith(false);
-    expect(eventHandlerProps.setAccount).toHaveBeenCalledWith(undefined);
     expect(eventHandlerProps.setConnected).toHaveBeenCalledWith(true);
     expect(eventHandlerProps.setError).toHaveBeenCalledWith(undefined);
   });

--- a/packages/sdk-react/src/EventsHandlers/useHandleInitializedEvent.ts
+++ b/packages/sdk-react/src/EventsHandlers/useHandleInitializedEvent.ts
@@ -14,7 +14,6 @@ export const useHandleInitializedEvent = ({
       console.debug(`MetaMaskProvider::provider on '_initialized' event.`);
     }
     setConnecting(false);
-    setAccount(activeProvider?.selectedAddress || undefined);
     setConnected(true);
     setError(undefined);
   }, [


### PR DESCRIPTION
Fix issue of account address resetting on `_initialized` event.
Issue was due to refactor on MetaMaskProvider that I tagged as:
```
  // FIXME calling directly useHandleInitializedEvent skip the parameter of the event.
  const onInitialized = useHandleInitializedEvent(eventHandlerProps);
```