### PR TITLE
fix: connectWith potnetially returning incorrect response

### DIFF
--- a/packages/sdk-socket-server-next/src/analytics-api.ts
+++ b/packages/sdk-socket-server-next/src/analytics-api.ts
@@ -243,6 +243,10 @@ app.post('/evt', async (_req, res) => {
 
     if (!userIdHash) {
       userIdHash = crypto.createHash('sha1').update(channelId).digest('hex');
+      logger.info(
+        `event: ${body.event} channelId: ${channelId}  - No cached channel info found for ${userIdHash} - creating new channelId`,
+      );
+
       await pubClient.set(
         channelId,
         userIdHash,


### PR DESCRIPTION
## Explanation

Since Async Key exchange, the mobile directly returns the account and chainId before the "with" method is processed which can potentially trigger an eth_getBalance on sdk_react. The sdk historically was waiting for the first rpc response to treat as response to connectWith which is why it could treat response to getBalance instead of the "with" method.
This PR fixes this issue.


## References

Fixes: https://consensyssoftware.atlassian.net/jira/software/projects/SDK/boards/711?selectedIssue=SDK-61&sprintStarted=true
 
<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
