### PR TITLE
feat: restrict rpc method analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ packages/examples/nodejs/.sdk-comm
 **/!.yarn/versions
 packages/devnext/next.webpack.config.json
 packages/devreact/webpack.config.json
+.tool-versions

--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -3,19 +3,17 @@ import {
   ConnectionStatus,
   EventType,
   MetaMaskSDK,
-  MetaMaskSDKOptions,
-  SDKProvider,
-  ServiceStatus,
-  RPCMethodResult,
-  RPCMethodCache,
+  MetaMaskSDKOptions, RPCMethodCache, RPCMethodResult, SDKProvider,
+  ServiceStatus
 } from '@metamask/sdk';
+import debugPackage from 'debug';
 import { EthereumRpcError } from 'eth-rpc-errors';
 import React, {
   createContext,
   useEffect,
   useMemo,
   useRef,
-  useState,
+  useState
 } from 'react';
 import { useHandleAccountsChangedEvent } from './EventsHandlers/useHandleAccountsChangedEvent';
 import { useHandleChainChangedEvent } from './EventsHandlers/useHandleChainChangedEvent';
@@ -26,7 +24,6 @@ import { useHandleOnConnectingEvent } from './EventsHandlers/useHandleOnConnecti
 import { useHandleProviderEvent } from './EventsHandlers/useHandleProviderEvent';
 import { useHandleSDKStatusEvent } from './EventsHandlers/useHandleSDKStatusEvent';
 import { logger } from './utils/logger';
-import debugPackage from 'debug';
 
 export interface EventHandlerProps {
   setConnecting: React.Dispatch<React.SetStateAction<boolean>>;
@@ -192,9 +189,7 @@ const MetaMaskProviderClient = ({
       );
 
       setBalanceQuery(currentBalanceQuery);
-      sdk
-        ?.getProvider()
-        .request({
+      provider?.request({
           method: 'eth_getBalance',
           params: [account, 'latest'],
         })
@@ -217,7 +212,7 @@ const MetaMaskProviderClient = ({
     } else {
       setBalance(undefined);
     }
-  }, [account, chainId, balanceQuery]);
+  }, [account, provider, chainId, balanceQuery]);
 
   useEffect(() => {
     // Prevent sdk double rendering with StrictMode

--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -291,7 +291,6 @@ const MetaMaskProviderClient = ({
       activeProvider.removeListener('disconnect', onDisconnect);
       activeProvider.removeListener('accountsChanged', onAccountsChanged);
       activeProvider.removeListener('chainChanged', onChainChanged);
-      setReady(false);
       sdk.removeListener(EventType.SERVICE_STATUS, onSDKStatusEvent);
     };
   }, [trigger, sdk, ready]);

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -19,6 +19,11 @@ export const METHODS_TO_REDIRECT: { [method: string]: boolean } = {
   metamask_batch: true,
   metamask_open: true,
 };
+
+export const lcAnalyticsRPCs = Object.keys(METHODS_TO_REDIRECT).map((method) =>
+  method.toLowerCase(),
+);
+
 export const STORAGE_PATH = '.sdk-comm';
 export const STORAGE_PROVIDER_TYPE = 'providerType';
 export const RPC_METHODS = {

--- a/packages/sdk/src/provider/initializeMobileProvider.ts
+++ b/packages/sdk/src/provider/initializeMobileProvider.ts
@@ -2,20 +2,19 @@ import {
   CommunicationLayerPreference,
   EventType,
   PlatformType,
-  TrackingEvents,
 } from '@metamask/sdk-communication-layer';
-import { logger } from '../utils/logger';
 import packageJson from '../../package.json';
+import { METHODS_TO_REDIRECT, RPC_METHODS } from '../config';
+import { ProviderConstants } from '../constants';
 import { MetaMaskInstaller } from '../Platform/MetaMaskInstaller';
 import { PlatformManager } from '../Platform/PlatfformManager';
 import { getPostMessageStream } from '../PostMessageStream/getPostMessageStream';
-import { METHODS_TO_REDIRECT, RPC_METHODS } from '../config';
-import { ProviderConstants } from '../constants';
 import { MetaMaskSDK } from '../sdk';
 import { Ethereum } from '../services/Ethereum';
 import { RemoteConnection } from '../services/RemoteConnection';
 import { rpcRequestHandler } from '../services/rpc-requests/RPCRequestHandler';
 import { PROVIDER_UPDATE_TYPE } from '../types/ProviderUpdateType';
+import { logger } from '../utils/logger';
 import { wait } from '../utils/wait';
 
 const initializeMobileProvider = ({
@@ -159,10 +158,12 @@ const initializeMobileProvider = ({
     if (rpcEndpoint && isReadOnlyMethod) {
       try {
         const params = args?.[0]?.params;
-        sdk.analytics?.send({
-          event: TrackingEvents.SDK_RPC_REQUEST,
-          params: { method, from: 'readonly' },
-        });
+
+        // TODO: decide if we want external provider tracking
+        // sdk.analytics?.send({
+        //   event: TrackingEvents.SDK_RPC_REQUEST,
+        //   params: { method, from: 'readonly' },
+        // });
         const readOnlyResponse = await rpcRequestHandler({
           rpcEndpoint,
           sdkInfo,

--- a/packages/sdk/src/provider/wrapExtensionProvider.ts
+++ b/packages/sdk/src/provider/wrapExtensionProvider.ts
@@ -1,6 +1,6 @@
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { TrackingEvents } from '@metamask/sdk-communication-layer';
-import { RPC_METHODS } from '../config';
+import { lcAnalyticsRPCs, RPC_METHODS } from '../config';
 import { MetaMaskSDK } from '../sdk';
 import { logger } from '../utils/logger';
 
@@ -30,10 +30,12 @@ export const wrapExtensionProvider = ({
 
           const { method, params } = args;
 
-          sdkInstance.analytics?.send({
-            event: TrackingEvents.SDK_RPC_REQUEST,
-            params: { method, from: 'extension' },
-          });
+          if (lcAnalyticsRPCs.includes(method.toLowerCase())) {
+            sdkInstance.analytics?.send({
+              event: TrackingEvents.SDK_RPC_REQUEST,
+              params: { method, from: 'extension' },
+            });
+          }
 
           // special method handling
           if (method === RPC_METHODS.METAMASK_BATCH && Array.isArray(params)) {


### PR DESCRIPTION
## Explanation

Limit the number of rpc calls that are tracked for analytics to the one redirecting to wallet on extension.
On mobile the list is:
```
  'eth_sendTransaction',
  'eth_signTypedData',
  'eth_signTransaction',
  'wallet_requestPermissions',
  'wallet_switchEthereumChain',
  'eth_signTypedData_v3',
  'eth_signTypedData_v4',
  'metamask_connectSign',
  'metamask_connectWith',
  'metamask_batch',
```
## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
