### PR TITLE
feat: graceful warning instead of throwing keyexchange

### DIFF
--- a/packages/sdk-communication-layer/src/KeyExchange.ts
+++ b/packages/sdk-communication-layer/src/KeyExchange.ts
@@ -233,13 +233,11 @@ export class KeyExchange extends EventEmitter2 {
   }
 
   checkStep(stepList: string[]): void {
-    console.warn(
-      `KeyExchange::checkStep() ${this.step} ${Date.now()}`,
-      stepList,
-    );
-
     if (stepList.length > 0 && stepList.indexOf(this.step.toString()) === -1) {
-      throw new Error(`Wrong Step "${this.step}" not within ${stepList}`);
+      // Graceful warning but continue communication
+      console.warn(
+        `[KeyExchange] Wrong Step "${this.step}" not within ${stepList}`,
+      );
     }
   }
 


### PR DESCRIPTION
Allow mobile to overwrite keyexchange at any point which can be useful when the keys are updated via deeplink.