### PR TITLE
Release 84.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "83.0.0",
+  "version": "84.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-react-native/CHANGELOG.md
+++ b/packages/sdk-react-native/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8]
+### Uncategorized
+- chore: improve the deeplink handling for MetaMask SDK on iOS ([#1002](https://github.com/MetaMask/metamask-sdk/pull/1002))
+
 ## [0.3.7]
 ### Uncategorized
 - chore: update native sdk versions ([#997](https://github.com/MetaMask/metamask-sdk/pull/997))
@@ -50,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.7...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.8...HEAD
+[0.3.8]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.7...@metamask/sdk-react-native@0.3.8
 [0.3.7]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.6...@metamask/sdk-react-native@0.3.7
 [0.3.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.5...@metamask/sdk-react-native@0.3.6
 [0.3.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.4...@metamask/sdk-react-native@0.3.5

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/sdk-react-native",
   "title": "MetaMask - ReactNative SDK",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "MetaMask SDK for React Native applications, enabling seamless integration with MetaMask for blockchain interactions.",
   "main": "dist/esm/index.js",
   "types": "dist/esm/src/index.d.ts",


### PR DESCRIPTION
## sdk-react-native [0.3.8]
### Added
- chore: improve the deeplink handling for MetaMask SDK on iOS ([#1002](https://github.com/MetaMask/metamask-sdk/pull/1002))