### PR TITLE
feat: disable sourcemaps

### DIFF
--- a/packages/sdk-communication-layer/rollup.config.js
+++ b/packages/sdk-communication-layer/rollup.config.js
@@ -46,7 +46,7 @@ const config = [
       {
         file: packageJson.browser,
         format: 'es',
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
@@ -87,13 +87,13 @@ const config = [
         name: 'browser',
         file: packageJson.unpkg,
         format: 'umd',
-        sourcemap: true,
+        sourcemap: false,
       },
       {
         file: 'dist/browser/iife/metamask-sdk-communication-layer.js',
         format: 'iife',
         name: 'MetaMaskSDK',
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
@@ -123,7 +123,7 @@ const config = [
       {
         file: packageJson['react-native'],
         format: 'es',
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
@@ -169,7 +169,7 @@ const config = [
         // This must be set to true if using a different file extension that '.node'
         dlopen: false,
         // Generate sourcemap
-        sourcemap: true,
+        sourcemap: false,
       }),
       typescript({ tsconfig: './tsconfig.json' }),
       nodeResolve({

--- a/packages/sdk-install-modal-web/rollup.config.js
+++ b/packages/sdk-install-modal-web/rollup.config.js
@@ -15,18 +15,18 @@ const config = [
       {
         file: packageJson.module,
         format: 'es',
-        sourcemap: true,
+        sourcemap: false,
       },
       {
         name: 'browser',
         file: packageJson.unpkg,
         format: 'umd',
-        sourcemap: true,
+        sourcemap: false,
       },
       {
         file: packageJson.main,
         format: 'cjs',
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [resolve(), commonjs(), typescript({ sourceMap: true }), terser()],

--- a/packages/sdk-react-ui/rollup.config.js
+++ b/packages/sdk-react-ui/rollup.config.js
@@ -20,13 +20,13 @@ const config = [
         file: packageJson.module,
         inlineDynamicImports: true,
         format: 'esm',
-        sourcemap: true,
+        sourcemap: false,
       },
       {
         file: packageJson.main,
         inlineDynamicImports: true,
         format: 'cjs',
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [

--- a/packages/sdk-react/rollup.config.js
+++ b/packages/sdk-react/rollup.config.js
@@ -21,7 +21,7 @@ const config = [
         file: packageJson.module,
         inlineDynamicImports: true,
         format: 'esm',
-        sourcemap: true,
+        sourcemap: false,
         sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
           // Not sure why rollup otherwise adds an extra '../' to the path
 
@@ -33,7 +33,7 @@ const config = [
         file: packageJson.main,
         inlineDynamicImports: true,
         format: 'cjs',
-        sourcemap: true,
+        sourcemap: false,
         sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
           // Not sure why rollup otherwise adds an extra '../' to the path
 

--- a/packages/sdk/rollup.config.js
+++ b/packages/sdk/rollup.config.js
@@ -35,7 +35,7 @@ const config = [
         file: 'dist/browser/es/metamask-sdk.js',
         format: 'es',
         inlineDynamicImports: true,
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
@@ -71,14 +71,14 @@ const config = [
         file: packageJson.unpkg,
         inlineDynamicImports: true,
         format: 'umd',
-        sourcemap: true,
+        sourcemap: false,
       },
       {
         file: 'dist/browser/iife/metamask-sdk.js',
         format: 'iife',
         name: 'MetaMaskSDK',
         inlineDynamicImports: true,
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
@@ -111,7 +111,7 @@ const config = [
         file: 'dist/react-native/es/metamask-sdk.js',
         format: 'es',
         inlineDynamicImports: true,
-        sourcemap: true,
+        sourcemap: false,
       },
     ],
     plugins: [
@@ -160,7 +160,7 @@ const config = [
         // This must be set to true if using a different file extension that '.node'
         dlopen: false,
         // Generate sourcemap
-        sourcemap: true,
+        sourcemap: false,
       }),
       typescript({ tsconfig: './tsconfig.json' }),
       nodeResolve({


### PR DESCRIPTION
## Explanation
Prevent excessive bundle size which included sourcemaps.

## References
https://github.com/MetaMask/metamask-sdk/issues/628

## Changelog


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
