### PR TITLE
feat: sdk done event on dapp side

### DIFF
--- a/packages/sdk-communication-layer/src/services/SocketService/EventListeners/handleMessage.ts
+++ b/packages/sdk-communication-layer/src/services/SocketService/EventListeners/handleMessage.ts
@@ -187,7 +187,7 @@ export function handleMessage(instance: SocketService, channelId: string) {
           SendAnalytics(
             {
               id: instance.remote.state.channelId ?? '',
-              event: TrackingEvents.SDK_RPC_REQUEST_RECEIVED,
+              event: TrackingEvents.SDK_RPC_REQUEST_DONE,
               sdkVersion: instance.remote.state.sdkVersion,
               commLayerVersion: packageJson.version,
               walletVersion: instance.remote.state.walletInfo?.version,
@@ -214,14 +214,6 @@ export function handleMessage(instance: SocketService, channelId: string) {
         };
         instance.state.rpcMethodTracker[rpcMessage.id] = rpcResult;
         instance.emit(EventType.RPC_UPDATE, rpcResult);
-
-        logger.SocketService(
-          `[SocketService handleMessage()] HACK (wallet <7.3) update rpcMethodTracker`,
-          rpcResult,
-        );
-
-        // FIXME hack while waiting for mobile release 7.3
-        instance.emit(EventType.AUTHORIZED);
       }
     }
 

--- a/packages/sdk-communication-layer/src/types/TrackingEvent.ts
+++ b/packages/sdk-communication-layer/src/types/TrackingEvent.ts
@@ -11,6 +11,7 @@ export enum TrackingEvents {
   SDK_USE_EXTENSION = 'sdk_use_extension',
   SDK_RPC_REQUEST = 'sdk_rpc_request',
   SDK_RPC_REQUEST_RECEIVED = 'sdk_rpc_request_received',
+  SDK_RPC_REQUEST_DONE = 'sdk_rpc_request_done',
   SDK_EXTENSION_UTILIZED = 'sdk_extension_utilized',
   SDK_USE_INAPP_BROWSER = 'sdk_use_inapp_browser',
 }


### PR DESCRIPTION
## Explanation

- Add `sdk_rpc_request_done` to show when a method is received on the dapp side and differentiate with `sdk_rpc_request_received` to show when a method is received on the wallet side.

- remove outdated backward compatibility code
