### PR TITLE
Update token used for gh-pages deployments

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Deploy dapps
       uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.DEPLOY_TOKEN }}
         force_orphan: true
         keep_files: true  # Important to keep the rest of the files deployed previously
         publish_dir: ./deployments

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,11 +1,7 @@
 name: Deploy to GitHub Pages
-permissions:
-  contents: write
 
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   workflow_dispatch:  # Allows you to run this workflow manually from the Actions tab
 


### PR DESCRIPTION
## Explanation

This pull request updates the token that is used for gh-pages deployments to a MetaMaskBot token as seen on other repositories. I've also adjusted the job to run upon merge to the main branch rather than on pull requests as well. If this behaviour was intentional, please let me know and we can explore how to support this updated token on branches as well.

Once this pull request is merged, please to a test deployment to ensure that the deployment functions as expected.

## References

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
