### PR TITLE
feat: fake metamask wallet detection

### DIFF
--- a/packages/sdk/src/utils/get-browser-extension.test.ts
+++ b/packages/sdk/src/utils/get-browser-extension.test.ts
@@ -104,6 +104,20 @@ describe('getBrowserExtension', () => {
     ).rejects.toThrow('MetaMask provider not found in Ethereum');
   });
 
+  it('should throw an error if mustBeMetaMask is true but uniswap wallet installed instead of Metamask', async () => {
+    (eip6963RequestProvider as jest.Mock).mockRejectedValue(
+      new Error('Provider request failed'),
+    );
+
+    global.window = {
+      ethereum: { isMetaMask: true, isUniswapWallet: true },
+    } as any;
+
+    await expect(
+      getBrowserExtension({ mustBeMetaMask: true, sdkInstance }),
+    ).rejects.toThrow('MetaMask provider not found in Ethereum');
+  });
+
   it('should return ethereum object if mustBeMetaMask is false and ethereum object exists', async () => {
     const ethereumObj = { isMetaMask: true };
     (eip6963RequestProvider as jest.Mock).mockRejectedValue(


### PR DESCRIPTION
I’ve discovered an issue with the SDK (pure JavaScript and wagmi).
The SDK tests the boolean `window.ethereum.isMetaMask` to detect if the extension is installed.
However, some other extensions use the same boolean to imitate MetaMask (e.g., Uniswap, Zerion, Rabby, etc.), and it works…

<img width="985" alt="Screenshot 2024-10-14 at 11 09 05" src="https://github.com/user-attachments/assets/80aa3808-a147-4bb3-b942-63cca49be564">


So, if the MetaMask extension is not installed, but one of those wallets is, the SDK will open the “fake” extension instead of the connection modal.
Wagmi has a similar detection on their side, but they don’t take into account the “Uniswap Wallet.”

I also created a PR on Wagmi to add Uniswap to their detection test.

Here’s a demo video.

https://github.com/user-attachments/assets/be461d80-436b-475c-9fd5-9c692b9010bd



