### PR TITLE
feat: store account between refresh

### DIFF
--- a/packages/devnext/src/pages/demo.tsx
+++ b/packages/devnext/src/pages/demo.tsx
@@ -373,8 +373,6 @@ const Demo = () => {
 
   const testReadOnlyCalls = async () => {
     try {
-      await checkBalances();
-
       // Following code can only work after the sdk has connected once and saved initial accounts+chainid.
       console.log(`Testing sdk accounts+chainid caching...`);
       const chain = await provider?.request({
@@ -388,6 +386,8 @@ const Demo = () => {
         params: [],
       });
       console.log(`accounts`, accounts);
+
+      await checkBalances();
     } catch (err) {
       console.error(`testReadOnlyCalls error`, err);
     }

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -58,6 +58,8 @@ export const rpcWithAccountParam = [
 
 export const STORAGE_PATH = '.sdk-comm';
 export const STORAGE_PROVIDER_TYPE = 'providerType';
+export const STORAGE_DAPP_SELECTED_ADDRESS = 'MMSDK_cached_address';
+export const STORAGE_DAPP_CHAINID = 'MMSDK_cached_chainId';
 
 export const EXTENSION_EVENTS = {
   CHAIN_CHANGED: 'chainChanged',

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
@@ -1,8 +1,14 @@
 import { EventType } from '@metamask/sdk-communication-layer';
 import { logger } from '../../../utils/logger';
-import { STORAGE_PROVIDER_TYPE } from '../../../config';
+import {
+  STORAGE_DAPP_CHAINID,
+  STORAGE_DAPP_SELECTED_ADDRESS,
+  STORAGE_PROVIDER_TYPE,
+} from '../../../config';
 import { MetaMaskSDK } from '../../../sdk';
 import { PROVIDER_UPDATE_TYPE } from '../../../types/ProviderUpdateType';
+
+const hasLocalStoage = typeof window !== 'undefined' && window.localStorage;
 
 /**
  * Terminates the MetaMask connection, switching back to the injected provider if connected via extension.
@@ -21,15 +27,19 @@ export function terminate(instance: MetaMaskSDK) {
     return;
   }
 
+  if (hasLocalStoage) {
+    window.localStorage.removeItem(STORAGE_PROVIDER_TYPE);
+    window.localStorage.removeItem(STORAGE_DAPP_CHAINID);
+    window.localStorage.removeItem(STORAGE_DAPP_SELECTED_ADDRESS);
+  }
+
   // check if connected with extension provider
   // if it is, disconnect from it and switch back to injected provider
   if (instance.extensionActive) {
-    localStorage.removeItem(STORAGE_PROVIDER_TYPE);
     if (instance.options.extensionOnly) {
       logger(
         `[MetaMaskSDK: terminate()] extensionOnly --- prevent switching providers`,
       );
-
       return;
     }
     // Re-use default extension provider as default


### PR DESCRIPTION
## Explanation

This PR is created to manage reconnection on wagmi so that even though the wallet is not fully connected, it detects the previous active account and chainID similarly to what wallet connect does.

## References

https://github.com/MetaMask/metamask-sdk/assets/107169956/49d668bb-486b-4001-8ea9-a07dac799ca3

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
