### PR TITLE
feat: new rpc call metamask_connectwith

### DIFF
--- a/packages/devnext/src/components/layout.tsx
+++ b/packages/devnext/src/components/layout.tsx
@@ -1,4 +1,8 @@
-import { FloatingMetaMaskButton, SDKConfigCard } from '@metamask/sdk-ui';
+import {
+  FloatingMetaMaskButton,
+  SDKDebugPanel,
+  SDKConfigCard,
+} from '@metamask/sdk-ui';
 import { useRouter } from 'next/router';
 import { ReactNode } from 'react';
 
@@ -17,8 +21,9 @@ export const Layout = ({ children }: LayoutProps) => {
           router.push('/');
         }}
       />
-      {children}
       <FloatingMetaMaskButton distance={{ bottom: 40 }} />
+      {children}
+      <SDKDebugPanel bottom={40} />
     </div>
   );
 };

--- a/packages/devnext/src/pages/index.tsx
+++ b/packages/devnext/src/pages/index.tsx
@@ -29,15 +29,6 @@ export default function Home() {
         <div style={{ padding: 20 }}>
           <MetaMaskButton />
         </div>
-        <div>
-          {/* <ADD />
-          <PreviewScreen />
-          <Avatar
-            variant={AvatarVariant.Network}
-            name="Ethereum"
-            imageSource={assets.ethereum}
-          /> */}
-        </div>
       </div>
     </div>
   );

--- a/packages/devnext/src/pages/uikit.tsx
+++ b/packages/devnext/src/pages/uikit.tsx
@@ -1,4 +1,6 @@
 import { MetaMaskButton, useAccount } from '@metamask/sdk-react-ui';
+import { MetaMaskButton as NativeMetamaskButton } from '@metamask/sdk-ui';
+
 import Head from 'next/head';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
