### PR TITLE
feat: update prod socket server url

### DIFF
--- a/packages/devreact/.env.sample
+++ b/packages/devreact/.env.sample
@@ -1,4 +1,4 @@
-REACT_APP_COMM_SERVER_URL=https://metamask-sdk-socket.metafi.codefi.network/
+REACT_APP_COMM_SERVER_URL=https://metamask-sdk.api.cx.metamask.io/
 REACT_APP_SIMPLE_CONTRACT_ADDRESS='0x13A0A1998B968CFbb780500c83A74F0137193703'
 # Replace with your Ganache RPC URL if different
 REACT_APP_PROVIDER_RPCURL='http://localhost:8545'

--- a/packages/examples/create-react-app/.env.sample
+++ b/packages/examples/create-react-app/.env.sample
@@ -1,1 +1,1 @@
-REACT_APP_COMM_SERVER_URL=https://metamask-sdk-socket.metafi.codefi.network/
+REACT_APP_COMM_SERVER_URL=https://metamask-sdk.api.cx.metamask.io/

--- a/packages/examples/nextjs-demo/.env.sample
+++ b/packages/examples/nextjs-demo/.env.sample
@@ -1,2 +1,2 @@
 # comm server default to https://metamask-sdk-socket.metafi.codefi.network/
-NEXT_PUBLIC_COMM_SERVER_URL=https://metamask-sdk-socket.metafi.codefi.network/
+NEXT_PUBLIC_COMM_SERVER_URL=https://metamask-sdk.api.cx.metamask.io/

--- a/packages/examples/react-with-custom-modal/.env.sample
+++ b/packages/examples/react-with-custom-modal/.env.sample
@@ -1,1 +1,1 @@
-REACT_APP_COMM_SERVER_URL=https://metamask-sdk-socket.metafi.codefi.network/
+REACT_APP_COMM_SERVER_URL=https://metamask-sdk.api.cx.metamask.io/

--- a/packages/sdk-communication-layer/e2e/sdk-comm.test.ts
+++ b/packages/sdk-communication-layer/e2e/sdk-comm.test.ts
@@ -35,7 +35,7 @@ describe('SDK Comm Server', () => {
     const platform = 'jest';
     // const communicationServerUrl = 'http://localhost:4000/';
     const communicationServerUrl =
-      'https://metamask-sdk-socket.metafi.codefi.network/';
+      'https://metamask-sdk.api.cx.metamask.io/';
 
     const waitForReady = async (): Promise<void> => {
       return new Promise<void>((resolve) => {

--- a/packages/sdk-communication-layer/src/config.ts
+++ b/packages/sdk-communication-layer/src/config.ts
@@ -1,5 +1,4 @@
-export const DEFAULT_SERVER_URL =
-  'https://metamask-sdk-socket.metafi.codefi.network/';
+export const DEFAULT_SERVER_URL = 'https://metamask-sdk.api.cx.metamask.io/';
 export const DEFAULT_SOCKET_TRANSPORTS = ['websocket'];
 export const MIN_IN_MS = 1000 * 60;
 export const HOUR_IN_MS = MIN_IN_MS * 60;


### PR DESCRIPTION
## Explanation

Change of production socket server URL from the previous `https://metamask-sdk-socket.metafi.codefi.network/` to the new `https://metamask-sdk.api.cx.metamask.io/`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
