### PR TITLE
fix: send missing originator info in rpc request analytics

### DIFF
--- a/packages/sdk-communication-layer/src/services/SocketService/MessageHandlers/handleSendMessage.ts
+++ b/packages/sdk-communication-layer/src/services/SocketService/MessageHandlers/handleSendMessage.ts
@@ -78,6 +78,7 @@ export async function handleSendMessage(
         {
           id: instance.remote.state.channelId ?? '',
           event: TrackingEvents.SDK_RPC_REQUEST,
+          ...instance.remote.state.originatorInfo,
           params: {
             method: message.method,
             from: 'mobile',


### PR DESCRIPTION
## Explanation

This PR adds originator info in the `sdk_rpc_request` analytics. This information is currently missing making it not possible to attribute `sdk_rpc_request_done` to the corresponding request.

Currently the `sdk_rpc_request` analytics analytics looks like this:
```
{
  "id": "f24a4662-ed1c-4628-a31c-ea3f0ee60675",
  "event": "sdk_rpc_request",
  "method": "personal_sign",
  "from": "mobile"
}
```

While the corresponding the `sdk_rpc_request_done` analytics analytics looks like this:
```
{
  "id": "f24a4662-ed1c-4628-a31c-ea3f0ee60675",
  "event": "sdk_rpc_request_done",
  "sdkVersion": "0.29.2",
  "commLayerVersion": "0.29.2",
  "url": "http://localhost:3000",
  "title": "Demo React App",
  "source": "direct",
  "dappId": "localhost",
  "icon": "http://localhost:3000/favicon.ico",
  "platform": "web-desktop",
  "apiVersion": "0.29.2",
  "method": "personal_sign",
  "from": "mobile"
}
```
* Fixes [#SDK-87](https://consensyssoftware.atlassian.net/browse/SDK-87)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
