### PR TITLE
feat: expose channel id via hook + expose wallet status via sdk instance

### DIFF
--- a/packages/sdk-react/src/MetaMaskProvider.spec.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.spec.tsx
@@ -51,6 +51,7 @@ describe('MetaMaskProvider Component', () => {
             removeListener: mockProviderRemoveListener,
             request: mockRequest,
           }),
+          getChannelId: jest.fn().mockReturnValue('MOCKED_channelId'),
           _getConnection: jest.fn(),
         } as unknown as MetaMaskSDK),
     );

--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -45,6 +45,7 @@ export interface SDKState {
   // Allow querying blockchain while wallet isn't connected
   readOnlyCalls: boolean;
   provider?: SDKProvider;
+  channelId?: string;
   error?: EthereumRpcError<unknown>;
   chainId?: string;
   balance?: string; // hex value in wei
@@ -86,6 +87,7 @@ const MetaMaskProviderClient = ({
   const [balanceProcessing, setBalanceProcessing] = useState<boolean>(false);
   const [balanceQuery, setBalanceQuery] = useState<string>('');
   const [account, setAccount] = useState<string>();
+  const [channelId, setChannelId] = useState<string>();
   const [error, setError] = useState<EthereumRpcError<unknown>>();
   const [provider, setProvider] = useState<SDKProvider>();
   const [status, setStatus] = useState<ServiceStatus>();
@@ -158,6 +160,7 @@ const MetaMaskProviderClient = ({
   useEffect(() => {
     // avoid asking balance multiple times on same account/chain
     const currentBalanceQuery = `${account}${chainId}`;
+    setChannelId(sdk?.getChannelId());
 
     if (account?.startsWith('0x') && chainId?.startsWith('0x') && currentBalanceQuery !== balanceQuery) {
       // Retrieve balance of account
@@ -285,6 +288,7 @@ const MetaMaskProviderClient = ({
         provider,
         rpcHistory,
         connecting,
+        channelId,
         account,
         balance,
         balanceProcessing,

--- a/packages/sdk-react/src/SDKConfigProvider.tsx
+++ b/packages/sdk-react/src/SDKConfigProvider.tsx
@@ -66,7 +66,7 @@ export const SDKConfigProvider = ({ initialSocketServer, initialInfuraKey, debug
   useEffect(() => {
     // Load context from localStorage and URL (priority to URL)
     const loadContext = () => {
-      const storedContext = localStorage.getItem(STORAGE_LOCATION);
+      const storedContext = localStorage?.getItem(STORAGE_LOCATION);
       const initialContext: Partial<SDKConfigContextProps> = storedContext ? JSON.parse(storedContext)
         : {
           infuraAPIKey: initialInfuraKey,

--- a/packages/sdk-ui/src/components/sdk-status/sdk-status.tsx
+++ b/packages/sdk-ui/src/components/sdk-status/sdk-status.tsx
@@ -28,6 +28,7 @@ export const SDKStatus = ({ response, requesting, error }: SDKStatusProps) => {
     balance,
     balanceProcessing,
     channelId,
+    status,
     extensionActive,
     account,
     sdk,
@@ -48,6 +49,10 @@ export const SDKStatus = ({ response, requesting, error }: SDKStatusProps) => {
           {!extensionActive && (
             <>
               <ItemView label="ChannelId" value={channelId} />
+              <ItemView
+                label="Wallet Status"
+                value={status?.connectionStatus}
+              />
             </>
           )}
           <ItemView label="Connected" value={connected ? 'YES' : 'NO'} />

--- a/packages/sdk-ui/src/components/sdk-status/sdk-status.tsx
+++ b/packages/sdk-ui/src/components/sdk-status/sdk-status.tsx
@@ -27,7 +27,7 @@ export const SDKStatus = ({ response, requesting, error }: SDKStatusProps) => {
     connecting,
     balance,
     balanceProcessing,
-    status: serviceStatus,
+    channelId,
     extensionActive,
     account,
     sdk,
@@ -47,10 +47,7 @@ export const SDKStatus = ({ response, requesting, error }: SDKStatusProps) => {
           <ItemView label="SDK Version" value={sdk?.getVersion()} />
           {!extensionActive && (
             <>
-              <ItemView
-                label="ChannelId"
-                value={serviceStatus?.channelConfig?.channelId}
-              />
+              <ItemView label="ChannelId" value={channelId} />
             </>
           )}
           <ItemView label="Connected" value={connected ? 'YES' : 'NO'} />

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -346,6 +346,18 @@ export class MetaMaskSDK extends EventEmitter2 {
     return universalLink;
   }
 
+  getChannelId() {
+    return this.remoteConnection?.getChannelConfig()?.channelId;
+  }
+
+  getRPCHistory() {
+    return this.remoteConnection?.getConnector()?.getRPCMethodTracker();
+  }
+
+  getVersion() {
+    return packageJson.version;
+  }
+
   // TODO: remove once reaching sdk 1.0
   // Not exposed. Should only be used during dev.
   _getChannelConfig() {
@@ -382,13 +394,5 @@ export class MetaMaskSDK extends EventEmitter2 {
 
   _getConnection() {
     return this.remoteConnection;
-  }
-
-  getRPCHistory() {
-    return this.remoteConnection?.getConnector()?.getRPCMethodTracker();
-  }
-
-  getVersion() {
-    return packageJson.version;
   }
 }

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -358,6 +358,10 @@ export class MetaMaskSDK extends EventEmitter2 {
     return packageJson.version;
   }
 
+  getWalletStatus() {
+    return this.remoteConnection?.getConnector()?.getConnectionStatus();
+  }
+
   // TODO: remove once reaching sdk 1.0
   // Not exposed. Should only be used during dev.
   _getChannelConfig() {


### PR DESCRIPTION
## Explanation

Some of the sdk playground components require displaying channelId, previous method involved accessing values via theorically private methods.
Exposing the channelId directly is cleaner and simplify the code.

```ts
# Can be accessed via the sdk instance
sdk.getChannelId() 
sdk.getWalletStatus()

# Can also be accessed via the sdk-react useSDK() hooks
const {  channelId } = useSDK();
```

![image](https://github.com/MetaMask/metamask-sdk/assets/107169956/a33d03cc-9c24-442a-ad4b-f43530a61bfd)

## References

Possible status:
```ts
export enum ConnectionStatus {
  // DISCONNECTED: counterparty is disconnected
  DISCONNECTED = 'disconnected',
  // WAITING: means connected to the websocket but the counterparty (MetaMask or Dapps) isn't.
  WAITING = 'waiting',
  // TIMEOUT: means auto connect didn't establish link within given timeout
  TIMEOUT = 'timeout',
  // LINKED: is connected after handshake, using a different verb to avoid confusion to just being connected to the websocket and waiting for counterpart.
  // LINKED is set when receiving 'READY' message from counterpart.
  LINKED = 'linked',
  // PAUSED:
  PAUSED = 'paused',
  // TERMINATED: if a user manually disconnect the session.
  TERMINATED = 'terminated',
}
```

### `@metamask/sdk`

- expose sdk.getWalletStatus()

### `@metamask/sdk-react

- expose channelId via useSDK

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
