### PR TITLE
Add platforms.json to track sdk versions

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -1,0 +1,32 @@
+{
+    "@metamask/sdk": {
+        "stable": "0.18.4"
+    },
+    "@metamask/sdk-react": {
+        "stable": "0.18.4"
+    },
+    "@metamask/sdk-install-modal-web": {
+        "stable": "0.17.0"
+    },
+    "@metamask/sdk-communication-layer": {
+        "stable": "0.18.4"
+    },
+    "@metamask/sdk-react-ui": {
+        "stable": "0.18.4"
+    },
+    "@metamask/sdk-ui": {
+        "stable": "0.4.1"
+    },
+    "@metamask/sdk-lab": {
+        "stable": "0.1.5"
+    },
+    "metamask-unity-sdk": {
+        "stable": "1.3.3"
+    },
+    "metamask-ios-sdk": {
+        "stable": "0.6.0"
+    },
+    "metamask-android-sdk": {
+        "stable": "0.5.3"
+    }
+}


### PR DESCRIPTION
## Explanation

This PR adds a central place to store _current_ stable SDK versions across different SDK variants. This can then be used by version checking mechanisms inside of the SDKs. The Unity SDK plans on using this file in the 2.0 release in its version checker.

The file is JSON to allow easy parsing and potential CI / CD automation

## References

The Unity SDK plans on using this file in the 2.0 release in its version checker.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
