### PR TITLE
chore: bump ios sdk version

### DIFF
--- a/packages/sdk-react-native/metamask-sdk-react-native.podspec
+++ b/packages/sdk-react-native/metamask-sdk-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'metamask-ios-sdk', '~> 0.8.7'
+  s.dependency 'metamask-ios-sdk', '~> 0.8.8'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Explanation
Bump ios sdk to version 0.8.8

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
