### PR TITLE
chore: removes the 'defaultReadOnlyChainId' option from the SDK options

### DIFF
--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -39,12 +39,6 @@ export interface MetaMaskSDKOptions {
   infuraAPIKey?: string;
 
   /**
-   * Allow sending read-only rpc calls before the user has connected to the wallet.
-   * The value will be automatically updated to the wallet chainId once connected.
-   */
-  defaultReadOnlyChainId?: number | `0x${string}`;
-
-  /**
    * A map of RPC URLs to use for read-only requests.
    */
   readonlyRPCMap?: RPC_URLS_MAP;
@@ -197,8 +191,6 @@ export class MetaMaskSDK extends EventEmitter2 {
 
   private readonlyRPCCalls = false;
 
-  public defaultReadOnlyChainId = `0x1`;
-
   public i18nInstance: i18n = createInstance();
 
   public availableLanguages: string[] = ['en'];
@@ -247,20 +239,6 @@ export class MetaMaskSDK extends EventEmitter2 {
           `You must provide dAppMetadata option (name and/or url)`,
         );
       }
-    }
-
-    if (options.defaultReadOnlyChainId) {
-      if (typeof options.defaultReadOnlyChainId === 'number') {
-        this.defaultReadOnlyChainId = `0x${options.defaultReadOnlyChainId.toString(
-          16,
-        )}`; // convert to hex string
-      } else if (
-        typeof options.defaultReadOnlyChainId === 'string' &&
-        !options.defaultReadOnlyChainId.startsWith('0x')
-      ) {
-        throw new Error(`Invalid defaultReadOnlyChainId, must start with '0x'`);
-      }
-      this.defaultReadOnlyChainId = options.defaultReadOnlyChainId.toString();
     }
 
     this.options = options;


### PR DESCRIPTION
## Explanation
This PR removes the `defaultReadOnlyChainId` option from the SDK options configuration. 
This option is not utilized anywhere in the codebase, so its presence is unnecessary.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
