### PR TITLE
fix: crossfetch version not matching comm layer

### DIFF
--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -67,7 +67,7 @@
     "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
-    "cross-fetch": "^3.1.5",
+    "cross-fetch": "^4.0.0",
     "eciesjs": "^0.3.16",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,7 +7958,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.26.0
     "@typescript-eslint/parser": ^4.26.0
     bufferutil: ^4.0.8
-    cross-fetch: ^3.1.5
+    cross-fetch: ^4.0.0
     date-fns: ^2.29.3
     debug: ^4.3.4
     eciesjs: ^0.3.16


### PR DESCRIPTION
## Explanation

Align crossfetch version between comm-layer and sdk.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
