### PR TITLE
fix: normalize uppercase account addresses in SDKProvider, to resolve MaxListenersExceededWarning

### DIFF
--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -163,11 +163,13 @@ const MetaMaskProviderClient = ({
   }, [rpcHistory, status]);
 
   useEffect(() => {
-    const currentAddress = provider?.getSelectedAddress();
-    if (currentAddress && currentAddress != account) {
+    const currentAddress = provider?.getSelectedAddress()
+
+    if (currentAddress && currentAddress != account?.toLowerCase()) {
       logger(
         `[MetaMaskProviderClient] account changed detected from ${account} to ${currentAddress}`,
       );
+
       setAccount(currentAddress);
     }
   }, [rpcHistory]);

--- a/packages/sdk/src/provider/SDKProvider.ts
+++ b/packages/sdk/src/provider/SDKProvider.ts
@@ -107,7 +107,8 @@ export class SDKProvider extends MetaMaskInpageProvider {
       console.log('No accounts found');
       return null;
     }
-    return accounts[0] || '';
+
+    return accounts[0]?.toLowerCase() || '';
   }
 
   getChainId() {


### PR DESCRIPTION
## Explanation
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->


This PR fixes a MaxListenersExceededWarning in the "`react-metamask-button`" example, caused by excessive accountsChanged listeners due to case sensitivity in account addresses.

**Root Cause & Fix**
The issue stemmed from `getSelectedAddress()` returning uppercase addresses, while we expect lowercase, leading to unnecessary re-triggering of a `useEffect` in `MetaMaskProvider.tsx`. 
The solution was straightforward: modifying `getSelectedAddress()` to return the address in `lowercase`.

## Screenshots

<img width="1089" alt="Screenshot 2024-03-14 at 16 24 54" src="https://github.com/MetaMask/metamask-sdk/assets/61094771/de9edb58-7b74-40fe-abfa-404c4219acc7">


## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
