### PR TITLE
feat: emit connectWithResponse event

### DIFF
--- a/packages/devnext/src/pages/_app.tsx
+++ b/packages/devnext/src/pages/_app.tsx
@@ -21,7 +21,6 @@ const WithSDKConfig = ({ children }: { children: React.ReactNode }) => {
     socketServer,
     infuraAPIKey,
     useDeeplink,
-    _experimentalDeeplinkProtocol,
     checkInstallationImmediately,
   } = useSDKConfig();
 
@@ -38,7 +37,6 @@ const WithSDKConfig = ({ children }: { children: React.ReactNode }) => {
           '0x539': process.env.NEXT_PUBLIC_PROVIDER_RPCURL ?? '',
         },
         extensionOnly: false,
-        _experimentalDeeplinkProtocol,
         logging: {
           developerMode: true,
           remoteLayer: true,
@@ -76,7 +74,6 @@ export default function App({ Component, pageProps }: AppProps) {
       <SDKConfigProvider
         initialSocketServer={process.env.NEXT_PUBLIC_COMM_SERVER_URL}
         initialInfuraKey={process.env.NEXT_PUBLIC_INFURA_API_KEY}
-        _initialExperimentalDeeplinkProtocol={false}
         debug={true}
       >
         <WithSDKConfig>

--- a/packages/devnext/src/pages/demo.tsx
+++ b/packages/devnext/src/pages/demo.tsx
@@ -3,7 +3,7 @@ import { useSDK } from '@metamask/sdk-react';
 import { MetaMaskButton, SDKStatus, RPCHistoryViewer } from '@metamask/sdk-ui';
 import { ethers } from 'ethers';
 import Head from 'next/head';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import SimpleABI from '../abi/Simple.json';
 import { getSignParams } from '../utils/sign-utils';
 import { SiweMessage } from 'siwe';
@@ -15,6 +15,19 @@ const Demo = () => {
   const [response, setResponse] = useState<unknown>('');
   const [rpcError, setRpcError] = useState<unknown>();
   const [requesting, setRequesting] = useState(false);
+
+  useEffect(() => {
+    if (sdk) {
+      const listener = (response: unknown) => {
+        console.warn('Received connectWithResponse', response);
+      };
+      sdk.on('connectWithResponse', listener);
+
+      return () => {
+        sdk.off('connectWithResponse', listener);
+      };
+    }
+  }, [sdk]);
 
   const connect = async () => {
     try {

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -66,6 +66,8 @@ export const STORAGE_PROVIDER_TYPE = 'providerType';
 export const STORAGE_DAPP_SELECTED_ADDRESS = '.MMSDK_cached_address';
 export const STORAGE_DAPP_CHAINID = '.MMSDK_cached_chainId';
 
+export const CONNECTWITH_RESPONSE_EVENT = 'connectWithResponse';
+
 export const EXTENSION_EVENTS = {
   CHAIN_CHANGED: 'chainChanged',
   ACCOUNTS_CHANGED: 'accountsChanged',

--- a/packages/sdk/src/provider/extensionProviderHelpers/handleConnectWithMethod.ts
+++ b/packages/sdk/src/provider/extensionProviderHelpers/handleConnectWithMethod.ts
@@ -44,8 +44,10 @@ export const handleConnectWithMethod = async ({
     return accounts;
   }
 
-  return await target.request({
+  const response = await target.request({
     method: currentRpcMethod,
     params: currentRpcParams,
   });
+
+  return response;
 };

--- a/packages/sdk/src/provider/initializeMobileProvider.ts
+++ b/packages/sdk/src/provider/initializeMobileProvider.ts
@@ -122,7 +122,14 @@ const initializeMobileProvider = async ({
     executeRequest: any,
     debugRequest: boolean,
   ) => {
+    const provider = Ethereum.getProvider();
+
     if (initializationOngoing) {
+      // Always re-emit the display_uri event
+      provider.emit('display_uri', {
+        uri: remoteConnection?.state.qrcodeLink || '',
+      });
+
       // make sure the active modal is displayed
       remoteConnection?.showActiveModal();
 
@@ -148,8 +155,6 @@ const initializeMobileProvider = async ({
     const isInstalled = platformManager.isMetaMaskInstalled();
     // Also check that socket is connected -- otherwise it would be in inconherant state.
     const socketConnected = remoteConnection?.isConnected();
-
-    const provider = Ethereum.getProvider();
 
     let selectedAddress: string | null = null;
     let connectedAccounts: string[] | null = null;


### PR DESCRIPTION
## Explanation

Emit a new event to inform clients using provider such as wagmi of the response from `connectWith` or `connectAndSign`.
This allows for better flexibility for the developer if the connector integration only returns the list of account.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
