### PR TITLE
fix: update the 'request' method wrapper logic in 'wrapExtensionProvider' to handle connectAndSign issues

### DIFF
--- a/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.test.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.test.ts
@@ -1,0 +1,120 @@
+import { MetaMaskInpageProvider } from '@metamask/providers';
+import { TrackingEvents } from '@metamask/sdk-communication-layer';
+import { MetaMaskSDK } from '../../sdk';
+import { handleBatchMethod } from './handleBatchMethod';
+
+jest.mock('@metamask/providers', () => {
+  return {
+    MetaMaskInpageProvider: jest.fn(() => {
+      return {
+        // Mock implementation here
+        request: jest.fn(),
+      };
+    }),
+  };
+});
+
+describe('handleBatchMethod', () => {
+  let sdkInstance: MetaMaskSDK;
+  let mockProvider: MetaMaskInpageProvider;
+  let mockTarget: MetaMaskInpageProvider;
+  const spyAnalytics = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    sdkInstance = {
+      analytics: {
+        send: spyAnalytics,
+      },
+    } as unknown as MetaMaskSDK;
+
+    mockProvider = {
+      request: jest.fn(),
+    } as unknown as MetaMaskInpageProvider;
+
+    mockTarget = {
+      request: jest.fn(),
+    } as unknown as MetaMaskInpageProvider;
+  });
+
+  it('should calls the provider request method for each RPC in params', async () => {
+    const params = [
+      { method: 'rpc1', params: [] },
+      { method: 'rpc2', params: [] },
+    ];
+    const args = { method: 'someMethod', params: ['param1'] };
+
+    await handleBatchMethod({
+      params,
+      target: mockTarget,
+      args,
+      trackEvent: false,
+      provider: mockProvider,
+      sdkInstance,
+    });
+
+    expect(mockProvider.request).toHaveBeenCalledWith({
+      method: 'rpc1',
+      params: [],
+    });
+
+    expect(mockProvider.request).toHaveBeenCalledWith({
+      method: 'rpc2',
+      params: [],
+    });
+  });
+
+  it('should returns the response from the target request method', async () => {
+    const params: any[] = [];
+    const args = { method: 'someMethod', params: ['param1'] };
+    const mockResponse = 'mockResponse';
+    (mockTarget.request as jest.Mock).mockResolvedValue(mockResponse);
+
+    const response = await handleBatchMethod({
+      params,
+      target: mockTarget,
+      args,
+      trackEvent: false,
+      provider: mockProvider,
+      sdkInstance,
+    });
+
+    expect(response).toBe(mockResponse);
+  });
+
+  it('should sends tracking event if trackEvent is true', async () => {
+    const params: any[] = [];
+    const args = { method: 'someMethod', params: ['param1'] };
+
+    await handleBatchMethod({
+      params,
+      target: mockTarget,
+      args,
+      trackEvent: true,
+      provider: mockProvider,
+      sdkInstance,
+    });
+
+    expect(spyAnalytics).toHaveBeenCalledWith({
+      event: TrackingEvents.SDK_RPC_REQUEST_DONE,
+      params: { method: 'someMethod', from: 'extension' },
+    });
+  });
+
+  it('should does not send tracking event if trackEvent is false', async () => {
+    const params: any[] = [];
+    const args = { method: 'someMethod', params: ['param1'] };
+
+    await handleBatchMethod({
+      params,
+      target: mockTarget,
+      args,
+      trackEvent: false,
+      provider: mockProvider,
+      sdkInstance,
+    });
+
+    expect(spyAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.ts
@@ -1,0 +1,39 @@
+import { MetaMaskInpageProvider } from '@metamask/providers';
+import { TrackingEvents } from '@metamask/sdk-communication-layer';
+import { MetaMaskSDK } from '../../sdk';
+import { RequestArguments } from '../wrapExtensionProvider';
+
+export const handleBatchMethod = async ({
+  params,
+  target,
+  args,
+  trackEvent,
+  provider,
+  sdkInstance,
+}: {
+  params: any[];
+  target: MetaMaskInpageProvider;
+  args: RequestArguments;
+  trackEvent: boolean;
+  provider: MetaMaskInpageProvider;
+  sdkInstance: MetaMaskSDK;
+}) => {
+  // params is a list of RPCs to call
+  const responses = [];
+  for (const rpc of params) {
+    const response = await provider?.request({
+      method: rpc.method,
+      params: rpc.params,
+    });
+    responses.push(response);
+  }
+
+  const resp = await target.request(args);
+  if (trackEvent) {
+    sdkInstance.analytics?.send({
+      event: TrackingEvents.SDK_RPC_REQUEST_DONE,
+      params: { method: args.method, from: 'extension' },
+    });
+  }
+  return resp;
+};

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleConnectSignMethod.test.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleConnectSignMethod.test.ts
@@ -1,0 +1,75 @@
+import { MetaMaskInpageProvider } from '@metamask/providers';
+import { RPC_METHODS } from '../../config';
+import { handleConnectSignMethod } from './handleConnectSignMethod';
+
+jest.mock('@metamask/providers', () => {
+  return {
+    MetaMaskInpageProvider: jest.fn(() => {
+      return {
+        // Mock implementation here
+        request: jest.fn(),
+      };
+    }),
+  };
+});
+
+describe('handleConnectSignMethod', () => {
+  let mockTarget: MetaMaskInpageProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockTarget = {
+      request: jest.fn(),
+    } as unknown as MetaMaskInpageProvider;
+  });
+
+  it('should requests ETH accounts and calls personal_sign with the first account', async () => {
+    const accounts = ['0x1234567890abcdef'];
+    (mockTarget.request as jest.Mock)
+      .mockResolvedValueOnce(accounts) // For ETH_REQUESTACCOUNTS
+      .mockResolvedValueOnce('signedMessage'); // For PERSONAL_SIGN
+
+    const params = ['message'];
+    const response = await handleConnectSignMethod({
+      target: mockTarget,
+      params,
+    });
+
+    expect(mockTarget.request).toHaveBeenCalledWith({
+      method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+      params: [],
+    });
+
+    expect(mockTarget.request).toHaveBeenCalledWith({
+      method: RPC_METHODS.PERSONAL_SIGN,
+      params: ['message', '0x1234567890abcdef'],
+    });
+
+    expect(response).toBe('signedMessage');
+  });
+
+  it('should throws an error if no accounts are returned', async () => {
+    (mockTarget.request as jest.Mock).mockResolvedValueOnce([]); // For ETH_REQUESTACCOUNTS
+
+    const params = ['message'];
+    await expect(
+      handleConnectSignMethod({
+        target: mockTarget,
+        params,
+      }),
+    ).rejects.toThrow('SDK state invalid -- undefined accounts');
+  });
+
+  it('should throws an error if the accounts array is undefined', async () => {
+    (mockTarget.request as jest.Mock).mockResolvedValueOnce([]); // For ETH_REQUESTACCOUNTS
+
+    const params = ['message'];
+    await expect(
+      handleConnectSignMethod({
+        target: mockTarget,
+        params,
+      }),
+    ).rejects.toThrow('SDK state invalid -- undefined accounts');
+  });
+});

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleConnectSignMethod.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleConnectSignMethod.ts
@@ -1,0 +1,24 @@
+import { MetaMaskInpageProvider } from '@metamask/providers';
+import { RPC_METHODS } from '../../config';
+
+export const handleConnectSignMethod = async ({
+  target,
+  params,
+}: {
+  target: MetaMaskInpageProvider;
+  params: any[];
+}) => {
+  const accounts = (await target.request({
+    method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+    params: [],
+  })) as string[];
+
+  if (!accounts.length) {
+    throw new Error('SDK state invalid -- undefined accounts');
+  }
+
+  return await target.request({
+    method: RPC_METHODS.PERSONAL_SIGN,
+    params: [params[0], accounts[0]],
+  });
+};

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleConnectWithMethod.test.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleConnectWithMethod.test.ts
@@ -1,0 +1,138 @@
+import { MetaMaskInpageProvider } from '@metamask/providers';
+import { RPC_METHODS, rpcWithAccountParam } from '../../config';
+import { handleConnectWithMethod } from './handleConnectWithMethod';
+
+jest.mock('@metamask/providers', () => {
+  return {
+    MetaMaskInpageProvider: jest.fn(() => {
+      return {
+        request: jest.fn(),
+      };
+    }),
+  };
+});
+
+describe('handleConnectWithMethod', () => {
+  let mockTarget: MetaMaskInpageProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockTarget = {
+      request: jest.fn(),
+    } as unknown as MetaMaskInpageProvider;
+  });
+
+  it('should requests ETH accounts and calls personal_sign with the first account', async () => {
+    const accounts = ['0x1234567890abcdef'];
+    (mockTarget.request as jest.Mock)
+      .mockResolvedValueOnce(accounts) // For ETH_REQUESTACCOUNTS
+      .mockResolvedValueOnce('signedMessage'); // For PERSONAL_SIGN
+
+    const params = [{ method: RPC_METHODS.PERSONAL_SIGN, params: ['message'] }];
+    const response = await handleConnectWithMethod({
+      target: mockTarget,
+      params,
+    });
+
+    expect(mockTarget.request).toHaveBeenCalledWith({
+      method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+      params: [],
+    });
+
+    expect(mockTarget.request).toHaveBeenCalledWith({
+      method: RPC_METHODS.PERSONAL_SIGN,
+      params: ['message', '0x1234567890abcdef'],
+    });
+
+    expect(response).toBe('signedMessage');
+  });
+
+  it('should requests ETH accounts and calls eth_sendTransaction with the first account', async () => {
+    const accounts = ['0x1234567890abcdef'];
+    (mockTarget.request as jest.Mock)
+      .mockResolvedValueOnce(accounts) // For ETH_REQUESTACCOUNTS
+      .mockResolvedValueOnce('transactionHash'); // For ETH_SENDTRANSACTION
+
+    const params = [
+      { method: RPC_METHODS.ETH_SENDTRANSACTION, params: [{ to: '0xabcd' }] },
+    ];
+    const response = await handleConnectWithMethod({
+      target: mockTarget,
+      params,
+    });
+
+    expect(mockTarget.request).toHaveBeenCalledWith({
+      method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+      params: [],
+    });
+
+    expect(mockTarget.request).toHaveBeenCalledWith({
+      method: RPC_METHODS.ETH_SENDTRANSACTION,
+      params: [{ to: '0xabcd', from: '0x1234567890abcdef' }],
+    });
+
+    expect(response).toBe('transactionHash');
+  });
+
+  it('should returns accounts if the method is in rpcWithAccountParam', async () => {
+    const accounts = ['0x1234567890abcdef'];
+    (mockTarget.request as jest.Mock).mockResolvedValueOnce(accounts); // For ETH_REQUESTACCOUNTS
+
+    const params = [{ method: 'someOtherMethod', params: ['param1'] }];
+    rpcWithAccountParam.push('someothermethod'); // Adding method to mock the list
+
+    const response = await handleConnectWithMethod({
+      target: mockTarget,
+      params,
+    });
+
+    expect(response).toBe(accounts);
+  });
+
+  it('should calls the rpc method directly if it is not in rpcWithAccountParam and does not require accounts', async () => {
+    const accounts = ['0x1234567890abcdef'];
+    (mockTarget.request as jest.Mock).mockResolvedValueOnce(accounts); // For ETH_REQUESTACCOUNTS
+    (mockTarget.request as jest.Mock).mockResolvedValueOnce('rpcResponse'); // For other RPC methods
+
+    const params = [{ method: 'someRpcMethod', params: ['param1'] }];
+
+    const response = await handleConnectWithMethod({
+      target: mockTarget,
+      params,
+    });
+
+    expect(mockTarget.request).toHaveBeenCalledWith({
+      method: 'someRpcMethod',
+      params: ['param1'],
+    });
+
+    expect(response).toBe('rpcResponse');
+  });
+
+  it('should throws an error if no accounts are returned', async () => {
+    (mockTarget.request as jest.Mock).mockResolvedValueOnce([]); // For ETH_REQUESTACCOUNTS
+
+    const params = [{ method: RPC_METHODS.PERSONAL_SIGN, params: ['message'] }];
+
+    await expect(
+      handleConnectWithMethod({
+        target: mockTarget,
+        params,
+      }),
+    ).rejects.toThrow('SDK state invalid -- undefined accounts');
+  });
+
+  it('should throws an error if the accounts array is undefined', async () => {
+    (mockTarget.request as jest.Mock).mockResolvedValueOnce([]); // For ETH_REQUESTACCOUNTS
+
+    const params = [{ method: RPC_METHODS.PERSONAL_SIGN, params: ['message'] }];
+
+    await expect(
+      handleConnectWithMethod({
+        target: mockTarget,
+        params,
+      }),
+    ).rejects.toThrow('SDK state invalid -- undefined accounts');
+  });
+});

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleConnectWithMethod.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleConnectWithMethod.ts
@@ -1,0 +1,51 @@
+import { MetaMaskInpageProvider } from '@metamask/providers';
+import { RPC_METHODS, rpcWithAccountParam } from '../../config';
+
+export const handleConnectWithMethod = async ({
+  target,
+  params,
+}: {
+  target: MetaMaskInpageProvider;
+  params: any[];
+}) => {
+  const [rpc] = params;
+  const currentRpcMethod = rpc.method;
+  const currentRpcParams = rpc.params;
+  const accounts = (await target.request({
+    method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+    params: [],
+  })) as string[];
+
+  if (!accounts.length) {
+    throw new Error('SDK state invalid -- undefined accounts');
+  }
+
+  if (
+    currentRpcMethod?.toLowerCase() === RPC_METHODS.PERSONAL_SIGN.toLowerCase()
+  ) {
+    return await target.request({
+      method: currentRpcMethod,
+      params: [currentRpcParams[0], accounts[0]],
+    });
+  } else if (
+    currentRpcMethod?.toLowerCase() ===
+    RPC_METHODS.ETH_SENDTRANSACTION.toLowerCase()
+  ) {
+    return await target.request({
+      method: currentRpcMethod,
+      params: [{ ...currentRpcParams[0], from: accounts[0] }],
+    });
+  }
+
+  if (rpcWithAccountParam.includes(currentRpcMethod.toLowerCase())) {
+    console.warn(
+      `MetaMaskSDK connectWith method=${currentRpcMethod} -- not handled by the extension -- call separately`,
+    );
+    return accounts;
+  }
+
+  return await target.request({
+    method: currentRpcMethod,
+    params: currentRpcParams,
+  });
+};