@@ -26,6 +28,9 @@ export default function UIKitPage() {
         <Link href={'/'}>Index Page</Link>
         <div>
           <MetaMaskButton theme={'light'} color="white"></MetaMaskButton>
+        </div>
+        <div>
+          <NativeMetamaskButton theme={'light'} color="white" />
         </div>
         {isClient && (
           <pre>

--- a/packages/devnext/src/pages/web3onboard.tsx
+++ b/packages/devnext/src/pages/web3onboard.tsx
@@ -2,6 +2,7 @@ import { useSDK, useSDKConfig } from '@metamask/sdk-ui';
 import { init, useConnectWallet } from '@web3-onboard/react';
 import React from 'react';
 import metamaskSDK from '@web3-onboard/metamask';
+// import metamaskSDK from '../connector/onboard-sdk-connector';
 
 const chains = [
   {

--- a/packages/devnext/src/utils/sign-utils.ts
+++ b/packages/devnext/src/utils/sign-utils.ts
@@ -1,0 +1,75 @@
+export const getSignParams = ({
+  hexChainId = '0x1', // Default to Mainnet
+}: {
+  hexChainId?: string;
+}) => {
+  const params = {
+    domain: {
+      // Defining the chain aka Rinkeby testnet or Ethereum Main Net
+      chainId: hexChainId,
+      // Give a user friendly name to the specific contract you are signing for.
+      name: 'Ether Mail',
+      // If name isn't enough add verifying contract to make sure you are establishing contracts with the proper entity
+      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+      // Just let's you know the latest version. Definitely make sure the field name is correct.
+      version: '1',
+    },
+
+    // Defining the message signing data content.
+    message: {
+      /*
+       - Anything you want. Just a JSON Blob that encodes the data you want to send
+       - No required fields
+       - This is DApp Specific
+       - Be as explicit as possible when building out the message schema.
+      */
+      contents: 'Hello, Bob!',
+      attachedMoneyInEth: 4.2,
+      from: {
+        name: 'Cow',
+        wallets: [
+          '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+          '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+        ],
+      },
+      to: [
+        {
+          name: 'Bob',
+          wallets: [
+            '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+            '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+            '0xB0B0b0b0b0b0B000000000000000000000000000',
+          ],
+        },
+      ],
+    },
+    // Refers to the keys of the *types* object below.
+    primaryType: 'Mail',
+    types: {
+      // TODO: Clarify if EIP712Domain refers to the domain the contract is hosted on
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+      ],
+      // Not an EIP712Domain definition
+      Group: [
+        { name: 'name', type: 'string' },
+        { name: 'members', type: 'Person[]' },
+      ],
+      // Refer to PrimaryType
+      Mail: [
+        { name: 'from', type: 'Person' },
+        { name: 'to', type: 'Person[]' },
+        { name: 'contents', type: 'string' },
+      ],
+      // Not an EIP712Domain definition
+      Person: [
+        { name: 'name', type: 'string' },
+        { name: 'wallets', type: 'address[]' },
+      ],
+    },
+  };
+  return params;
+};

--- a/packages/devreact/src/App.tsx
+++ b/packages/devreact/src/App.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { SDKProvider } from '@metamask/sdk';
-import { useSDK } from '@metamask/sdk-react';
+import { useSDK } from '@metamask/sdk-ui';
 import { useState } from 'react';
 import Web from 'web3';
 import './App.css';
 import { MetaMaskButton } from '@metamask/sdk-ui';
+import { ChainRPC, RPCHistoryViewer } from '@metamask/sdk-lab';
 
 declare global {
   interface Window {
@@ -360,6 +361,7 @@ export const App = () => {
       <p>{`Account balance: ${balance}`}</p>
       <p>{`Last request response: ${response}`}</p>
       <p>{`Connected: ${connected}`}</p>
+      <RPCHistoryViewer />
     </div>
   );
 };

--- a/packages/devreact/src/index.tsx
+++ b/packages/devreact/src/index.tsx
@@ -73,7 +73,7 @@ root.render(
             }}
           />
           <App />
-          <FloatingMetaMaskButton />
+          <FloatingMetaMaskButton distance={{ bottom: 40 }} />
         </WithUI>
       </WithSDKConfig>
     </SDKConfigProvider>

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -19,6 +19,7 @@ export const STORAGE_PROVIDER_TYPE = 'providerType';
 export const RPC_METHODS = {
   METAMASK_GETPROVIDERSTATE: 'metamask_getProviderState',
   METAMASK_CONNECTSIGN: 'metamask_connectSign',
+  METAMASK_CONNECTWITH: 'metamask_connectWith',
   METAMASK_BATCH: 'metamask_batch',
   PERSONAL_SIGN: 'personal_sign',
   ETH_REQUESTACCOUNTS: 'eth_requestAccounts',

--- a/packages/sdk/src/provider/initializeMobileProvider.ts
+++ b/packages/sdk/src/provider/initializeMobileProvider.ts
@@ -3,6 +3,7 @@ import {
   EventType,
   PlatformType,
 } from '@metamask/sdk-communication-layer';
+import packageJson from '../../package.json';
 import { MetaMaskInstaller } from '../Platform/MetaMaskInstaller';
 import { PlatformManager } from '../Platform/PlatfformManager';
 import { getPostMessageStream } from '../PostMessageStream/getPostMessageStream';
@@ -11,10 +12,9 @@ import { ProviderConstants } from '../constants';
 import { MetaMaskSDK } from '../sdk';
 import { Ethereum } from '../services/Ethereum';
 import { RemoteConnection } from '../services/RemoteConnection';
+import { rpcRequestHandler } from '../services/rpc-requests/RPCRequestHandler';
 import { PROVIDER_UPDATE_TYPE } from '../types/ProviderUpdateType';
 import { wait } from '../utils/wait';
-import { rpcRequestHandler } from '../services/rpc-requests/RPCRequestHandler';
-import packageJson from '../../package.json';
 
 const initializeMobileProvider = ({
   checkInstallationOnAllCalls = false,
@@ -149,6 +149,7 @@ const initializeMobileProvider = ({
     const ALLOWED_CONNECT_METHODS = [
       RPC_METHODS.ETH_REQUESTACCOUNTS,
       RPC_METHODS.METAMASK_CONNECTSIGN,
+      RPC_METHODS.METAMASK_CONNECTWITH,
     ];
 
     // is it a readonly method with infura supported chain?
@@ -206,7 +207,10 @@ const initializeMobileProvider = ({
             }
 
             // Special case for metamask_connectSign, split the request in 2 parts (connect + sign)
-            if (method === RPC_METHODS.METAMASK_CONNECTSIGN) {
+            if (
+              method.toLowerCase() ===
+              RPC_METHODS.METAMASK_CONNECTSIGN.toLowerCase()
+            ) {
               const [temp] = args;
               const { params } = temp;
               const accounts = (await sdk.getProvider()?.request({
@@ -221,6 +225,36 @@ const initializeMobileProvider = ({
                 method: RPC_METHODS.PERSONAL_SIGN,
                 params: [params[0], accounts[0]],
               });
+            } else if (
+              method.toLowerCase() ===
+              RPC_METHODS.METAMASK_CONNECTWITH.toLowerCase()
+            ) {
+              const accounts = (await sdk.getProvider()?.request({
+                method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+                params: [],
+              })) as string[];
+              if (!accounts.length) {
+                throw new Error(`SDK state invalid -- undefined accounts`);
+              }
+
+              const [initialMethod] = args;
+              console.log(`connectWith:: initialMethod`, initialMethod);
+              const { params } = initialMethod;
+              const [rpc] = params;
+              console.warn(`FIXME:: handle CONNECT_WITH`, rpc);
+
+              if (
+                rpc.method?.toLowerCase() ===
+                RPC_METHODS.PERSONAL_SIGN.toLowerCase()
+              ) {
+                const connectedRpc = {
+                  method: rpc.method,
+                  params: [rpc.params[0], accounts[0]],
+                };
+                console.log(`connectWith:: connectedRpc`, connectedRpc);
+                return await sdk.getProvider()?.request(connectedRpc);
+              }
+              console.warn(`FIXME:: handle CONNECT_WITH`, rpc);
             }
 
             // Re-create the query on the active provider

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -25,6 +25,7 @@ import {
 import { SDKLoggingOptions } from './types/SDKLoggingOptions';
 import { SDKUIOptions } from './types/SDKUIOptions';
 import { WakeLockStatus } from './types/WakeLockStatus';
+import { connectWith } from './services/MetaMaskSDK/ConnectionManager/connectWith';
 
 export interface MetaMaskSDKOptions {
   /**
@@ -278,6 +279,10 @@ export class MetaMaskSDK extends EventEmitter2 {
   // msg can be a simple string or ABNF RFC 5234 compliant string.
   async connectAndSign({ msg }: { msg: string }) {
     return connectAndSign({ instance: this, msg });
+  }
+
+  async connectWith(rpc: { method: string; params: any[] }) {
+    return connectWith({ instance: this, rpc });
   }
 
   resume() {

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/connectWith.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/connectWith.test.ts
@@ -1,0 +1,38 @@
+import { MetaMaskSDK } from '../../../sdk';
+import { connectWith } from './connectWith';
+
+jest.mock('../../../sdk');
+
+const mockRpc = {
+  method: 'personal_sign',
+  params: [],
+};
+
+describe('connectWith', () => {
+  let instance: MetaMaskSDK;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    instance = {
+      _initialized: false,
+      debug: false,
+      init: jest.fn().mockResolvedValue(true),
+      activeProvider: {
+        request: jest.fn().mockResolvedValue('result'),
+      },
+    } as unknown as MetaMaskSDK;
+  });
+
+  describe('SDK Initialization', () => {
+    it('should initialize MetaMaskSDK if not initialized', async () => {
+      await connectWith({ instance, rpc: mockRpc });
+      expect(instance.init).toHaveBeenCalled();
+    });
+
+    it('should not initialize MetaMaskSDK if already initialized', async () => {
+      instance._initialized = true;
+      await connectWith({ instance, rpc: mockRpc });
+      expect(instance.init).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/connectWith.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/connectWith.ts
@@ -1,0 +1,30 @@
+import { RPC_METHODS } from '../../../config';
+import { MetaMaskSDK } from '../../../sdk';
+
+export async function connectWith({
+  instance,
+  rpc,
+}: {
+  instance: MetaMaskSDK;
+  rpc: { method: string; params: any[] };
+}) {
+  if (!instance._initialized) {
+    if (instance.debug) {
+      console.log(`SDK::connectWith() provider not ready -- wait for init()`);
+    }
+    await instance.init();
+  }
+
+  if (instance.debug) {
+    console.debug(`SDK::connectWith() method: ${rpc.method}`, rpc);
+  }
+
+  if (!instance.activeProvider) {
+    throw new Error(`SDK state invalid -- undefined provider`);
+  }
+
+  return instance.activeProvider.request({
+    method: RPC_METHODS.METAMASK_CONNECTWITH,
+    params: [rpc],
+  });
+}


### PR DESCRIPTION
Allow to establish connection to the wallet with any wrapped rpc call.
```
const connectWith = async ({
    type,
  }: {
    type:
      | 'PERSONAL_SIGN'
      | 'ETH_SENDTRANSACTION'
      | 'ETH_SIGNTYPEDDATA_V4'
      | 'ETH_CHAINID';
  }) => {
    try {
      setRpcError(null);
      setRequesting(true);
      setResponse('');

      const sendTransactionRpc = {
        method: 'eth_sendTransaction',
        params: [
          {
            to: '0xA9FBbc6C2E49643F8B58Efc63ED0c1f4937A171E', // Required except during contract publications.
            from: '0xMYACCOUNT', // must match user's active address.
            value: '0x5AF3107A4000', // Only required to send ether to the recipient from the initiating external account.
          },
        ],
      };
      const personalSignRpc = {
        method: 'personal_sign',
        params: ['hello world', '0xMYACCOUNT'],
      };
      const signTypeDatav4Rpc = {
        method: 'eth_signTypedData_v4',
        params: ['0xMyaccount', getSignParams({ hexChainId: chainId })],
      };

      let rpc;
      switch (type) {
        case 'PERSONAL_SIGN':
          rpc = personalSignRpc;
          break;
        case 'ETH_SENDTRANSACTION':
          rpc = sendTransactionRpc;
          break;
        case 'ETH_SIGNTYPEDDATA_V4':
          rpc = signTypeDatav4Rpc;
          break;
        case 'ETH_CHAINID':
          rpc = { method: 'eth_chainId', params: [] };
          break;
        default:
          throw new Error(`Unknown type: ${type}`);
      }

      const hexResponse = await sdk?.connectWith(rpc);
      // const accounts = window.ethereum?.request({method: 'eth_requestAccounts', params: []});
      console.debug(`connectWith response:`, hexResponse);
      setResponse(hexResponse);
    } catch (err) {
      console.log('connectWith ERR', err);
      setRpcError(err);
    } finally {
      setRequesting(false);
    }
  };

```