### PR TITLE
fix(docs): correct start command in NodeJs example README

### DIFF
--- a/packages/examples/nodejs/README.md
+++ b/packages/examples/nodejs/README.md
@@ -9,5 +9,5 @@ yarn install
 and
 
 ```bash
-yarn start
+yarn start:connect
 ```


### PR DESCRIPTION
## Explanation

Update the README to reflect the correct start command for the NodeJs example. Changed `yarn run start` to `yarn run start:connect`.