### PR TITLE
fix: display_uri event malformed

### DIFF
--- a/packages/sdk/src/provider/initializeMobileProvider.ts
+++ b/packages/sdk/src/provider/initializeMobileProvider.ts
@@ -130,9 +130,7 @@ const initializeMobileProvider = async ({
 
     if (initializationOngoing) {
       // Always re-emit the display_uri event
-      provider.emit('display_uri', {
-        uri: remoteConnection?.state.qrcodeLink || '',
-      });
+      provider.emit('display_uri', remoteConnection?.state.qrcodeLink || '');
 
       // make sure the active modal is displayed
       remoteConnection?.showActiveModal();


### PR DESCRIPTION
The `display_uri ` should be just a string containing the uri, not an object.

See first event sent here: https://github.com/MetaMask/metamask-sdk/blob/986648007c09eef112708d5d08a0e47eac3cd7d3/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts#L178