### PR TITLE
feat: ui quick swap and new rpc call metamask_open

### DIFF
--- a/packages/devnext/package.json
+++ b/packages/devnext/package.json
@@ -20,6 +20,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@metamask/design-tokens": "^1.12.0",
     "@metamask/providers": "^10.2.1",
     "@metamask/sdk": "workspace:^",
     "@metamask/sdk-communication-layer": "workspace:^",

--- a/packages/devnext/src/components/layout.tsx
+++ b/packages/devnext/src/components/layout.tsx
@@ -17,6 +17,7 @@ export const Layout = ({ children }: LayoutProps) => {
     <div>
       <SDKConfigCard
         options={{ showQRCode: true }}
+        title={`DevNext`}
         onHomePress={() => {
           router.push('/');
         }}

--- a/packages/devreactnative/App.tsx
+++ b/packages/devreactnative/App.tsx
@@ -25,6 +25,7 @@ import RootNavigator from './src/RootNavigator';
 
 LogBox.ignoreLogs([
   'Possible Unhandled Promise Rejection',
+  'No handleCopy function provided for address',
   'Message ignored because invalid key exchange status',
   "MetaMask: 'ethereum._metamask' exposes",
   '`new NativeEventEmitter()` was called with a non-null',

--- a/packages/sdk-ui/src/components/floating-metamask-button/floating-metamask-button.tsx
+++ b/packages/sdk-ui/src/components/floating-metamask-button/floating-metamask-button.tsx
@@ -10,7 +10,10 @@ import { FAB } from 'react-native-paper';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import FABGroupFix from '../fab-group-fix/FabGroupFix';
 import { IconOriginal } from '../icons/IconOriginal';
-import { MetaMaskModal } from '../metamask-modal/metamask-modal';
+import {
+  MetaMaskModal,
+  MetaMaskModalProps,
+} from '../metamask-modal/metamask-modal';
 
 export interface FloatingMetaMaskButtonProps {
   distance?: {
@@ -40,9 +43,10 @@ const getStyles = ({
 export const FloatingMetaMaskButton = ({
   distance,
 }: FloatingMetaMaskButtonProps) => {
-  const { sdk, connected, connecting } = useSDK();
+  const { sdk, connected, connecting, provider } = useSDK();
   const [modalOpen, setModalOpen] = useState(false);
   const [active, setActive] = useState(false);
+  const [target, setTarget] = useState<MetaMaskModalProps['target']>('network');
   const styles = useMemo(() => getStyles({ distance }), [distance]);
 
   const renderIcon = ({ color }: { color: string }) => {
@@ -96,14 +100,38 @@ export const FloatingMetaMaskButton = ({
           {
             label: 'Network',
             icon: 'swap-horizontal',
-            onPress: () => setModalOpen(true),
+            onPress: () => {
+              setTarget('network');
+              setModalOpen(true);
+            },
+          },
+          {
+            label: 'Buy ETH',
+            icon: 'swap-horizontal',
+            onPress: () => {
+              provider?.request({
+                method: 'metamask_open',
+                params: [{ target: 'buy' }],
+              });
+            },
+          },
+          {
+            label: 'SWAP',
+            icon: 'swap-horizontal',
+            onPress: () => {
+              setTarget('swap');
+              setModalOpen(true);
+            },
           },
           {
             icon: ({ color }) => (
               <MaterialIcons name="price-change" color={color} size={24} />
             ),
-            label: 'GAS Api',
-            onPress: () => console.log('Pressed notifications'),
+            label: 'Infura GAS Api',
+            onPress: () => {
+              setTarget('gasprice');
+              setModalOpen(true);
+            },
           },
           {
             label: 'Disconnect',
@@ -116,7 +144,11 @@ export const FloatingMetaMaskButton = ({
         ]}
         onStateChange={handleStateChange}
       />
-      <MetaMaskModal modalOpen={modalOpen} onClose={closeModal} />
+      <MetaMaskModal
+        modalOpen={modalOpen}
+        target={target}
+        onClose={closeModal}
+      />
     </>
   );
 };

--- a/packages/sdk-ui/src/components/gasprice-panel/gasprice-panel.stories.tsx
+++ b/packages/sdk-ui/src/components/gasprice-panel/gasprice-panel.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta } from '@storybook/react-native';
+import React from 'react';
+import { GasPricePanel, GasPricePanelProps } from './gasprice-panel';
+import { SDKState } from '@metamask/sdk-react';
+import {
+  SdkContextDecorator,
+  sdkProviderArgTypes,
+} from '../../mocks/storybook.mocks';
+
+const SwapPanelMeta: Meta<GasPricePanelProps & SDKState> = {
+  component: GasPricePanel,
+  title: 'SDK UI / GasPrice Panel',
+  argTypes: {
+    ...sdkProviderArgTypes,
+  },
+  decorators: [SdkContextDecorator],
+  parameters: {},
+};
+
+export default SwapPanelMeta;
+
+export const Primary = {
+  args: {
+    connected: true,
+    chainId: '0x1',
+    balance: '11111111111111111',
+    account: '0xAAAAA0e296961f476E01184274Ce85ae60184CB0',
+  },
+  component: (args: GasPricePanelProps) => <GasPricePanel {...args} />,
+};

--- a/packages/sdk-ui/src/components/gasprice-panel/gasprice-panel.tsx
+++ b/packages/sdk-ui/src/components/gasprice-panel/gasprice-panel.tsx
@@ -1,0 +1,60 @@
+import { useSDK } from '@metamask/sdk-react';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StyleSheet, View } from 'react-native';
+import Text, { TextVariant } from '../../design-system/components/Texts/Text';
+import { useTheme } from '../../theme';
+import { Theme } from '../../theme/models';
+import { AccountBalance } from '../metamask-button/account-balance/account-balance';
+
+const getStyles = ({}: { theme: Theme }) =>
+  StyleSheet.create({
+    container: {
+      display: 'flex',
+      width: '100%',
+      flex: 1,
+      padding: 5,
+      flexDirection: 'column',
+      paddingRight: 15,
+      paddingLeft: 15,
+      gap: 10,
+      justifyContent: 'space-evenly',
+      alignItems: 'center',
+    },
+    balanceContainer: {
+      flexDirection: 'row',
+      gap: 10,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    segmentedButtons: {
+      width: '100%',
+    },
+    actionContainer: {
+      gap: 10,
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    cryptoIcon: { width: 24, height: 24 },
+  });
+
+export interface GasPricePanelProps {}
+export const GasPricePanel = ({}: GasPricePanelProps) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const styles = useMemo(() => getStyles({ theme }), [theme]);
+  const { chainId } = useSDK();
+
+  return (
+    <View style={styles.container}>
+      <Text variant={TextVariant.HeadingLG}>Gas Price</Text>
+      <View style={styles.balanceContainer}>
+        <Text>Balance</Text>
+        <AccountBalance decimals={4} />
+      </View>
+      <Text>chain: {chainId}</Text>
+      <Text>{t('TODO: implement infura gas price API')}</Text>
+    </View>
+  );
+};

--- a/packages/sdk-ui/src/components/metamask-modal/metamask-modal.tsx
+++ b/packages/sdk-ui/src/components/metamask-modal/metamask-modal.tsx
@@ -8,9 +8,12 @@ import { SDKSummary } from '../sdk-summary/sdk-summary';
 import { useSDK } from '@metamask/sdk-react';
 import { useTheme } from '../../theme';
 import { Theme } from '@metamask/design-tokens';
+import { SwapPanel } from '../swap-panel/swap-panel';
+import { GasPricePanel } from '../gasprice-panel/gasprice-panel';
 
 export interface MetaMaskModalProps {
   modalOpen: boolean;
+  target?: 'network' | 'swap' | 'gasprice';
   onClose?: () => void;
 }
 
@@ -51,7 +54,11 @@ const getStyles = ({ theme }: { theme: Theme }) => {
   });
 };
 
-export const MetaMaskModal = ({ modalOpen, onClose }: MetaMaskModalProps) => {
+export const MetaMaskModal = ({
+  modalOpen,
+  target = 'network',
+  onClose,
+}: MetaMaskModalProps) => {
   const { toastRef } = useContext(ToastContext);
   const { connected } = useSDK();
   const theme = useTheme();
@@ -65,7 +72,9 @@ export const MetaMaskModal = ({ modalOpen, onClose }: MetaMaskModalProps) => {
     >
       <View style={styles.centeredView}>
         <View style={styles.modalView}>
-          <SDKSummary />
+          {target === 'network' && <SDKSummary />}
+          {target === 'swap' && <SwapPanel />}
+          {target === 'gasprice' && <GasPricePanel />}
           <TouchableOpacity style={styles.closeButton} onPress={onClose}>
             <MaterialCommunityIcons
               name="close"

--- a/packages/sdk-ui/src/components/sdk-config-card/sdk-config-card.tsx
+++ b/packages/sdk-ui/src/components/sdk-config-card/sdk-config-card.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import {
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native';
 import { IconButton } from 'react-native-paper';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 
@@ -80,9 +86,12 @@ export const SDKConfigCard = ({
     >
       <View style={styles.centered}>
         {renderLeft()}
-        <View style={styles.titleContainer}>
+        <Pressable
+          style={styles.titleContainer}
+          onPress={() => setVisible((v) => !v)}
+        >
           <Text>{title}</Text>
-        </View>
+        </Pressable>
         <View>{renderRight()}</View>
       </View>
       {visible && <SDKConfig {...options} />}

--- a/packages/sdk-ui/src/components/sdk-summary/sdk-summary.tsx
+++ b/packages/sdk-ui/src/components/sdk-summary/sdk-summary.tsx
@@ -1,5 +1,5 @@
 import { useSDK } from '@metamask/sdk-react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleSheet, View } from 'react-native';
 import { ActivityIndicator } from 'react-native-paper';
@@ -13,13 +13,50 @@ import Button, {
   ButtonVariants,
 } from '../../design-system/components/Buttons/Button';
 import { IconName } from '../../design-system/components/Icons/Icon';
+import { useTheme } from '../../theme';
+import { Theme } from '../../theme/models';
 import { AddressCopyButton } from '../address-copy-button/address-copy-button';
 import { AccountBalance } from '../metamask-button/account-balance/account-balance';
 import NetworkSelector from '../network-selector/network-selector';
 
+const getStyles = ({}: { theme: Theme }) =>
+  StyleSheet.create({
+    container: {
+      display: 'flex',
+      width: '100%',
+      flex: 1,
+      padding: 5,
+      flexDirection: 'column',
+      paddingRight: 15,
+      paddingLeft: 15,
+      gap: 0,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    header: {
+      width: '100%',
+      gap: 0,
+      height: 160,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    headerContent: {},
+    balanceContainer: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    icon: { padding: 5 },
+    network: {},
+    address: {},
+  });
+
 export interface SDKSummaryProps {}
-export const SDKSummary = () => {
+export const SDKSummary = ({}: SDKSummaryProps) => {
   const { t } = useTranslation('sdk-summary');
+  const theme = useTheme();
+  const styles = useMemo(() => getStyles({ theme }), [theme]);
 
   const { account, connected, balanceProcessing, sdk } = useSDK();
 
@@ -56,35 +93,3 @@ export const SDKSummary = () => {
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    display: 'flex',
-    width: '100%',
-    flex: 1,
-    padding: 5,
-    flexDirection: 'column',
-    paddingRight: 15,
-    paddingLeft: 15,
-    gap: 0,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  header: {
-    width: '100%',
-    gap: 0,
-    height: 160,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  headerContent: {},
-  balanceContainer: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  icon: { padding: 5 },
-  network: {},
-  address: {},
-});

--- a/packages/sdk-ui/src/components/swap-panel/swap-panel.stories.tsx
+++ b/packages/sdk-ui/src/components/swap-panel/swap-panel.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta } from '@storybook/react-native';
+import React from 'react';
+import { SwapPanel, SwapPanelProps } from './swap-panel';
+import { SDKState } from '@metamask/sdk-react';
+import {
+  SdkContextDecorator,
+  sdkProviderArgTypes,
+} from '../../mocks/storybook.mocks';
+
+const SwapPanelMeta: Meta<SwapPanelProps & SDKState> = {
+  component: SwapPanel,
+  title: 'SDK UI / Swap Panel',
+  argTypes: {
+    ...sdkProviderArgTypes,
+  },
+  decorators: [SdkContextDecorator],
+  parameters: {},
+};
+
+export default SwapPanelMeta;
+
+export const Primary = {
+  args: {
+    connected: true,
+    chainId: '0x1',
+    balance: '11111111111111111',
+    account: '0xAAAAA0e296961f476E01184274Ce85ae60184CB0',
+  },
+  component: (args: SwapPanelProps) => <SwapPanel {...args} />,
+};

--- a/packages/sdk-ui/src/components/swap-panel/swap-panel.tsx
+++ b/packages/sdk-ui/src/components/swap-panel/swap-panel.tsx
@@ -1,0 +1,172 @@
+import { useSDK } from '@metamask/sdk-react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Image, StyleSheet, View } from 'react-native';
+import { SegmentedButtons } from 'react-native-paper';
+import images from '../../../assets/images/image-icons';
+import Button, {
+  ButtonVariants,
+} from '../../design-system/components/Buttons/Button';
+import HelpText, {
+  HelpTextSeverity,
+} from '../../design-system/components/Form/HelpText';
+import TextField from '../../design-system/components/Form/TextField';
+import Text, { TextVariant } from '../../design-system/components/Texts/Text';
+import { useTheme } from '../../theme';
+import { Theme } from '../../theme/models';
+import { getNetworkByHexChainId } from '../../utils/networks';
+import { AccountBalance } from '../metamask-button/account-balance/account-balance';
+
+const getStyles = ({}: { theme: Theme }) =>
+  StyleSheet.create({
+    container: {
+      display: 'flex',
+      width: '100%',
+      flex: 1,
+      padding: 5,
+      flexDirection: 'column',
+      paddingRight: 15,
+      paddingLeft: 15,
+      gap: 10,
+      justifyContent: 'space-evenly',
+      alignItems: 'center',
+    },
+    balanceContainer: {
+      flexDirection: 'row',
+      gap: 10,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    segmentedButtons: {
+      width: '100%',
+    },
+    actionContainer: {
+      gap: 10,
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    cryptoIcon: { width: 24, height: 24 },
+  });
+
+export interface SwapPanelProps {}
+export const SwapPanel = ({}: SwapPanelProps) => {
+  const { t } = useTranslation('sdk-summary');
+  const theme = useTheme();
+  const styles = useMemo(() => getStyles({ theme }), [theme]);
+  const [amount, setAmount] = useState<number>(0);
+
+  const { chainId, balance, provider } = useSDK();
+
+  const [targetToken, setTargetToken] = useState('LINEA');
+
+  const userBalance = useMemo(() => {
+    if (!balance) {
+      return 0;
+    }
+
+    // Convert the hexadecimal balance to a decimal number
+    const balanceInWei = parseInt(balance, 16);
+
+    // Assuming the balance is in Wei (for Ethereum), convert it to Ether.
+    // 1 Ether = 1e18 Wei
+    const balanceInEther = balanceInWei / 1e18;
+
+    // Format the number
+    return balanceInEther;
+  }, [balance]);
+
+  const error = useMemo(() => {
+    return userBalance < amount || userBalance === 0;
+  }, [userBalance, amount]);
+
+  const network = useMemo(() => {
+    return chainId ? getNetworkByHexChainId(chainId) : undefined;
+  }, [chainId]);
+
+  const renderIcon = (iconName: string) => (
+    <Image
+      style={styles.cryptoIcon}
+      source={images[iconName as keyof typeof images]}
+    />
+  );
+
+  const buttons = [
+    {
+      value: 'LINEA',
+      icon: () => renderIcon('LINEA-MAINNET'),
+      label: 'Linea ETH',
+    },
+    {
+      value: 'Matic',
+      icon: () => renderIcon('MATIC'),
+      label: 'Polygon MATIC',
+    },
+  ];
+
+  const handleAmountChange = (inputAmount: string) => {
+    const fAmount = parseFloat(inputAmount);
+    console.log(`new amount`, fAmount);
+    setAmount(fAmount);
+  };
+
+  const handleBuyMore = useCallback(() => {
+    provider?.request({
+      method: 'metamask_open',
+      params: [{ target: 'buy' }],
+    });
+  }, [provider]);
+
+  const handleSwap = useCallback(() => {
+    provider?.request({
+      method: 'metamask_open',
+      params: [{ target: 'swap', amount, token: targetToken }],
+    });
+  }, [provider, amount, targetToken]);
+
+  return (
+    <View style={styles.container}>
+      <Text variant={TextVariant.HeadingLG}>SDK Quick SWAP</Text>
+      <View style={styles.balanceContainer}>
+        <Text>Balance</Text>
+        <AccountBalance decimals={4} />
+      </View>
+
+      <TextField
+        placeholder="Amount"
+        onChangeText={handleAmountChange}
+        endAccessory={<Text>{network?.symbol}</Text>}
+      />
+
+      {error && (
+        <>
+          <HelpText severity={HelpTextSeverity.Error}>
+            {t('Insufficient balance')}
+          </HelpText>
+        </>
+      )}
+      <View>
+        <Button
+          variant={error ? ButtonVariants.Primary : ButtonVariants.Link}
+          label={`Buy More ${network?.symbol}`}
+          onPress={handleBuyMore}
+        />
+      </View>
+
+      <SegmentedButtons
+        value={targetToken}
+        style={styles.segmentedButtons}
+        onValueChange={setTargetToken}
+        buttons={buttons}
+      />
+      <View style={styles.actionContainer}>
+        <Button
+          variant={error ? ButtonVariants.Secondary : ButtonVariants.Primary}
+          label={'Swap Now'}
+          // disabled={!!error}
+          onPress={handleSwap}
+        />
+      </View>
+    </View>
+  );
+};

--- a/packages/sdk-ui/src/mocks/storybook.mocks.tsx
+++ b/packages/sdk-ui/src/mocks/storybook.mocks.tsx
@@ -13,6 +13,7 @@ export const defaultSDKtArgs: Partial<SDKState> = {
   connecting: false,
   extensionActive: false,
   chainId: '0x1',
+  balance: '11111111111111111',
   account: '0xAAAAA0e296961f476E01184274Ce85ae60184CB0',
 };
 
@@ -31,6 +32,10 @@ export const sdkProviderArgTypes: ArgTypes<Partial<SDKState>> = {
   account: {
     control: 'text',
     defaultValue: defaultSDKtArgs.account,
+  },
+  balance: {
+    control: 'text',
+    defaultValue: defaultSDKtArgs.balance,
   },
   chainId: {
     control: 'select',
@@ -56,6 +61,7 @@ export const SdkContextDecorator = (ThisStory: Story, sc: any) => {
     connected,
     connecting,
     chainId,
+    balance,
     readOnlyCalls,
     extensionActive,
     rpcHistory,
@@ -79,6 +85,7 @@ export const SdkContextDecorator = (ThisStory: Story, sc: any) => {
       value={{
         ready,
         extensionActive,
+        balance,
         connected,
         readOnlyCalls,
         connecting,

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -14,6 +14,7 @@ export const METHODS_TO_REDIRECT: { [method: string]: boolean } = {
   metamask_connectSign: true,
   metamask_connectWith: true,
   metamask_batch: true,
+  metamask_open: true,
 };
 export const STORAGE_PATH = '.sdk-comm';
 export const STORAGE_PROVIDER_TYPE = 'providerType';
@@ -21,6 +22,7 @@ export const RPC_METHODS = {
   METAMASK_GETPROVIDERSTATE: 'metamask_getProviderState',
   METAMASK_CONNECTSIGN: 'metamask_connectSign',
   METAMASK_CONNECTWITH: 'metamask_connectWith',
+  METAMASK_OPEN: 'metamask_open',
   METAMASK_BATCH: 'metamask_batch',
   PERSONAL_SIGN: 'personal_sign',
   ETH_REQUESTACCOUNTS: 'eth_requestAccounts',

--- a/yarn.lock
+++ b/yarn.lock
@@ -19752,6 +19752,7 @@ __metadata:
     "@fortawesome/free-solid-svg-icons": ^6.4.2
     "@fortawesome/react-fontawesome": ^0.2.0
     "@lavamoat/allow-scripts": ^2.3.1
+    "@metamask/design-tokens": ^1.12.0
     "@metamask/providers": ^10.2.1
     "@metamask/sdk": "workspace:^"
     "@metamask/sdk-communication-layer": "workspace:^"


### PR DESCRIPTION
New component inside the floating MetaMask Button to directly create swap from any dapps.
- Also allow to onboard users to onramp and buy currency
- [TESTING] new rpc call `metamask_open` which can be used to directly open a screen in the wallet 
![image](https://github.com/MetaMask/metamask-sdk/assets/107169956/014d2c3d-29dd-478e-938f-2048e654daa9)
![image](https://github.com/MetaMask/metamask-sdk/assets/107169956/5b953d89-c8a0-4850-bac3-bd66f24bfc5c)
