### PR TITLE
chore: update react native example dapp to latest sdk version

### DIFF
--- a/packages/examples/reactNativeSdkDemo/ios/Podfile.lock
+++ b/packages/examples/reactNativeSdkDemo/ios/Podfile.lock
@@ -15,11 +15,11 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.5)
   - hermes-engine/Pre-built (0.72.5)
   - libevent (2.1.12)
-  - metamask-ios-sdk (0.8.1):
+  - metamask-ios-sdk (0.8.4):
     - Socket.IO-Client-Swift (~> 16.1.0)
     - Starscream (= 4.0.6)
-  - metamask-sdk-react-native (0.3.5):
-    - metamask-ios-sdk (~> 0.8.0)
+  - metamask-sdk-react-native (0.3.7):
+    - metamask-ios-sdk (~> 0.8.4)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - RCT-Folly (2021.07.22.00):
@@ -644,8 +644,8 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: f6cf92a471053245614d9d8097736f6337d5b86c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  metamask-ios-sdk: e9b1494f82232ffa8f8122a382ea94cf08a5dec3
-  metamask-sdk-react-native: 3df372e523eb6091c39b2dbb09babc3db6e94cb1
+  metamask-ios-sdk: eb147a8b4003f6fce54bd98aae4511e695e9d090
+  metamask-sdk-react-native: 39f6adb410d7750fb2d76fa1a94376fe36e38f52
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: df81ab637d35fac9e6eb94611cfd20f0feb05455
   RCTTypeSafety: 4636e4a36c7c2df332bda6d59b19b41c443d4287

--- a/packages/examples/reactNativeSdkDemo/package.json
+++ b/packages/examples/reactNativeSdkDemo/package.json
@@ -13,7 +13,7 @@
     "allow-scripts": ""
   },
   "dependencies": {
-    "@metamask/sdk-react-native": "^0.3.5",
+    "@metamask/sdk-react-native": "^0.3.7",
     "@react-native-async-storage/async-storage": "^1.19.3",
     "@react-navigation/bottom-tabs": "^6.5.11",
     "@react-navigation/native": "^6.1.9",

--- a/packages/examples/reactNativeSdkDemo/yarn.lock
+++ b/packages/examples/reactNativeSdkDemo/yarn.lock
@@ -2499,9 +2499,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/sdk-react-native@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "@metamask/sdk-react-native@npm:0.3.5"
+"@metamask/sdk-react-native@npm:^0.3.7":
+  version: 0.3.7
+  resolution: "@metamask/sdk-react-native@npm:0.3.7"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -2515,7 +2515,7 @@ __metadata:
       optional: false
     react-native:
       optional: true
-  checksum: 41f2b631f7ceb339a874fea6f53e3a1156b85954ae42eb084ab5a27b63be0ad7dc626e66ef9322cc5856b7b381b90dc3da6980270df11b3efdfb4d9ee5c1b01b
+  checksum: a5a6c943f7209ac2540b9ff4e9048530c9bcd9e6865cc21301712b6c29203d2185f1883f2eadcf235ba3276e73f20240e3297d95613340006a87bfcff3736ceb
   languageName: node
   linkType: hard
 
@@ -10332,7 +10332,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
-    "@metamask/sdk-react-native": ^0.3.5
+    "@metamask/sdk-react-native": ^0.3.7
     "@react-native-async-storage/async-storage": ^1.19.3
     "@react-native-community/eslint-config": ^3.2.0
     "@react-native/eslint-config": ^0.72.2


### PR DESCRIPTION
Update the `reactNativeSdkDemo` example dapp to the latest sdk versions