### PR TITLE
fix: connectAndSign send as hexString

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/connectAndSign.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/connectAndSign.ts
@@ -1,6 +1,7 @@
 import { logger } from '../../../utils/logger';
 import { RPC_METHODS } from '../../../config';
 import { MetaMaskSDK } from '../../../sdk';
+import { isHexString, stringToHex } from '../../../utils/hex.utils';
 
 /**
  * Asynchronously connects to MetaMask, requests account access and sign message.
@@ -36,12 +37,15 @@ export async function connectAndSign({
     throw new Error(`SDK state invalid -- undefined provider`);
   }
 
+  // Check if msg is a hex string and convert if not
+  const hexMsg = isHexString(msg) ? msg : stringToHex(msg);
+
   return instance.activeProvider.request({
     method: RPC_METHODS.METAMASK_CONNECTWITH,
     params: [
       {
         method: RPC_METHODS.PERSONAL_SIGN,
-        params: [msg],
+        params: [hexMsg],
       },
     ],
   });

--- a/packages/sdk/src/utils/hex.utils.test.ts
+++ b/packages/sdk/src/utils/hex.utils.test.ts
@@ -1,0 +1,78 @@
+import { isHexString, stringToHex, hexToString } from './hex.utils';
+
+describe('hex utils', () => {
+  describe('isHexString', () => {
+    it('should return true for valid hex strings', () => {
+      expect(isHexString('0x1234')).toBe(true);
+      expect(isHexString('0xabcdef')).toBe(true);
+      expect(isHexString('0xABCDEF')).toBe(true);
+      expect(isHexString('0x123ABC')).toBe(true);
+    });
+
+    it('should return false for invalid hex strings', () => {
+      expect(isHexString('1234')).toBe(false);
+      expect(isHexString('0x12G')).toBe(false);
+      expect(isHexString('0x')).toBe(false);
+      expect(isHexString('abc')).toBe(false);
+    });
+  });
+
+  describe('stringToHex', () => {
+    it('should convert ASCII strings to hex', () => {
+      expect(stringToHex('Hello')).toBe('0x48656c6c6f');
+      expect(stringToHex('World')).toBe('0x576f726c64');
+    });
+
+    it('should convert empty string to hex', () => {
+      expect(stringToHex('')).toBe('0x');
+    });
+
+    it('should convert Unicode strings to hex', () => {
+      expect(stringToHex('こんにちは')).toBe(
+        '0xe38193e38293e381abe381a1e381af',
+      );
+      expect(stringToHex('🚀')).toBe('0xf09f9a80');
+    });
+  });
+
+  describe('hexToString', () => {
+    it('should convert hex to ASCII strings', () => {
+      expect(hexToString('0x48656c6c6f')).toBe('Hello');
+      expect(hexToString('0x576f726c64')).toBe('World');
+    });
+
+    it('should convert empty hex to empty string', () => {
+      expect(hexToString('0x')).toBe('');
+    });
+
+    it('should convert hex to Unicode strings', () => {
+      expect(hexToString('0xe38193e38293e381abe381a1e381af')).toBe(
+        'こんにちは',
+      );
+      expect(hexToString('0xf09f9a80')).toBe('🚀');
+    });
+
+    it('should throw an error for invalid hex strings', () => {
+      expect(() => hexToString('invalid')).toThrow('Invalid hex string');
+      expect(() => hexToString('0x123G')).toThrow('Invalid hex string');
+    });
+  });
+
+  describe('roundtrip conversion', () => {
+    const testCases = [
+      'Hello, World!',
+      'こんにちは、世界！',
+      '🚀✨🌍',
+      '',
+      'The quick brown fox jumps over the lazy dog.',
+    ];
+
+    testCases.forEach((testCase) => {
+      it(`should correctly roundtrip: ${testCase}`, () => {
+        const hex = stringToHex(testCase);
+        const roundtrip = hexToString(hex);
+        expect(roundtrip).toBe(testCase);
+      });
+    });
+  });
+});

--- a/packages/sdk/src/utils/hex.utils.ts
+++ b/packages/sdk/src/utils/hex.utils.ts
@@ -1,0 +1,59 @@
+// Helper functions
+export function isHexString(value: string): boolean {
+  if (value === '0x') {
+    return false;
+  }
+  return /^0x([0-9A-Fa-f]{2})+$/u.test(value);
+}
+
+export function stringToHex(value: string): string {
+  let hexString: string;
+
+  if (typeof Buffer !== 'undefined') {
+    // Node.js environment
+    hexString = Buffer.from(value, 'utf8').toString('hex');
+  } else if (typeof TextEncoder !== 'undefined') {
+    // Web environment
+    const encoder = new TextEncoder();
+    const uint8Array = encoder.encode(value);
+    hexString = Array.from(uint8Array)
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  } else if (typeof global === 'object' && 'Buffer' in global) {
+    // React Native environment
+    hexString = global.Buffer.from(value, 'utf8').toString('hex');
+  } else {
+    throw new Error('Unable to convert string to hex: No available method.');
+  }
+
+  return `0x${hexString}`;
+}
+
+export function hexToString(hex: string): string {
+  if (!isHexString(hex)) {
+    throw new Error('Invalid hex string');
+  }
+
+  const hexWithoutPrefix = hex.slice(2);
+  let string: string;
+
+  if (typeof Buffer !== 'undefined') {
+    // Node.js environment
+    string = Buffer.from(hexWithoutPrefix, 'hex').toString('utf8');
+  } else if (typeof TextDecoder !== 'undefined') {
+    // Web environment
+    const matches = hexWithoutPrefix.match(/.{1,2}/gu);
+    if (!matches) {
+      throw new Error('Invalid hex string');
+    }
+    const bytes = new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
+    string = new TextDecoder('utf-8').decode(bytes);
+  } else if (typeof global === 'object' && 'Buffer' in global) {
+    // React Native environment
+    string = global.Buffer.from(hexWithoutPrefix, 'hex').toString('utf8');
+  } else {
+    throw new Error('Unable to convert hex to string: No available method.');
+  }
+
+  return string;
+}


### PR DESCRIPTION
## Explanation

Always convert non hex string to hex when using connectAndSign.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
