### PR TITLE
Fix/sdk config provider

### DIFF
--- a/packages/devnext/src/pages/_app.tsx
+++ b/packages/devnext/src/pages/_app.tsx
@@ -66,6 +66,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <SDKConfigProvider
         initialSocketServer={process.env.NEXT_PUBLIC_COMM_SERVER_URL}
         initialInfuraKey={process.env.NEXT_PUBLIC_INFURA_API_KEY}
+        debug={true}
       >
         <WithSDKConfig>
           <UIProvider>

--- a/packages/sdk-react/src/SDKConfigProvider.tsx
+++ b/packages/sdk-react/src/SDKConfigProvider.tsx
@@ -30,7 +30,9 @@ const initProps: SDKConfigContextProps = {
 export const SDKConfigContext = createContext({
   ...initProps,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setAppContext: (_: Partial<SDKConfigContextProps>) => { }, // placeholder implemented in the provider.
+  setAppContext: (_: Partial<SDKConfigContextProps>) => {}, // placeholder implemented in the provider.
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  reset: () => {}, // placeholder implemented in the provider.
 });
 
 export interface SDKConfigProviderProps {
@@ -132,9 +134,14 @@ export const SDKConfigProvider = ({ initialSocketServer, initialInfuraKey, debug
     });
   };
 
+  const reset = () => {
+   updateAppContext({ ...initProps, socketServer: initialSocketServer ?? DEFAULT_SERVER_URL, infuraAPIKey: initialInfuraKey });
+  }
+
   // The context value now includes the state and the function to update it
   const contextValue = {
     ...appContext,
+    reset,
     setAppContext: updateAppContext,
   };
 

--- a/packages/sdk-socket-server/src/api-config.ts
+++ b/packages/sdk-socket-server/src/api-config.ts
@@ -17,7 +17,6 @@ const THIRTY_DAYS_IN_SECONDS = 30 * 24 * 60 * 60; // expiration time of entries 
 
 const app = express();
 
-// FIXME enable correctly
 // let windowMsNum = 1;
 // try {
 //   if (process.env.REDIS_HTTP_WINDOW_MS_NUM) {

--- a/packages/sdk-ui/src/components/sdk-config/sdk-config.tsx
+++ b/packages/sdk-ui/src/components/sdk-config/sdk-config.tsx
@@ -14,8 +14,14 @@ export interface SDKConfigProps {
   showQRCode?: boolean;
 }
 export const SDKConfig = ({ showQRCode }: SDKConfigProps) => {
-  const { socketServer, useDeeplink, lang, infuraAPIKey, setAppContext } =
-    useSDKConfig();
+  const {
+    socketServer,
+    useDeeplink,
+    lang,
+    infuraAPIKey,
+    setAppContext,
+    reset,
+  } = useSDKConfig();
   const isProdServer = socketServer === DEFAULT_SERVER_URL;
 
   const currentUrl = location.protocol + '//' + location.host;
@@ -29,6 +35,10 @@ export const SDKConfig = ({ showQRCode }: SDKConfigProps) => {
 
   const updateUseDeeplink = () => {
     setAppContext({ useDeeplink: !useDeeplink });
+  };
+
+  const onReset = () => {
+    reset();
   };
 
   return (
@@ -47,6 +57,12 @@ export const SDKConfig = ({ showQRCode }: SDKConfigProps) => {
           variant={ButtonVariants.Secondary}
           label={`Toggle Deeplink`}
           onPress={updateUseDeeplink}
+        />
+        <Button
+          variant={ButtonVariants.Secondary}
+          label={`Reset`}
+          isDanger={true}
+          onPress={onReset}
         />
       </View>
       {showQRCode && (


### PR DESCRIPTION
## Explanation

Add a reset button to allow changing the configuration options and overwrite if they change.
Previous behavior would always re-use the value in the localStorage making it impossible to reset the url of the  socket server without manually deleting the browser cache.

![image](https://github.com/MetaMask/metamask-sdk/assets/107169956/fa7c4de1-f77d-4db5-82f9-ae082f9118a4)

## References

## Changelog

### `@metamask/sdk-ui`

- add reset button

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
