### PR TITLE
consensys.net -> consensys.io

### DIFF
--- a/packages/sdk-ui/src/constants/urls.ts
+++ b/packages/sdk-ui/src/constants/urls.ts
@@ -15,7 +15,7 @@ export const CONNECTING_TO_A_DECEPTIVE_SITE =
   'https://support.metamask.io/hc/en-us/articles/4428045875483--Deceptive-site-ahead-when-trying-to-connect-to-a-site';
 
 // Policies
-export const CONSENSYS_PRIVACY_POLICY = 'https://consensys.net/privacy-policy/';
+export const CONSENSYS_PRIVACY_POLICY = 'https://consensys.io/privacy-policy/';
 
 // Keystone
 export const KEYSTONE_SUPPORT = 'https://keyst.one/mmm';


### PR DESCRIPTION
## Explanation

Update consensys.net url to consensys.io

## Related issues

https://github.com/Consensys/dx-team/issues/1703
