### PR TITLE
chore: Bump the socket-server-next version to 2.0.1 for the /version endpoint

### DIFF
--- a/packages/sdk-socket-server-next/package.json
+++ b/packages/sdk-socket-server-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-socket-server-scale",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",


### PR DESCRIPTION
## Explanation
This PR bumps the socket-server-next version to 2.0.1 for us to get a proper version in the /version endpoint.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
