### PR TITLE
fix: improper implementation of handleBatchMethod + more robust tests

### DIFF
--- a/packages/devnext/src/pages/demo.tsx
+++ b/packages/devnext/src/pages/demo.tsx
@@ -457,22 +457,12 @@ const Demo = () => {
     const selectedAddress = provider?.getSelectedAddress();
 
     const initChainId = chainId;
-    const targetChainId = initChainId === '0x5' ? '0xe704' : '0x5';
+    const targetChainId = initChainId === '0x1' ? '0x89' : '0x1';
 
     const rpcs: ChainRPC[] = [
       {
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: targetChainId }],
-      },
-      {
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            to: '0x0000000000000000000000000000000000000000', // Required except during contract publications.
-            from: provider?.getSelectedAddress(), // must match user's active address.
-            value: '0x5AF3107A4000', // Only required to send ether to the recipient from the initiating external account.
-          },
-        ],
       },
       {
         method: 'personal_sign',

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.test.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.test.ts
@@ -50,10 +50,10 @@ describe('handleBatchMethod', () => {
     mockProvider = {
       request: jest.fn(),
     } as unknown as MetaMaskInpageProvider;
-    
+
     // the provider is always the target
     // in wrapExtensionProvider
-    mockTarget = mockProvider 
+    mockTarget = mockProvider;
   });
 
   afterEach(() => {

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.test.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.test.ts
@@ -50,10 +50,10 @@ describe('handleBatchMethod', () => {
     mockProvider = {
       request: jest.fn(),
     } as unknown as MetaMaskInpageProvider;
-
-    mockTarget = {
-      request: jest.fn(),
-    } as unknown as MetaMaskInpageProvider;
+    
+    // the provider is always the target
+    // in wrapExtensionProvider
+    mockTarget = mockProvider 
   });
 
   afterEach(() => {
@@ -66,14 +66,12 @@ describe('handleBatchMethod', () => {
       { method: 'rpc1', params: [] },
       { method: 'rpc2', params: [] },
     ];
-    const args = { method: 'someMethod', params: ['param1'] };
+    const args = { method: 'metamask_batch', params };
 
     await handleBatchMethod({
-      params,
       target: mockTarget,
       args,
       trackEvent: false,
-      provider: mockProvider,
       sdkInstance,
     });
 
@@ -86,43 +84,48 @@ describe('handleBatchMethod', () => {
       method: 'rpc2',
       params: [],
     });
+
+    expect(mockProvider.request).toHaveReturnedTimes(2);
   });
 
   it('should returns the response from the target request method', async () => {
-    const params: any[] = [];
-    const args = { method: 'someMethod', params: ['param1'] };
+    const params = [
+      { method: 'rpc1', params: [] },
+      { method: 'rpc2', params: [] },
+    ];
+    const args = { method: 'metamask_batch', params };
     const mockResponse = 'mockResponse';
     (mockTarget.request as jest.Mock).mockResolvedValue(mockResponse);
 
     const response = await handleBatchMethod({
-      params,
       target: mockTarget,
       args,
       trackEvent: false,
-      provider: mockProvider,
       sdkInstance,
     });
 
-    expect(response).toBe(mockResponse);
+    // 2 RPCs mean 2 return values
+    expect(response).toStrictEqual([mockResponse, mockResponse]);
   });
 
   it('should sends tracking event if trackEvent is true', async () => {
-    const params: any[] = [];
-    const args = { method: 'someMethod', params: ['param1'] };
+    const params = [
+      { method: 'rpc1', params: [] },
+      { method: 'rpc2', params: [] },
+    ];
+    const args = { method: 'metamask_batch', params };
 
     await handleBatchMethod({
-      params,
       target: mockTarget,
       args,
       trackEvent: true,
-      provider: mockProvider,
       sdkInstance,
     });
 
     expect(spyAnalytics).toHaveBeenCalledWith({
       event: TrackingEvents.SDK_RPC_REQUEST_DONE,
       params: {
-        method: 'someMethod',
+        method: 'metamask_batch',
         from: 'N/A',
         id: expect.any(String),
       },
@@ -130,15 +133,16 @@ describe('handleBatchMethod', () => {
   });
 
   it('should does not send tracking event if trackEvent is false', async () => {
-    const params: any[] = [];
-    const args = { method: 'someMethod', params: ['param1'] };
+    const params = [
+      { method: 'rpc1', params: [] },
+      { method: 'rpc2', params: [] },
+    ];
+    const args = { method: 'metamask_batch', params };
 
     await handleBatchMethod({
-      params,
       target: mockTarget,
       args,
       trackEvent: false,
-      provider: mockProvider,
       sdkInstance,
     });
 

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.ts
@@ -15,8 +15,8 @@ export const handleBatchMethod = async ({
   trackEvent: boolean;
   sdkInstance: MetaMaskSDK;
 }) => {
-  if (args.method !== "metamask_batch") {
-    throw new Error("Invalid usage");
+  if (args.method !== 'metamask_batch') {
+    throw new Error('Invalid usage');
   }
 
   // params is a list of RPCs to call

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleBatchMethod.ts
@@ -5,31 +5,30 @@ import { RequestArguments } from '../wrapExtensionProvider';
 import { getPlatformDetails } from './handleUuid';
 
 export const handleBatchMethod = async ({
-  params,
   target,
   args,
   trackEvent,
-  provider,
   sdkInstance,
 }: {
-  params: any[];
   target: MetaMaskInpageProvider;
   args: RequestArguments;
   trackEvent: boolean;
-  provider: MetaMaskInpageProvider;
   sdkInstance: MetaMaskSDK;
 }) => {
+  if (args.method !== "metamask_batch") {
+    throw new Error("Invalid usage");
+  }
+
   // params is a list of RPCs to call
   const responses = [];
+  const params = args?.params ?? [];
   for (const rpc of params) {
-    const response = await provider?.request({
+    const response = await target?.request({
       method: rpc.method,
       params: rpc.params,
     });
     responses.push(response);
   }
-
-  const resp = await target.request(args);
 
   const { id, from } = getPlatformDetails(sdkInstance);
 
@@ -43,5 +42,5 @@ export const handleBatchMethod = async ({
       },
     });
   }
-  return resp;
+  return responses;
 };

--- a/packages/sdk/src/provider/wrapExtensionProvider.test.ts
+++ b/packages/sdk/src/provider/wrapExtensionProvider.test.ts
@@ -141,12 +141,10 @@ describe('wrapExtensionProvider', () => {
     await wrapped.request(args);
 
     expect(handleBatchMethod).toHaveBeenCalledWith({
-      params: args.params,
       target: mockProvider,
       args,
       trackEvent: true,
       sdkInstance,
-      provider: mockProvider,
     });
   });
 

--- a/packages/sdk/src/provider/wrapExtensionProvider.ts
+++ b/packages/sdk/src/provider/wrapExtensionProvider.ts
@@ -49,12 +49,10 @@ export const wrapExtensionProvider = ({
 
           if (method === RPC_METHODS.METAMASK_BATCH && Array.isArray(params)) {
             return handleBatchMethod({
-              params,
               target,
               args,
               trackEvent,
               sdkInstance,
-              provider,
             });
           }
 


### PR DESCRIPTION
## Explanation

This PR fixes a bug where the extension provider invokes the `metamask_batch` request logic correctly, but then also sends a `metamask_batch` request again. This (at best) causes the requests to be sent individually, then all at once or (at worst) causing `metamask_batch` to break entirely if the extension doesn't support the RPC

Currently, the latter case happens. The requests are sent individually, but then errors because it then tries to send `metamask_batch` and the extension doesn't support that

![Screenshot 2024-10-04 at 2 17 14 PM](https://github.com/user-attachments/assets/e9255b8c-ceaf-4275-a401-041c3d22fae7)

With the fixed logic in `handleBatchMethod`, the extension **and SDK** return the correct result

![Screenshot 2024-10-04 at 2 38 59 PM](https://github.com/user-attachments/assets/7ab8350b-14a9-476a-9ff4-417823b58451)

This PR also updates the unit tests for `handleBatchMethod` to be more robust to ensure this behavior doesn't regress.

## References

This likely closes #1045 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [N/A] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [N/A] I've highlighted breaking changes using the "BREAKING" category above as appropriate
