### PR TITLE
fix: adds extensionOnly default to true to SDK initialization

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/initializeProviderAndEventListeners.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/initializeProviderAndEventListeners.ts
@@ -30,6 +30,7 @@ export async function initializeProviderAndEventListeners(
     checkInstallationOnAllCalls: options.checkInstallationOnAllCalls as boolean,
     injectProvider: options.injectProvider ?? true,
     shouldShimWeb3: options.shouldShimWeb3 ?? true,
+    extensionOnly: options.extensionOnly ?? true,
     installer: instance.installer as MetaMaskInstaller,
     remoteConnection: instance.remoteConnection,
     debug: instance.debug,

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.test.ts
@@ -61,6 +61,7 @@ describe('performSDKInitialization', () => {
       storage: {
         enabled: true,
       },
+      extensionOnly: true,
     });
 
     expect(setupPlatformManager).toHaveBeenCalledWith(instance);

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
@@ -57,6 +57,7 @@ export async function performSDKInitialization(instance: MetaMaskSDK) {
   options.enableAnalytics = options.enableAnalytics ?? true;
   options.injectProvider = options.injectProvider ?? true;
   options.shouldShimWeb3 = options.shouldShimWeb3 ?? true;
+  options.extensionOnly = options.extensionOnly ?? true;
   options.useDeeplink = options.useDeeplink ?? false;
   options.storage = options.storage ?? {
     enabled: true,


### PR DESCRIPTION
## Explanation
Fixes the extensionOnly default to true to SDK initialization.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
