### PR TITLE
feat: always re-emit display uri event

### DIFF
--- a/packages/devnext/src/pages/_app.tsx
+++ b/packages/devnext/src/pages/_app.tsx
@@ -21,7 +21,6 @@ const WithSDKConfig = ({ children }: { children: React.ReactNode }) => {
     socketServer,
     infuraAPIKey,
     useDeeplink,
-    _experimentalDeeplinkProtocol,
     checkInstallationImmediately,
   } = useSDKConfig();
 
@@ -38,7 +37,6 @@ const WithSDKConfig = ({ children }: { children: React.ReactNode }) => {
           '0x539': process.env.NEXT_PUBLIC_PROVIDER_RPCURL ?? '',
         },
         extensionOnly: false,
-        _experimentalDeeplinkProtocol,
         logging: {
           developerMode: true,
           remoteLayer: true,
@@ -76,7 +74,6 @@ export default function App({ Component, pageProps }: AppProps) {
       <SDKConfigProvider
         initialSocketServer={process.env.NEXT_PUBLIC_COMM_SERVER_URL}
         initialInfuraKey={process.env.NEXT_PUBLIC_INFURA_API_KEY}
-        _initialExperimentalDeeplinkProtocol={false}
         debug={true}
       >
         <WithSDKConfig>

--- a/packages/sdk/src/provider/initializeMobileProvider.ts
+++ b/packages/sdk/src/provider/initializeMobileProvider.ts
@@ -122,7 +122,14 @@ const initializeMobileProvider = async ({
     executeRequest: any,
     debugRequest: boolean,
   ) => {
+    const provider = Ethereum.getProvider();
+
     if (initializationOngoing) {
+      // Always re-emit the display_uri event
+      provider.emit('display_uri', {
+        uri: remoteConnection?.state.qrcodeLink || '',
+      });
+
       // make sure the active modal is displayed
       remoteConnection?.showActiveModal();
 
@@ -148,8 +155,6 @@ const initializeMobileProvider = async ({
     const isInstalled = platformManager.isMetaMaskInstalled();
     // Also check that socket is connected -- otherwise it would be in inconherant state.
     const socketConnected = remoteConnection?.isConnected();
-
-    const provider = Ethereum.getProvider();
 
     let selectedAddress: string | null = null;
     let connectedAccounts: string[] | null = null;


### PR DESCRIPTION
## Explanation

Some clients implementation rely on the `display_uri` event being re-triggered every time the modal is opened.
This PR automatically republish the uri so that clients don't have to implement their own cache of the display_uri.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
