### PR TITLE
feat: Conditionally Invoke getMobileProvider in setupExtensionPreferences Based on if Mobile Provider is Availabile

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
@@ -53,9 +53,13 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
           console.debug('PROPAGATE chainChanged', chainId);
         }
 
-        instance
-          .getMobileProvider()
-          .emit(EXTENSION_EVENTS.CHAIN_CHANGED, chainId);
+        const hasMobileProvider = Boolean(instance.sdkProvider);
+
+        if (hasMobileProvider) {
+          instance
+            .getMobileProvider()
+            .emit(EXTENSION_EVENTS.CHAIN_CHANGED, chainId);
+        }
       });
 
       metamaskBrowserExtension.on(
@@ -65,9 +69,13 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
             console.debug('PROPAGATE accountsChanged', accounts);
           }
 
-          instance
-            .getMobileProvider()
-            .emit(EXTENSION_EVENTS.ACCOUNTS_CHANGED, accounts);
+          const hasMobileProvider = Boolean(instance.sdkProvider);
+
+          if (hasMobileProvider) {
+            instance
+              .getMobileProvider()
+              .emit(EXTENSION_EVENTS.ACCOUNTS_CHANGED, accounts);
+          }
         },
       );
 
@@ -76,21 +84,34 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
           console.debug('PROPAGATE disconnect', error);
         }
 
-        instance.getMobileProvider().emit(EXTENSION_EVENTS.DISCONNECT, error);
+        const hasMobileProvider = Boolean(instance.sdkProvider);
+
+        if (hasMobileProvider) {
+          instance.getMobileProvider().emit(EXTENSION_EVENTS.DISCONNECT, error);
+        }
       });
 
       metamaskBrowserExtension.on(EXTENSION_EVENTS.CONNECT, (args) => {
         if (developerMode) {
           console.debug('PROPAGATE connect', args);
         }
-        instance.getMobileProvider().emit(EXTENSION_EVENTS.CONNECT, args);
+
+        const hasMobileProvider = Boolean(instance.sdkProvider);
+
+        if (hasMobileProvider) {
+          instance.getMobileProvider().emit(EXTENSION_EVENTS.CONNECT, args);
+        }
       });
 
       metamaskBrowserExtension.on(EXTENSION_EVENTS.CONNECTED, (args) => {
         if (developerMode) {
           console.debug('PROPAGATE connected', args);
         }
-        instance.getMobileProvider().emit(EXTENSION_EVENTS.CONNECTED, args);
+        const hasMobileProvider = Boolean(instance.sdkProvider);
+
+        if (hasMobileProvider) {
+          instance.getMobileProvider().emit(EXTENSION_EVENTS.CONNECTED, args);
+        }
       });
     } catch (err) {
       // Ignore error if metamask extension not found


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->


This PR optimizes the `setupExtensionPreferences` method by invoking `getMobileProvider` only if a mobile provider is detected. This is determined by checking the existence of `sdkProvider` in the instance. 
This conditional execution prevents unnecessary method calls, streamlining the setup process for extension preferences when a mobile provider is available.

Also that's going to fix this issue on Wagmi:
https://github.com/wevm/wagmi/issues/3400

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/sdk`

- feat: Conditionally Invoke getMobileProvider in setupExtensionPreferences Based on if Mobile Provider is Availabile

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
