### PR TITLE
feat: default web url metadata

### DIFF
--- a/packages/sdk-communication-layer/src/Analytics.ts
+++ b/packages/sdk-communication-layer/src/Analytics.ts
@@ -7,7 +7,7 @@ import { logger } from './utils/logger';
 export interface AnalyticsProps {
   id: string;
   event: TrackingEvents;
-  originationInfo?: OriginatorInfo;
+  originatorInfo?: OriginatorInfo;
   commLayer?: CommunicationLayerPreference;
   sdkVersion?: string;
   commLayerVersion?: string;
@@ -46,8 +46,8 @@ async function sendBufferedEvents(parameters: AnalyticsProps) {
   swapBuffers();
 
   const serverUrl = targetUrl.endsWith('/')
-    ? `${targetUrl}debug`
-    : `${targetUrl}/debug`;
+    ? `${targetUrl}evt`
+    : `${targetUrl}/evt`;
 
   const flatParams: {
     [key: string]: unknown;

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -150,7 +150,7 @@ describe('MetaMaskSDK', () => {
 
     it('should throw error if dappMetadata is missing', () => {
       expect(() => new MetaMaskSDK({} as MetaMaskSDKOptions)).toThrow(
-        'You must provide dAppMetadata option (name and/or url)',
+        'You must provide dAppMetadata url',
       );
     });
 

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -228,17 +228,15 @@ export class MetaMaskSDK extends EventEmitter2 {
     logger(`[MetaMaskSDK: constructor()]: begin.`);
     this.setMaxListeners(50);
 
-    if (!options.dappMetadata?.name && !options.dappMetadata?.url) {
+    if (!options.dappMetadata?.url) {
       // Automatically set dappMetadata on web env.
       if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         options.dappMetadata = {
-          url: window.location.href,
-          name: document.title,
+          ...options.dappMetadata,
+          url: `${window.location.protocol}//${window.location.host}`,
         };
       } else {
-        throw new Error(
-          `You must provide dAppMetadata option (name and/or url)`,
-        );
+        throw new Error(`You must provide dAppMetadata url`);
       }
     }
 

--- a/packages/sdk/src/services/Analytics.ts
+++ b/packages/sdk/src/services/Analytics.ts
@@ -48,7 +48,7 @@ export class Analytics {
       id: ANALYTICS_CONSTANTS.DEFAULT_ID,
       event,
       sdkVersion: packageJson.version,
-      originationInfo: this.#originatorInfo,
+      ...this.#originatorInfo,
       params,
     };
     logger(`[Analytics: send()] event: ${event}`, props);

--- a/packages/sdk/src/services/Analytics.ts
+++ b/packages/sdk/src/services/Analytics.ts
@@ -17,7 +17,7 @@ export class Analytics {
 
   #enabled: boolean;
 
-  #originatorInfo: Readonly<AnalyticsProps['originationInfo']>;
+  #originatorInfo: Readonly<AnalyticsProps['originatorInfo']>;
 
   constructor({
     serverUrl,
@@ -25,7 +25,7 @@ export class Analytics {
     originatorInfo,
   }: {
     serverUrl: string;
-    originatorInfo: AnalyticsProps['originationInfo'];
+    originatorInfo: AnalyticsProps['originatorInfo'];
     enabled?: boolean;
   }) {
     this.#serverURL = serverUrl;


### PR DESCRIPTION
## Explanation

- Automatically set the dappMetadata on web. Previous behavior was to use the title if url not set.
- Align event format to spread originatorInfo data in the event

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
