### PR TITLE
feat: ping to retrieve pending messages from server

### DIFF
--- a/packages/sdk-communication-layer/src/services/SocketService/ConnectionManager/ping.test.ts
+++ b/packages/sdk-communication-layer/src/services/SocketService/ConnectionManager/ping.test.ts
@@ -1,7 +1,6 @@
 import { SocketService } from '../../../SocketService';
-import { logger } from '../../../utils/logger';
-import { EventType } from '../../../types/EventType';
 import { MessageType } from '../../../types/MessageType';
+import { logger } from '../../../utils/logger';
 import { ping } from './ping';
 
 describe('ping', () => {
@@ -11,7 +10,6 @@ describe('ping', () => {
   const mockSendMessage = jest.fn();
   const mockAreKeysExchanged = jest.fn();
   const mockStart = jest.fn();
-  const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,40 +44,23 @@ describe('ping', () => {
   it('should emit a PING message to the socket', async () => {
     await ping(instance);
 
-    expect(mockEmit).toHaveBeenCalledWith(EventType.MESSAGE, {
+    expect(mockEmit).toHaveBeenCalledWith(MessageType.PING, {
       id: 'sampleChannelId',
-      context: 'someContext',
+      context: 'ping',
       clientType: 'wallet',
-      message: {
-        type: MessageType.PING,
-      },
+      message: '',
     });
   });
 
-  it('should send a READY message if originator and keys are exchanged', async () => {
-    instance.state.isOriginator = true;
-    mockAreKeysExchanged.mockReturnValue(true);
-
+  it('should use correct clientType based on remote.state.isOriginator', async () => {
+    instance.remote.state.isOriginator = true;
     await ping(instance);
 
-    expect(spyWarn).toHaveBeenCalledWith(
-      '[SocketService:ping()] context=someContext sending READY message',
-    );
-    expect(mockSendMessage).toHaveBeenCalledWith({ type: MessageType.READY });
-  });
-
-  it('should start key exchange if originator and keys are not exchanged', async () => {
-    instance.state.isOriginator = true;
-    mockAreKeysExchanged.mockReturnValue(false);
-
-    await ping(instance);
-
-    expect(spyWarn).toHaveBeenCalledWith(
-      '[SocketService: ping()] context=someContext starting key exchange',
-    );
-
-    expect(mockStart).toHaveBeenCalledWith({
-      isOriginator: true,
+    expect(mockEmit).toHaveBeenCalledWith(MessageType.PING, {
+      id: 'sampleChannelId',
+      context: 'ping',
+      clientType: 'dapp',
+      message: '',
     });
   });
 
@@ -92,13 +73,11 @@ describe('ping', () => {
       '[SocketService: ping()] context=someContext originator=false keysExchanged=undefined',
     );
 
-    expect(mockEmit).toHaveBeenCalledWith(EventType.MESSAGE, {
+    expect(mockEmit).toHaveBeenCalledWith(MessageType.PING, {
       id: 'sampleChannelId',
-      context: 'someContext',
+      context: 'ping',
       clientType: 'wallet',
-      message: {
-        type: MessageType.PING,
-      },
+      message: '',
     });
   });
 });

--- a/packages/sdk-communication-layer/src/services/SocketService/ConnectionManager/ping.ts
+++ b/packages/sdk-communication-layer/src/services/SocketService/ConnectionManager/ping.ts
@@ -1,7 +1,6 @@
-import { logger } from '../../../utils/logger';
 import { SocketService } from '../../../SocketService';
-import { EventType } from '../../../types/EventType';
 import { MessageType } from '../../../types/MessageType';
+import { logger } from '../../../utils/logger';
 
 /**
  * Sends a PING message using a SocketService instance.
@@ -19,30 +18,10 @@ export async function ping(instance: SocketService) {
     } keysExchanged=${instance.state.keyExchange?.areKeysExchanged()}`,
   );
 
-  if (instance.state.isOriginator) {
-    if (instance.state.keyExchange?.areKeysExchanged()) {
-      console.warn(
-        `[SocketService:ping()] context=${instance.state.context} sending READY message`,
-      );
-
-      await instance.sendMessage({ type: MessageType.READY });
-    } else {
-      console.warn(
-        `[SocketService: ping()] context=${instance.state.context} starting key exchange`,
-      );
-
-      instance.state.keyExchange?.start({
-        isOriginator: instance.state.isOriginator ?? false,
-      });
-    }
-  }
-
-  instance.state.socket?.emit(EventType.MESSAGE, {
+  instance.state.socket?.emit(MessageType.PING, {
     id: instance.state.channelId,
-    context: instance.state.context,
+    context: 'ping',
     clientType: instance.remote.state.isOriginator ? 'dapp' : 'wallet',
-    message: {
-      type: MessageType.PING,
-    },
+    message: '',
   });
 }


### PR DESCRIPTION
## Explanation

Change the ping method on communication layer to query server for pending messages.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
