### PR TITLE
chore: filter metamask urls

### DIFF
--- a/packages/sdk-react-native/src/NativePackageMethods.ts
+++ b/packages/sdk-react-native/src/NativePackageMethods.ts
@@ -114,8 +114,12 @@ export const terminate = async (): Promise<void> => {
 export function setupDeeplinkHandling() {
   if (Platform.OS === 'ios') {
     const handleOpenURL = (event: any) => {
-      // Handle the URL event here
-      MetaMaskReactNativeSdk.handleDeepLink(event.url);
+      const url = new URL(event.url);
+      // Only listen for metamask urls
+      if (url.host === 'mmsdk') {
+        // Handle the URL event here
+        MetaMaskReactNativeSdk.handleDeepLink(event.url);
+      }
     };
 
     // Add event listener for URL events


### PR DESCRIPTION
## Explanation
This PR filters the urls that are handled by the sdk to only those with host `mmsdk`. All deeplink communication from the wallet to the dapp is done via deeplinks with this host. Currently, the sdk attempts to handle all deeplinks with the dapp scheme, including those not from metamask. Deeplink format: `${dappScheme}://mmsdk?message=${base64Message}`
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
