### PR TITLE
 chore: update peerDependencies of ‘@metamask/sdk-install-modal-web’ to resolve installation warnings

### DIFF
--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -85,7 +85,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "i18next": "23.2.3",
+    "i18next": "23.11.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8936,7 +8936,7 @@ __metadata:
     size-limit: ^11.0.2
     typescript: ^5.0.2
   peerDependencies:
-    i18next: 23.2.3
+    i18next: 23.11.5
     react: ^18.2.0
     react-dom: ^18.2.0
     react-native: "*"


### PR DESCRIPTION
## Explanation

This update addresses the peer dependency warning by updating the `peerDependencies` of the `@metamask/sdk-install-modal-web` package. 

The warning indicated an unmet peer dependency for i18next. 
The following changes have been made:
	•	Updated `i18next` peer dependency to version `23.11.5` to match the version found in `@metamask/sdk`

That's the warning:
<img width="621" alt="Screenshot 2024-06-28 at 17 17 03" src="https://github.com/MetaMask/metamask-sdk/assets/61094771/bc495dc0-024a-4aef-92d2-b034a82a853b">

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