--- a/packages/sdk/src/provider/wrapExtensionProvider.ts
+++ b/packages/sdk/src/provider/wrapExtensionProvider.ts
@@ -1,6 +1,6 @@
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { TrackingEvents } from '@metamask/sdk-communication-layer';
-import { lcAnalyticsRPCs, RPC_METHODS } from '../config';
+import { lcAnalyticsRPCs, RPC_METHODS, rpcWithAccountParam } from '../config';
 import { MetaMaskSDK } from '../sdk';
 import { logger } from '../utils/logger';
 
@@ -16,11 +16,95 @@ export const wrapExtensionProvider = ({
   provider: MetaMaskInpageProvider;
   sdkInstance: MetaMaskSDK;
 }) => {
-  // prevent double wrapping an invalid provider (it could happen with older web3onboard implementions)
-  // TODO remove after web3onboard is updated
   if ('state' in provider) {
-    throw new Error(`INVALID EXTENSION PROVIDER`);
+    throw new Error('INVALID EXTENSION PROVIDER');
   }
+
+  const handleBatchMethod = async (
+    params: any[],
+    target: any,
+    args: RequestArguments,
+    trackEvent: boolean,
+  ) => {
+    // params is a list of RPCs to call
+    const responses = [];
+    for (const rpc of params) {
+      const response = await provider?.request({
+        method: rpc.method,
+        params: rpc.params,
+      });
+      responses.push(response);
+    }
+
+    const resp = await target.request(args);
+    if (trackEvent) {
+      sdkInstance.analytics?.send({
+        event: TrackingEvents.SDK_RPC_REQUEST_DONE,
+        params: { method: args.method, from: 'extension' },
+      });
+    }
+    return resp;
+  };
+
+  const handleConnectSignMethod = async (target: any, params: any[]) => {
+    const accounts = (await target.request({
+      method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+      params: [],
+    })) as string[];
+
+    if (!accounts.length) {
+      throw new Error('SDK state invalid -- undefined accounts');
+    }
+
+    return await target.request({
+      method: RPC_METHODS.PERSONAL_SIGN,
+      params: [params[0], accounts[0]],
+    });
+  };
+
+  const handleConnectWithMethod = async (target: any, params: any[]) => {
+    const [rpc] = params;
+    const currentRpcMethod = rpc.method;
+    const currentRpcParams = rpc.params;
+    const accounts = (await target.request({
+      method: RPC_METHODS.ETH_REQUESTACCOUNTS,
+      params: [],
+    })) as string[];
+
+    if (!accounts.length) {
+      throw new Error('SDK state invalid -- undefined accounts');
+    }
+
+    if (
+      currentRpcMethod?.toLowerCase() ===
+      RPC_METHODS.PERSONAL_SIGN.toLowerCase()
+    ) {
+      return await target.request({
+        method: currentRpcMethod,
+        params: [currentRpcParams[0], accounts[0]],
+      });
+    } else if (
+      currentRpcMethod?.toLowerCase() ===
+      RPC_METHODS.ETH_SENDTRANSACTION.toLowerCase()
+    ) {
+      return await target.request({
+        method: currentRpcMethod,
+        params: [{ ...currentRpcParams[0], from: accounts[0] }],
+      });
+    }
+
+    if (rpcWithAccountParam.includes(currentRpcMethod.toLowerCase())) {
+      console.warn(
+        `MetaMaskSDK connectWith method=${currentRpcMethod} -- not handled by the extension -- call separately`,
+      );
+      return accounts;
+    }
+
+    return await target.request({
+      method: currentRpcMethod,
+      params: currentRpcParams,
+    });
+  };
 
   return new Proxy(provider, {
     get(target, propKey) {
@@ -29,8 +113,8 @@ export const wrapExtensionProvider = ({
           logger(`[wrapExtensionProvider()] Overwriting request method`, args);
 
           const { method, params } = args;
-
           const trackEvent = lcAnalyticsRPCs.includes(method.toLowerCase());
+
           if (trackEvent) {
             sdkInstance.analytics?.send({
               event: TrackingEvents.SDK_RPC_REQUEST,
@@ -38,26 +122,24 @@ export const wrapExtensionProvider = ({
             });
           }
 
-          // special method handling
           if (method === RPC_METHODS.METAMASK_BATCH && Array.isArray(params)) {
-            // params is a list of RPCs to call
-            const responses = [];
-            for (const rpc of params) {
-              const response = await provider?.request({
-                method: rpc.method,
-                params: rpc.params,
-              });
-              responses.push(response);
-            }
+            return handleBatchMethod(params, target, args, trackEvent);
+          }
 
-            const resp = await target.request(args);
-            if (trackEvent) {
-              sdkInstance.analytics?.send({
-                event: TrackingEvents.SDK_RPC_REQUEST_DONE,
-                params: { method, from: 'extension' },
-              });
-            }
-            return resp;
+          if (
+            method.toLowerCase() ===
+              RPC_METHODS.METAMASK_CONNECTSIGN.toLowerCase() &&
+            Array.isArray(params)
+          ) {
+            return handleConnectSignMethod(target, params);
+          }
+
+          if (
+            method.toLowerCase() ===
+              RPC_METHODS.METAMASK_CONNECTWITH.toLowerCase() &&
+            Array.isArray(params)
+          ) {
+            return handleConnectWithMethod(target, params);
           }
 
           let resp;
@@ -77,24 +159,16 @@ export const wrapExtensionProvider = ({
           return resp;
         };
       } else if (propKey === 'getChainId') {
-        return function () {
-          return provider.chainId;
-        };
+        return () => provider.chainId;
       } else if (propKey === 'getNetworkVersion') {
-        return function () {
-          return provider.networkVersion;
-        };
+        return () => provider.networkVersion;
       } else if (propKey === 'getSelectedAddress') {
-        return function () {
-          return provider.selectedAddress;
-        };
+        return () => provider.selectedAddress;
       } else if (propKey === 'isConnected') {
-        return function () {
-          // TODO: allowed because of issue on inpavge provider
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          return provider._state.isConnected;
-        };
+        // TODO: allowed because of issue on inpavge provider
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return () => provider._state.isConnected;
       }
 
       return target[propKey as keyof MetaMaskInpageProvider];

--- a/packages/sdk/src/provider/wrapExtensionProvider.ts
+++ b/packages/sdk/src/provider/wrapExtensionProvider.ts
@@ -159,16 +159,24 @@ export const wrapExtensionProvider = ({
           return resp;
         };
       } else if (propKey === 'getChainId') {
-        return () => provider.chainId;
+        return function () {
+          return provider.chainId;
+        };
       } else if (propKey === 'getNetworkVersion') {
-        return () => provider.networkVersion;
+        return function () {
+          return provider.networkVersion;
+        };
       } else if (propKey === 'getSelectedAddress') {
-        return () => provider.selectedAddress;
+        return function () {
+          return provider.selectedAddress;
+        };
       } else if (propKey === 'isConnected') {
-        // TODO: allowed because of issue on inpavge provider
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        return () => provider._state.isConnected;
+        return function () {
+          // TODO: allowed because of issue on inpavge provider
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          return provider._state.isConnected;
+        };
       }
 
       return target[propKey as keyof MetaMaskInpageProvider];


### PR DESCRIPTION
## Explanation

Fixed the `connectAndSign` method error when using MetaMask SDK. Updated `wrapExtensionProvider` to handle `metamask_connectSign` method correctly, ensuring smooth connection and flow.

What We Did:
- Updated `wrapExtensionProvider` to handle `metamask_connectSign` method.
- Enhanced logic for `request` method wrapper to make sure other special methods work well with the extension.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->


https://github.com/MetaMask/metamask-sdk/assets/61094771/9e2044a4-5d28-4d59-816a-5aaf7fdbed44





## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes [#12345](https://github.com/MetaMask/metamask-sdk/issues/793)
* Related to #67890
-->

* Fixes [#12345](https://github.com/MetaMask/metamask-sdk/issues/793)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
