### PR TITLE
Release 75.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "74.0.0",
+  "version": "75.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.5]
+### Added
+- chore: update peerDependencies of ‘@metamask/sdk-install-modal-web’ to resolve installation warnings ([#927](https://github.com/MetaMask/metamask-sdk/pull/927))
+
 ## [0.26.4]
 ### Added
 - chore: update SDK dependencies to resolve version conflicts ([#921](https://github.com/MetaMask/metamask-sdk/pull/921))
@@ -136,7 +140,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub actions workflows ([#102](https://github.com/MetaMask/metamask-sdk/pull/102))
 - [FEAT] Yarn v3 migration ([#100](https://github.com/MetaMask/metamask-sdk/pull/100))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.26.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.26.5...HEAD
+[0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.26.4...@metamask/sdk-install-modal-web@0.26.5
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.26.0...@metamask/sdk-install-modal-web@0.26.4
 [0.26.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.20.4...@metamask/sdk-install-modal-web@0.26.0
 [0.20.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.20.2...@metamask/sdk-install-modal-web@0.20.4

--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-install-modal-web",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "MetaMask SDK Install Modal for Web",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react-native/CHANGELOG.md
+++ b/packages/sdk-react-native/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2]
+### Added
+- chore: update the 'reactNativeSdkDemo' example to 'sdk-react-native' version 0.3.1 ([#936](https://github.com/MetaMask/metamask-sdk/pull/936))
+- chore: update the 'sdk-react-native' package native modules versions ([#935](https://github.com/MetaMask/metamask-sdk/pull/935))
+- feat: add script to align version before publishing ([#902](https://github.com/MetaMask/metamask-sdk/pull/902))
+
 ## [0.3.1]
 ### Uncategorized
 - chore: update reactNativeSdkDemo with latest sdk-react-native version ([#872](https://github.com/MetaMask/metamask-sdk.git/pull/872))
@@ -22,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.2...HEAD
+[0.3.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.1...@metamask/sdk-react-native@0.3.2
 [0.3.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.0...@metamask/sdk-react-native@0.3.1
 [0.3.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.2.0...@metamask/sdk-react-native@0.3.0
 [0.2.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-react-native@0.2.0

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/sdk-react-native",
   "title": "MetaMask - ReactNative SDK",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "MetaMask SDK for React Native applications, enabling seamless integration with MetaMask for blockchain interactions.",
   "module": "dist/esm/index.js",
   "types": "dist/esm/src/index.d.ts",

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.5]
+### Added
+- chore: update the '@metamask/providers' package to version '16.1.0'
+- chore: update the 'babel' packages ([#939](https://github.com/MetaMask/metamask-sdk/pull/939))
+
 ## [0.26.4]
 ### Added
 - chore: removes the 'defaultReadOnlyChainId' option from the SDK options ([#919](https://github.com/MetaMask/metamask-sdk/pull/919))
@@ -166,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.5...HEAD
+[0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.4...@metamask/sdk-react-ui@0.26.5
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.3...@metamask/sdk-react-ui@0.26.4
 [0.26.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.2...@metamask/sdk-react-ui@0.26.3
 [0.26.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.0...@metamask/sdk-react-ui@0.26.2

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.5]
+### Added
+- chore: update the '@metamask/providers' package to version '16.1.0'
+- chore: update the 'babel' packages ([#939](https://github.com/MetaMask/metamask-sdk/pull/939))
+
 ## [0.26.4]
 ### Added
 - chore: removes the 'defaultReadOnlyChainId' option from the SDK options ([#919](https://github.com/MetaMask/metamask-sdk/pull/919))
@@ -223,7 +228,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.5...HEAD
+[0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.4...@metamask/sdk-react@0.26.5
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.3...@metamask/sdk-react@0.26.4
 [0.26.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.2...@metamask/sdk-react@0.26.3
 [0.26.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.1...@metamask/sdk-react@0.26.2

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk",
   "bugs": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.5]
+### Added
+- chore: update the '@metamask/providers' package to version '16.1.0'
+
 ## [0.26.4]
 ### Added
 - chore: removes the 'defaultReadOnlyChainId' option from the SDK options ([#919](https://github.com/MetaMask/metamask-sdk/pull/919))
@@ -353,7 +357,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.5...HEAD
+[0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.4...@metamask/sdk@0.26.5
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.3...@metamask/sdk@0.26.4
 [0.26.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.2...@metamask/sdk@0.26.3
 [0.26.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.1...@metamask/sdk@0.26.2

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk [0.26.5]
### Added
- chore: update the '@metamask/providers' package to version '16.1.0'

## sdk-react [0.26.5]
### Added
- chore: update the '@metamask/providers' package to version '16.1.0'
- chore: update the 'babel' packages ([#939](https://github.com/MetaMask/metamask-sdk/pull/939))

## sdk-react-ui [0.26.5]
### Added
- chore: update the '@metamask/providers' package to version '16.1.0'
- chore: update the 'babel' packages ([#939](https://github.com/MetaMask/metamask-sdk/pull/939))

## sdk-react-native [0.3.2]
### Added
- chore: update the 'reactNativeSdkDemo' example to 'sdk-react-native' version 0.3.1 ([#936](https://github.com/MetaMask/metamask-sdk/pull/936))
- chore: update the 'sdk-react-native' package native modules versions ([#935](https://github.com/MetaMask/metamask-sdk/pull/935))
- feat: add script to align version before publishing ([#902](https://github.com/MetaMask/metamask-sdk/pull/902))

## sdk-install-modal-web [0.26.5]
### Added
- chore: update peerDependencies of ‘@metamask/sdk-install-modal-web’ to resolve installation warnings ([#927](https://github.com/MetaMask/metamask-sdk/pull/927))