### PR TITLE
Release 78.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "77.0.0",
+  "version": "78.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-communication-layer/CHANGELOG.md
+++ b/packages/sdk-communication-layer/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0]
+### Added
+- feat: adds `connector` analytical property ([#947](https://github.com/MetaMask/metamask-sdk/pull/947))
+
 ## [0.26.4]
 ### Added
 - chore: update SDK dependencies to resolve version conflicts ([#921](https://github.com/MetaMask/metamask-sdk/pull/921))
@@ -231,7 +235,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT]: improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.26.4...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.27.0...HEAD
+[0.27.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.26.4...@metamask/sdk-communication-layer@0.27.0
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.26.2...@metamask/sdk-communication-layer@0.26.4
 [0.26.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.26.0...@metamask/sdk-communication-layer@0.26.2
 [0.26.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-communication-layer@0.20.5...@metamask/sdk-communication-layer@0.26.0

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.26.4",
+  "version": "0.27.0",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0]
+### Added
+- fix: adds extensionOnly default to true to SDK initialization ([#962](https://github.com/MetaMask/metamask-sdk/pull/962))
+- feat: sets extensionOnly default to true ([#956](https://github.com/MetaMask/metamask-sdk/pull/956))
+- chore: bump .change files ([#957](https://github.com/MetaMask/metamask-sdk/pull/957))
+- feat: improve open deeplink on IOS Chrome ([#948](https://github.com/MetaMask/metamask-sdk/pull/948))
+
 ## [0.26.5]
 ### Added
 - chore: update the '@metamask/providers' package to version '16.1.0'
@@ -171,7 +178,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.5...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.27.0...HEAD
+[0.27.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.5...@metamask/sdk-react-ui@0.27.0
 [0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.4...@metamask/sdk-react-ui@0.26.5
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.3...@metamask/sdk-react-ui@0.26.4
 [0.26.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.2...@metamask/sdk-react-ui@0.26.3

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0]
+### Added
+- fix: adds extensionOnly default to true to SDK initialization ([#962](https://github.com/MetaMask/metamask-sdk/pull/962))
+- feat: sets extensionOnly default to true ([#956](https://github.com/MetaMask/metamask-sdk/pull/956))
+- chore: bump .change files ([#957](https://github.com/MetaMask/metamask-sdk/pull/957))
+- feat: improve open deeplink on IOS Chrome ([#948](https://github.com/MetaMask/metamask-sdk/pull/948))
+
 ## [0.26.5]
 ### Added
 - chore: update the '@metamask/providers' package to version '16.1.0'
@@ -228,7 +235,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.5...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.27.0...HEAD
+[0.27.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.5...@metamask/sdk-react@0.27.0
 [0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.4...@metamask/sdk-react@0.26.5
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.3...@metamask/sdk-react@0.26.4
 [0.26.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.26.2...@metamask/sdk-react@0.26.3

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk",
   "bugs": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0]
+### Added
+- fix: adds extensionOnly default to true to SDK initialization ([#962](https://github.com/MetaMask/metamask-sdk/pull/962))
+- feat: sets extensionOnly default to true ([#956](https://github.com/MetaMask/metamask-sdk/pull/956))
+- chore: bump .change files ([#957](https://github.com/MetaMask/metamask-sdk/pull/957))
+- feat: improve open deeplink on IOS Chrome ([#948](https://github.com/MetaMask/metamask-sdk/pull/948))
+
 ## [0.26.5]
 ### Added
 - chore: update the '@metamask/providers' package to version '16.1.0'
@@ -357,7 +364,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.5...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.27.0...HEAD
+[0.27.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.5...@metamask/sdk@0.27.0
 [0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.4...@metamask/sdk@0.26.5
 [0.26.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.3...@metamask/sdk@0.26.4
 [0.26.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.26.2...@metamask/sdk@0.26.3

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk-communication-layer [0.27.0]
### Added
- feat: adds `connector` analytical property ([#947](https://github.com/MetaMask/metamask-sdk/pull/947))

## sdk [0.27.0]
### Added
- fix: adds extensionOnly default to true to SDK initialization ([#962](https://github.com/MetaMask/metamask-sdk/pull/962))
- feat: sets extensionOnly default to true ([#956](https://github.com/MetaMask/metamask-sdk/pull/956))
- chore: bump .change files ([#957](https://github.com/MetaMask/metamask-sdk/pull/957))
- feat: improve open deeplink on IOS Chrome ([#948](https://github.com/MetaMask/metamask-sdk/pull/948))

## sdk-react [0.27.0]
### Added
- fix: adds extensionOnly default to true to SDK initialization ([#962](https://github.com/MetaMask/metamask-sdk/pull/962))
- feat: sets extensionOnly default to true ([#956](https://github.com/MetaMask/metamask-sdk/pull/956))
- chore: bump .change files ([#957](https://github.com/MetaMask/metamask-sdk/pull/957))
- feat: improve open deeplink on IOS Chrome ([#948](https://github.com/MetaMask/metamask-sdk/pull/948))

## sdk-react-ui [0.27.0]
### Added
- fix: adds extensionOnly default to true to SDK initialization ([#962](https://github.com/MetaMask/metamask-sdk/pull/962))
- feat: sets extensionOnly default to true ([#956](https://github.com/MetaMask/metamask-sdk/pull/956))
- chore: bump .change files ([#957](https://github.com/MetaMask/metamask-sdk/pull/957))
- feat: improve open deeplink on IOS Chrome ([#948](https://github.com/MetaMask/metamask-sdk/pull/948))