### PR TITLE
feat: emit url event

### DIFF
--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
@@ -108,6 +108,9 @@ export async function startConnection(
     logger(`[RemoteConnection: startConnection()] qrcodeLink=${qrcodeLink}`);
   }
 
+  // emit qrcode url link
+  provider.emit('display_uri', qrcodeLink);
+
   // first handle secure connection
   if (state.platformManager?.isSecure()) {
     // FIXME do we also need to wait for event on secure platform? ready / authorized


### PR DESCRIPTION
## Explanation

In order to integrate with wallet connectors, developer may want to access the qrcode url without actually initiating the deeplink.
The problem is we cannot know the url ahead of time and there is no direct dependencies between sdk and the connection provider.

A workaround is to directly emit display_uri on the provider in order to inform potential wallet connector of the actual uri.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
