### PR TITLE
fix: preferDesktop and onboarding

### DIFF
--- a/packages/devnext/src/pages/_app.tsx
+++ b/packages/devnext/src/pages/_app.tsx
@@ -30,6 +30,7 @@ const WithSDKConfig = ({ children }: { children: React.ReactNode }) => {
       sdkOptions={{
         communicationServerUrl: socketServer,
         enableAnalytics: true,
+        preferDesktop: false,
         infuraAPIKey,
         readonlyRPCMap: {
           '0x539': process.env.NEXT_PUBLIC_PROVIDER_RPCURL ?? '',

--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/initCommunicationLayer.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/ConnectionManager/initCommunicationLayer.ts
@@ -96,6 +96,10 @@ export function initCommunicationLayer({
     url,
     title,
     source: state.dappMetadata?.source,
+    dappId:
+      typeof window === 'undefined'
+        ? state.dappMetadata?.name ?? state.dappMetadata?.url ?? 'unkown'
+        : window.location.hostname,
     icon: state.dappMetadata?.iconUrl || state.dappMetadata?.base64Icon,
     platform: state.platformType,
     apiVersion: packageJson.version,

--- a/packages/sdk-communication-layer/src/types/OriginatorInfo.ts
+++ b/packages/sdk-communication-layer/src/types/OriginatorInfo.ts
@@ -2,6 +2,7 @@ export interface OriginatorInfo {
   url: string;
   title: string;
   platform: string;
+  dappId: string;
   icon?: string;
   source?: string;
   apiVersion?: string;

--- a/packages/sdk-install-modal-web/src/InstallModal.tsx
+++ b/packages/sdk-install-modal-web/src/InstallModal.tsx
@@ -16,6 +16,7 @@ export interface InstallModalProps {
   onClose: () => void;
   link: string;
   sdkVersion?: string;
+  preferDesktop: boolean;
   metaMaskInstaller: {
     startDesktopOnboarding: () => void;
   };
@@ -23,7 +24,7 @@ export interface InstallModalProps {
 }
 
 export const InstallModal = (props: InstallModalProps) => {
-  const [tab, setTab] = useState<number>(2);
+  const [tab, setTab] = useState<number>(props.preferDesktop ? 1 : 2);
   const qrCodeContainer = useRef<HTMLDivElement>(null);
   const { sdkVersion } = props;
 

--- a/packages/sdk-install-modal-web/src/ModalLoader.tsx
+++ b/packages/sdk-install-modal-web/src/ModalLoader.tsx
@@ -41,6 +41,7 @@ export class ModalLoader {
     reactRoot.render(
       <InstallModal
         link={props.link}
+        preferDesktop={props.preferDesktop}
         onClose={props.onClose}
         sdkVersion={this.sdkVersion}
         metaMaskInstaller={props.metaMaskInstaller}

--- a/packages/sdk/src/Platform/MetaMaskInstaller.test.ts
+++ b/packages/sdk/src/Platform/MetaMaskInstaller.test.ts
@@ -12,6 +12,7 @@ describe('MetaMaskInstaller', () => {
       remote: mockProviderService,
       platformManager: mockPlatformManager,
       debug: false,
+      preferDesktop: false,
     });
   });
 

--- a/packages/sdk/src/Platform/MetaMaskInstaller.ts
+++ b/packages/sdk/src/Platform/MetaMaskInstaller.ts
@@ -9,6 +9,7 @@ import { PlatformManager } from './PlatfformManager';
 // ethereum.on('disconnect', handler: (error: ProviderRpcError) => void);
 
 interface InstallerProps {
+  preferDesktop: boolean;
   remote: ProviderService;
   platformManager: PlatformManager;
   debug?: boolean;
@@ -18,6 +19,7 @@ interface MetaMaskInstallerState {
   isInstalling: boolean;
   hasInstalled: boolean;
   resendRequest: any;
+  preferDesktop: boolean;
   platformManager: PlatformManager | null;
   remote: ProviderService | null;
   debug: boolean;
@@ -33,6 +35,7 @@ export class MetaMaskInstaller {
     isInstalling: false,
     hasInstalled: false,
     resendRequest: null,
+    preferDesktop: false,
     platformManager: null,
     remote: null,
     debug: false,
@@ -40,10 +43,12 @@ export class MetaMaskInstaller {
 
   public constructor({
     remote,
+    preferDesktop,
     platformManager,
     debug = false,
   }: InstallerProps) {
     this.state.remote = remote;
+    this.state.preferDesktop = preferDesktop;
     this.state.platformManager = platformManager;
     this.state.debug = debug;
   }

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -75,7 +75,6 @@ export interface MetaMaskSDKOptions {
 
   /**
    * If true, the SDK will prefer the desktop version of MetaMask over the mobile version.
-   * @deprecated use `extensionOnly` instead
    */
   preferDesktop?: boolean;
 
@@ -260,13 +259,6 @@ export class MetaMaskSDK extends EventEmitter2 {
         throw new Error(`Invalid defaultReadOnlyChainId, must start with '0x'`);
       }
       this.defaultReadOnlyChainId = options.defaultReadOnlyChainId.toString();
-    }
-
-    // Remove deprecated options
-    if (options.preferDesktop) {
-      console.warn(
-        `The 'preferDesktop' option is deprecated. Use 'extensionOnly' instead.`,
-      );
     }
 
     this.options = options;

--- a/packages/sdk/src/services/Analytics.test.ts
+++ b/packages/sdk/src/services/Analytics.test.ts
@@ -35,6 +35,7 @@ describe('Analytics', () => {
         title: 'DApp Name',
         platform: 'web',
         source: 'custom-source',
+        dappId: 'dapp-id',
       },
     };
   });

--- a/packages/sdk/src/services/MetaMaskInstaller/redirectToProperInstall.test.ts
+++ b/packages/sdk/src/services/MetaMaskInstaller/redirectToProperInstall.test.ts
@@ -47,17 +47,6 @@ describe('redirectToProperInstall', () => {
     expect(result).toBe(false);
   });
 
-  it('should start desktop onboarding if platform is DesktopWeb and extension not available', async () => {
-    mockGetPlatformType.mockReturnValue(PlatformType.DesktopWeb);
-    global.window = {
-      extension: undefined,
-    } as any;
-    const result = await redirectToProperInstall(instance);
-
-    expect(mockStartDesktopOnboarding).toHaveBeenCalled();
-    expect(result).toBe(false);
-  });
-
   it('should start remote connection if platform is not MetaMaskMobileWebview', async () => {
     mockGetPlatformType.mockReturnValue(PlatformType.DesktopWeb);
     mockStartConnection.mockResolvedValue(true);

--- a/packages/sdk/src/services/MetaMaskInstaller/redirectToProperInstall.ts
+++ b/packages/sdk/src/services/MetaMaskInstaller/redirectToProperInstall.ts
@@ -28,16 +28,6 @@ export async function redirectToProperInstall(instance: MetaMaskInstaller) {
     return false;
   }
 
-  // If is not installed and is Extension, start Extension onboarding
-  if (platformType === PlatformType.DesktopWeb) {
-    state.isInstalling = true;
-    // If no extension is detected -- start desktop onboarding
-    if (typeof window !== 'undefined' && !window.extension) {
-      await instance.startDesktopOnboarding();
-      return false;
-    }
-  }
-
   // If is not installed, start remote connection
   state.isInstalling = true;
   try {

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.test.ts
@@ -34,11 +34,13 @@ describe('setupAnalytics', () => {
 
     expect(Analytics).toHaveBeenCalledWith({
       serverUrl: DEFAULT_SERVER_URL,
+      enabled: undefined,
       originatorInfo: {
         url: '',
         title: '',
         platform: '',
         source: '',
+        dappId: 'unkown',
       },
     });
   });
@@ -56,10 +58,12 @@ describe('setupAnalytics', () => {
     await setupAnalytics(instance);
 
     expect(Analytics).toHaveBeenCalledWith({
+      enabled: undefined,
       serverUrl: 'https://custom.server.url',
       originatorInfo: {
         url: 'https://dapp.url',
         title: 'DApp Name',
+        dappId: 'DApp Name',
         platform: 'web',
         source: 'custom-source',
       },

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupAnalytics.ts
@@ -23,6 +23,10 @@ export async function setupAnalytics(instance: MetaMaskSDK) {
     originatorInfo: {
       url: options.dappMetadata.url ?? '',
       title: options.dappMetadata.name ?? '',
+      dappId:
+        typeof window === 'undefined'
+          ? options.dappMetadata?.name ?? options.dappMetadata?.url ?? 'unkown'
+          : window.location.hostname,
       platform: platformType ?? '',
       source: options._source ?? '',
     },

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.test.ts
@@ -67,6 +67,7 @@ describe('setupRemoteConnectionAndInstaller', () => {
         ...instance.options.modals,
         onPendingModalDisconnect: expect.any(Function),
       },
+      preferDesktop: false,
     });
 
     expect(MetaMaskInstaller).toHaveBeenCalledWith(
@@ -90,6 +91,7 @@ describe('setupRemoteConnectionAndInstaller', () => {
     expect(MetaMaskInstaller).toHaveBeenCalledWith({
       remote: instance.remoteConnection,
       platformManager: instance.platformManager,
+      preferDesktop: false,
       debug: instance.debug,
     });
   });

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupRemoteConnectionAndInstaller.ts
@@ -28,6 +28,7 @@ export async function setupRemoteConnectionAndInstaller(
 
   instance.remoteConnection = new RemoteConnection({
     i18nInstance: instance.i18nInstance,
+    preferDesktop: options.preferDesktop ?? false,
     communicationLayerPreference:
       options.communicationLayerPreference ??
       CommunicationLayerPreference.SOCKET,
@@ -63,6 +64,7 @@ export async function setupRemoteConnectionAndInstaller(
 
   instance.installer = new MetaMaskInstaller({
     remote: instance.remoteConnection,
+    preferDesktop: options.preferDesktop ?? false,
     platformManager: instance.platformManager as PlatformManager,
     debug: instance.debug,
   });

--- a/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.ts
+++ b/packages/sdk/src/services/RemoteConnection/ModalManager/showInstallModal.ts
@@ -18,6 +18,7 @@ export function showInstallModal(
   state.installModal = options.modals.install?.({
     i18nInstance: options.sdk.i18nInstance,
     link,
+    preferDesktop: state.preferDesktop,
     installer: options.getMetaMaskInstaller(),
     terminate: () => {
       logger(

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -41,6 +41,7 @@ export interface RemoteConnectionProps {
   ecies?: ECIESProps;
   storage?: StorageManagerProps;
   logging?: SDKLoggingOptions;
+  preferDesktop?: boolean;
   i18nInstance: i18n;
   // Prevent circular dependencies
   getMetaMaskInstaller: () => MetaMaskInstaller;
@@ -51,6 +52,7 @@ export interface RemoteConnectionProps {
       i18nInstance: i18n;
       link: string;
       debug?: boolean;
+      preferDesktop?: boolean;
       installer: MetaMaskInstaller;
       terminate?: () => void;
       connectWithExtension?: () => void;
@@ -82,6 +84,7 @@ export interface RemoteConnectionState {
   analytics?: Analytics;
   authorized: boolean;
   reconnection: boolean;
+  preferDesktop?: boolean;
   communicationLayerPreference?: CommunicationLayerPreference;
   platformManager?: PlatformManager;
   pendingModal?: {
@@ -110,6 +113,7 @@ export class RemoteConnection implements ProviderService {
     developerMode: false,
     authorized: false,
     reconnection: false,
+    preferDesktop: false,
     communicationLayerPreference: undefined,
     platformManager: undefined,
     pendingModal: undefined,
@@ -123,6 +127,7 @@ export class RemoteConnection implements ProviderService {
       options.logging?.developerMode === true || options.logging?.sdk === true;
     this.state.developerMode = developerMode;
     this.state.analytics = options.analytics;
+    this.state.preferDesktop = options.preferDesktop ?? false;
     this.state.useDeeplink = options.sdk.options.useDeeplink;
     this.state.communicationLayerPreference =
       options.communicationLayerPreference;

--- a/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
@@ -11,10 +11,12 @@ const sdkWebInstallModal = ({
   installer,
   terminate,
   connectWithExtension,
+  preferDesktop,
   i18nInstance,
 }: {
   link: string;
   debug?: boolean;
+  preferDesktop?: boolean;
   installer: MetaMaskInstaller;
   terminate?: () => void;
   connectWithExtension?: () => void;
@@ -87,6 +89,7 @@ const sdkWebInstallModal = ({
       modalLoader.renderInstallModal({
         i18nInstance,
         parentElement: div,
+        preferDesktop,
         link,
         metaMaskInstaller: installer,
         onClose: unmount,

--- a/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
@@ -89,7 +89,7 @@ const sdkWebInstallModal = ({
       modalLoader.renderInstallModal({
         i18nInstance,
         parentElement: div,
-        preferDesktop,
+        preferDesktop: preferDesktop ?? false,
         link,
         metaMaskInstaller: installer,
         onClose: unmount,


### PR DESCRIPTION
## Explanation

- Fix desktop onboarding.
- Let user set `preferDesktop` to display the 'Desktop' tab by default.
 
![image](https://github.com/MetaMask/metamask-sdk/assets/107169956/de1101a7-ae81-4e65-b3a4-6465d0d8035a)


## References


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
