### PR TITLE
chore: (sdk-react-native) ensure URL event listener is only added on iOS 

### DIFF
--- a/packages/sdk-react-native/src/NativePackageMethods.ts
+++ b/packages/sdk-react-native/src/NativePackageMethods.ts
@@ -1,4 +1,4 @@
-import { Linking, NativeModules } from 'react-native';
+import { Linking, NativeModules, Platform } from 'react-native';
 import { MetaMaskSDKOptions } from './MetaMaskProvider';
 
 const { MetaMaskReactNativeSdk } = NativeModules;
@@ -118,7 +118,9 @@ export function setupDeeplinkHandling() {
   };
 
   // Add event listener for URL events
-  Linking.addEventListener('url', handleOpenURL);
+  if (Platform.OS === 'ios') {
+    Linking.addEventListener('url', handleOpenURL);
+  }
 }
 
 /**


### PR DESCRIPTION
## Explanation
ensure URL event listener is only added on iOS in the `sdk-react-native` package
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
