### PR TITLE
fix: mobile layout for devnext main demo

### DIFF
--- a/packages/devnext/src/pages/demo.tsx
+++ b/packages/devnext/src/pages/demo.tsx
@@ -626,6 +626,7 @@ const Demo = () => {
           <MetaMaskButton />
         </div>
         <div
+          id="demo"
           style={{
             display: 'flex',
             flexDirection: !connected ? 'column' : 'row-reverse',

--- a/packages/devnext/src/styles/globals.css
+++ b/packages/devnext/src/styles/globals.css
@@ -85,3 +85,15 @@ table th, table td {
   color: #007bff; /* Or any color you prefer */
   font-size: 2rem; /* Adjust the size as needed */
 }
+
+@media (max-width:961px)  { 
+  /* includes following devices */
+  /* smartphones, iPhone, portrait 480x320 phones */ 
+  /* portrait e-readers (Nook/Kindle), smaller tablets @ 600 or @ 640 wide. */ 
+  /* portrait tablets, portrait iPad, landscape e-readers, landscape 800x480 or 854x480 phones */ 
+  /* tablet, landscape iPad, lo-res laptops ands desktops */ 
+  #demo {
+    /* always enforce column layout on mobile */
+    flex-direction: column !important;
+  }
+}


### PR DESCRIPTION
## Explanation

This PR fixes mobile layout for devnext main demo using a media query that should cover most mobile devices. On mobile, the layout is reverted back to `flex-direction: row` which is the original layout prior to #719

## References

https://github.com/MetaMask/metamask-sdk/assets/879484/96ea1351-804b-4084-b24d-eb5ab478cd98

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate (n/a)
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate (n/a)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate (n/a)
