### PR TITLE
Release 91.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "90.0.0",
+  "version": "91.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-react-ui/CHANGELOG.md
+++ b/packages/sdk-react-ui/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.4]
+### Added
+- fix: update the `initializeMobileProvider` function to ensure it returns all connected accounts on mobile ([#1031](https://github.com/MetaMask/metamask-sdk/pull/1031))
+
 ## [0.28.1]
 ### Added
 - Release 85.0.0 ([#1006](https://github.com/MetaMask/metamask-sdk/pull/1006))
@@ -182,7 +186,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.28.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.28.4...HEAD
+[0.28.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.28.1...@metamask/sdk-react-ui@0.28.4
 [0.28.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.27.0...@metamask/sdk-react-ui@0.28.1
 [0.27.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.5...@metamask/sdk-react-ui@0.27.0
 [0.26.5]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react-ui@0.26.4...@metamask/sdk-react-ui@0.26.5

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react-ui",
-  "version": "0.28.1",
+  "version": "0.28.4",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.4]
+### Added
+- fix: update the `initializeMobileProvider` function to ensure it returns all connected accounts on mobile ([#1031](https://github.com/MetaMask/metamask-sdk/pull/1031))
+
 ## [0.28.3]
 ### Added
 - fix: invalid display_uri event emitted
@@ -251,7 +255,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.28.3...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.28.4...HEAD
+[0.28.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.28.3...@metamask/sdk-react@0.28.4
 [0.28.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.28.2...@metamask/sdk-react@0.28.3
 [0.28.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.28.1...@metamask/sdk-react@0.28.2
 [0.28.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.28.0...@metamask/sdk-react@0.28.1

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk",
   "bugs": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.4]
+### Added
+- fix: update the `initializeMobileProvider` function to ensure it returns all connected accounts on mobile ([#1031](https://github.com/MetaMask/metamask-sdk/pull/1031))
+
 ## [0.28.3]
 ### Added
 - fix: invalid display_uri event emitted
@@ -386,7 +390,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.28.3...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.28.4...HEAD
+[0.28.4]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.28.3...@metamask/sdk@0.28.4
 [0.28.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.28.2...@metamask/sdk@0.28.3
 [0.28.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.28.1...@metamask/sdk@0.28.2
 [0.28.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.28.0...@metamask/sdk@0.28.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk [0.28.4]
### Added
- fix: update the `initializeMobileProvider` function to ensure it returns all connected accounts on mobile ([#1031](https://github.com/MetaMask/metamask-sdk/pull/1031))

## sdk-react [0.28.4]
### Added
- fix: update the `initializeMobileProvider` function to ensure it returns all connected accounts on mobile ([#1031](https://github.com/MetaMask/metamask-sdk/pull/1031))

## sdk-react-ui [0.28.4]
### Added
- fix: update the `initializeMobileProvider` function to ensure it returns all connected accounts on mobile ([#1031](https://github.com/MetaMask/metamask-sdk/pull/1031))