### PR TITLE
chore: update connect method to return accounts array

### DIFF
--- a/packages/examples/reactNativeSdkDemo/src/views/DappView.tsx
+++ b/packages/examples/reactNativeSdkDemo/src/views/DappView.tsx
@@ -53,7 +53,7 @@ export const DAPPView = (_props: DAPPViewProps) => {
     try {
       console.log('Calling Connect....');
 
-      const res = (await sdk?.connect()) as string;
+      const res = (await sdk?.connect()) as string[];
       console.log('account', res);
     } catch (e) {
       console.log('ERROR', e);

--- a/packages/sdk-react-native/android/build.gradle
+++ b/packages/sdk-react-native/android/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation("io.metamask.androidsdk:metamask-android-sdk:0.6.3")
+  implementation("io.metamask.androidsdk:metamask-android-sdk:0.6.6")
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 

--- a/packages/sdk-react-native/ios/MetaMaskReactNativeSdk.swift
+++ b/packages/sdk-react-native/ios/MetaMaskReactNativeSdk.swift
@@ -89,8 +89,8 @@ class MetaMaskReactNativeSdk: NSObject, RCTBridgeModule {
       let result = await metaMaskSDK?.connect()
 
       switch result {
-      case .success(let account):
-        resolve(account)
+      case .success(let accounts):
+        resolve(accounts)
         return
       case .failure(let error):
         reject("ERROR_CONNECT", error.localizedDescription, error)

--- a/packages/sdk-react-native/metamask-sdk-react-native.podspec
+++ b/packages/sdk-react-native/metamask-sdk-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'metamask-ios-sdk', '~> 0.8.5'
+  s.dependency 'metamask-ios-sdk', '~> 0.8.6'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/sdk-react-native/src/NativePackageMethods.ts
+++ b/packages/sdk-react-native/src/NativePackageMethods.ts
@@ -24,7 +24,7 @@ export interface RequestArguments {
  *
  * @returns A Promise that resolves when the connection is successful.
  */
-export const connect = async (): Promise<string> => {
+export const connect = async (): Promise<string[]> => {
   return MetaMaskReactNativeSdk.connect();
 };
 


### PR DESCRIPTION
## Explanation

This PR updates the connect method to return an array of accounts instead of the selected account to match it with other sdks. The PR also updates dapp demo to likewise 

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
