### PR TITLE
fix: rpc protocol resetting after refresh

### DIFF
--- a/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleWalletInitMessage.ts
+++ b/packages/sdk-communication-layer/src/services/RemoteCommunication/MessageHandlers/handleWalletInitMessage.ts
@@ -31,11 +31,12 @@ export async function handleWalletInitMessage(
           const accounts = data.accounts as string[];
           const chainId = data.chainId as string;
           const walletKey = data.walletKey as string;
-          let deeplinProtocolAvailable = false;
+          let deeplinkProtocolAvailable = false;
           let walletVersion: string | undefined;
           if ('deeplinkProtocol' in data) {
-            deeplinProtocolAvailable = Boolean(data.deeplinkProtocol);
-            instance.state.deeplinkProtocolAvailable = deeplinProtocolAvailable;
+            deeplinkProtocolAvailable = Boolean(data.deeplinkProtocol);
+            instance.state.deeplinkProtocolAvailable =
+              deeplinkProtocolAvailable;
           }
 
           if ('walletVersion' in data) {
@@ -46,7 +47,7 @@ export async function handleWalletInitMessage(
             ...channelConfig,
             otherKey: walletKey,
             walletVersion,
-            deeplinkProtocolAvailable: deeplinProtocolAvailable,
+            deeplinkProtocolAvailable,
             relayPersistence: true,
           });
 

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -47,6 +47,14 @@ export interface RemoteConnectionProps {
   // Prevent circular dependencies
   getMetaMaskInstaller: () => MetaMaskInstaller;
   connectWithExtensionProvider?: () => void;
+  /**
+   * @deprecated Use the 'display_uri' event on the provider instead.
+   * Listen to this event to get the QR code URL and customize your UI.
+   * Example:
+   * sdk.getProvider().on('display_uri', (uri: string) => {
+   *   // Use the uri to display a QR code or customize your UI
+   * });
+   */
   modals: {
     onPendingModalDisconnect?: () => void;
     install?: (params: {
@@ -172,10 +180,9 @@ export class RemoteConnection {
       this.options.ecies = eciesProps;
     }
     initializeConnector(this.state, this.options);
+    await this.getConnector()?.initFromDappStorage();
 
     setupListeners(this.state, this.options);
-
-    return this.getConnector()?.initFromDappStorage();
   }
 
   showActiveModal() {


### PR DESCRIPTION
## Explanation

There is a race condition happening when the sdk is using the rpc protocol and restore its connection.

Because the socket layer receives the connection event before the channel config is restored from the storage, we loose the previous storage containing wallet version and rpcprotocol availability.

## References
- Fixes https://consensyssoftware.atlassian.net/jira/software/projects/SDK/boards/711?selectedIssue=SDK-99&sprintStarted=true
<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
