### PR TITLE
fix: emit `connect` event after the initialization 

### DIFF
--- a/packages/sdk/src/provider/SDKProvider.ts
+++ b/packages/sdk/src/provider/SDKProvider.ts
@@ -141,6 +141,10 @@ export class SDKProvider extends MetaMaskInpageProvider {
     chainId,
     networkVersion,
   }: { chainId?: string; networkVersion?: string } = {}) {
+    if (this.getState().accounts === null || this.getState().accounts?.length === 0) {
+      return;
+    }
+
     this.state.chainId = chainId as string;
     this.state.networkVersion = networkVersion as string;
 

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -84,7 +84,7 @@ export async function write(
       `channelId=${channelId}&pubkey=${pubKey}&comm=socket&t=d&v=2`,
     );
 
-    if (METHODS_TO_REDIRECT[targetMethod]) {
+    if (METHODS_TO_REDIRECT[targetMethod] && RPC_METHODS.ETH_ACCOUNTS.toLowerCase() !== targetMethod.toLowerCase()) {
       logger(
         `[RCPMS: _write()] redirect link for '${targetMethod}' socketConnected=${socketConnected} connect?${urlParams}`,
       );

--- a/packages/sdk/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts
+++ b/packages/sdk/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts
@@ -126,7 +126,8 @@ export async function initializeStateAsync(instance: SDKProvider) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       instance._state.isConnected = true;
-      instance.emit('connect', { chainId: initialState?.chainId });
     }
+
+    instance.emit('connect', { chainId: initialState?.chainId });
   }
 }


### PR DESCRIPTION
Issue 1: Async state accounts and `connect` event
  Dessription:
    - Why we have a redirect deeplink after we come back to the application
      - When the user select its account, during the state initialization, an event "connect" is emit before the accounts are saved in the state
        - So when the wagmi connector receive this event, it try to get account ([here](https://github.com/wevm/wagmi/blob/bf3a3aa3de2307cc4b003ae9fd360f314f7ef9e6/packages/connectors/src/metaMask.ts#L327))
          - But in the request function, as the account is not cached or in the state, it will do a regular request ([here](https://github.com/EdouardBougon/metamask-sdk/blob/ab022b40566da4b137517f2203fca4a68135f168/packages/sdk/src/provider/initializeMobileProvider.ts#L187))
            - And finally, in the write function, as `eth_accounts` is a "method to redirect", it will redirect to metamask ([here](https://github.com/EdouardBougon/metamask-sdk/blob/ab022b40566da4b137517f2203fca4a68135f168/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts#L87))


  Solution:
    - In the function `SDKProvider._handleChainChanged` test if the account are saved before emiting the 'connect' event. ([here](https://github.com/EdouardBougon/metamask-sdk/blob/ab022b40566da4b137517f2203fca4a68135f168/packages/sdk/src/provider/SDKProvider.ts#L140))
      - If not, do nothing
    - At the end of the function `initializeStateAsync` emit a `connect` event, not only when cach is enabled ([here](https://github.com/EdouardBougon/metamask-sdk/blob/ab022b40566da4b137517f2203fca4a68135f168/packages/sdk/src/services/SDKProvider/InitializationManager/initializeStateAsync.ts#L129))
    - In the write function, exlude `eth_accounts` from the redirect ([here](https://github.com/EdouardBougon/metamask-sdk/blob/ab022b40566da4b137517f2203fca4a68135f168/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts#L87))
    - In the wagmi provider, in `onConnect` throw an error if not account selected, instead of just return
      - We shouldn't have this case anymore
      - (The wagmi `connect` event type require the chainId and the account information)
      

See Wagmi PR: https://github.com/EdouardBougon/wagmi/pull/1