### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: github-pages
 
     steps:
     - name: Checkout Repository
@@ -30,7 +31,7 @@ jobs:
     - name: Deploy dapps
       uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
       with:
-        github_token: ${{ secrets.DEPLOY_TOKEN }}
+        personal_token: ${{ secrets.DEPLOY_TOKEN }}
         force_orphan: true
         keep_files: true  # Important to keep the rest of the files deployed previously
         publish_dir: ./deployments


### PR DESCRIPTION
## Explanation

This pull request updates the deploy workflow to explicitly note the environment its part of (github-pages) and use the `personal_token` field as per the `peaceiris/actions-gh-pages` docs.

This mimics a similar setup as the Website repository here: https://github.com/MetaMask/website/blob/master/.github/workflows/integrate.yml

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
