### PR TITLE
Release 88.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "87.0.0",
+  "version": "88.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-react-native/CHANGELOG.md
+++ b/packages/sdk-react-native/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9]
+### Uncategorized
+- chore: display the right 'rn-sdk' version in the wallet side ([#1015](https://github.com/MetaMask/metamask-sdk/pull/1015))
+- Release 85.0.0 ([#1006](https://github.com/MetaMask/metamask-sdk/pull/1006))
+
 ## [0.3.8]
 ### Uncategorized
 - chore: improve the deeplink handling for MetaMask SDK on iOS ([#1002](https://github.com/MetaMask/metamask-sdk/pull/1002))
@@ -54,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.8...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.9...HEAD
+[0.3.9]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.8...@metamask/sdk-react-native@0.3.9
 [0.3.8]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.7...@metamask/sdk-react-native@0.3.8
 [0.3.7]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.6...@metamask/sdk-react-native@0.3.7
 [0.3.6]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-native@0.3.5...@metamask/sdk-react-native@0.3.6

--- a/packages/sdk-react-native/android/build.gradle
+++ b/packages/sdk-react-native/android/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation("io.metamask.androidsdk:metamask-android-sdk:0.6.3")
+  implementation("io.metamask.androidsdk:metamask-android-sdk:0.6.4")
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 

--- a/packages/sdk-react-native/metamask-sdk-react-native.podspec
+++ b/packages/sdk-react-native/metamask-sdk-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'metamask-ios-sdk', '~> 0.8.5'
+  s.dependency 'metamask-ios-sdk', '~> 0.8.6'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/sdk-react-native/package.json
+++ b/packages/sdk-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/sdk-react-native",
   "title": "MetaMask - ReactNative SDK",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "MetaMask SDK for React Native applications, enabling seamless integration with MetaMask for blockchain interactions.",
   "main": "dist/esm/index.js",
   "types": "dist/esm/src/index.d.ts",


### PR DESCRIPTION
## [0.3.9] sdk-react-native
### Added
- chore: display the right 'rn-sdk' version in the wallet side ([#1015](https://github.com/MetaMask/metamask-sdk/pull/1015))