### PR TITLE
docs: add instructions for serving index.html with local HTTP server

### DIFF
--- a/packages/examples/pure-javascript/README.md
+++ b/packages/examples/pure-javascript/README.md
@@ -1,1 +1,10 @@
 # Pure JavaScript SDK example
+  **You must use a local HTTP server to serve index.html. Don't opening index.html with browser directly, the Metamast sdk will fail to detect Metamask extension**
+  
+  Here are the steps to run with node [http-server](https://github.com/http-party/http-server).
+  1. install nodejs
+  2. start http-server 
+     ```bash
+     npx http-server
+     ```
+  3. visit your pure javascript demo in your browser, the default url is `http://127.0.0.1:8081`


### PR DESCRIPTION
## Explanation
Update the README to include steps for using a local HTTP server to serve  index.html, as opening the file directly in the browser causes the Metamask  SDK to fail to detect the MetaMask extension.

Added:
- Explanation about the need for a local HTTP server.
- Steps to run the example using node http-server.

## References

Fixes #916
