### PR TITLE
chore: add prom client

### DIFF
--- a/packages/sdk-socket-server-next/package.json
+++ b/packages/sdk-socket-server-next/package.json
@@ -51,6 +51,7 @@
     "ioredis": "^5.3.2",
     "logform": "^2.6.0",
     "lru-cache": "^10.0.0",
+    "prom-client": "^15.1.3",
     "rate-limiter-flexible": "^2.3.8",
     "redis": "^4.6.12",
     "rimraf": "^4.4.0",

--- a/packages/sdk-socket-server-next/src/index.ts
+++ b/packages/sdk-socket-server-next/src/index.ts
@@ -11,7 +11,7 @@ import packageJson from '../package.json';
 import { isDevelopment, withAdminUI } from './config';
 import { analytics, app } from './analytics-api';
 import { getLogger } from './logger';
-import * as metrics from './metrics';
+import { read } from './metrics';
 import { configureSocketServer } from './socket-config';
 import { cleanupAndExit } from './utils';
 
@@ -49,7 +49,7 @@ configureSocketServer(server)
     // Make sure to protect the endpoint to be only available within the cluster for prometheus
     app.get('/metrics', async (_req, res) => {
       res.set('Content-Type', 'text/plain');
-      res.send(await metrics.read());
+      res.send(await read());
     });
 
     app.get('/version', (_req, res) => {

--- a/packages/sdk-socket-server-next/src/index.ts
+++ b/packages/sdk-socket-server-next/src/index.ts
@@ -11,7 +11,7 @@ import packageJson from '../package.json';
 import { isDevelopment, withAdminUI } from './config';
 import { analytics, app } from './analytics-api';
 import { getLogger } from './logger';
-import { read } from './metrics';
+import { readMetrics } from './metrics';
 import { configureSocketServer } from './socket-config';
 import { cleanupAndExit } from './utils';
 
@@ -49,7 +49,7 @@ configureSocketServer(server)
     // Make sure to protect the endpoint to be only available within the cluster for prometheus
     app.get('/metrics', async (_req, res) => {
       res.set('Content-Type', 'text/plain');
-      res.send(await read());
+      res.send(await readMetrics());
     });
 
     app.get('/version', (_req, res) => {

--- a/packages/sdk-socket-server-next/src/index.ts
+++ b/packages/sdk-socket-server-next/src/index.ts
@@ -11,7 +11,7 @@ import packageJson from '../package.json';
 import { isDevelopment, withAdminUI } from './config';
 import { analytics, app } from './analytics-api';
 import { getLogger } from './logger';
-import { extractMetrics } from './metrics';
+import * as metrics from './metrics';
 import { configureSocketServer } from './socket-config';
 import { cleanupAndExit } from './utils';
 
@@ -49,8 +49,7 @@ configureSocketServer(server)
     // Make sure to protect the endpoint to be only available within the cluster for prometheus
     app.get('/metrics', async (_req, res) => {
       res.set('Content-Type', 'text/plain');
-      const metrics = extractMetrics({ ioServer });
-      res.send(metrics);
+      res.send(await metrics.read());
     });
 
     app.get('/version', (_req, res) => {

--- a/packages/sdk-socket-server-next/src/metrics.ts
+++ b/packages/sdk-socket-server-next/src/metrics.ts
@@ -1,15 +1,31 @@
-import { Server } from 'socket.io';
+import * as prometheus from 'prom-client';
 
-export const extractMetrics = ({ ioServer }: { ioServer: Server }) => {
-  const totalClients = ioServer.engine.clientsCount;
-  let fullMetrics = `# HELP socket_io_server_total_clients Total number of connected clients\n`;
-  fullMetrics += `# TYPE socket_io_server_total_clients gauge\n`;
-  fullMetrics += `socket_io_server_total_clients ${totalClients}\n`;
+const register = new prometheus.Registry();
 
-  const totalRooms = ioServer.sockets.adapter.rooms.size;
-  fullMetrics += `# HELP socket_io_server_total_rooms Total number of rooms\n`;
-  fullMetrics += `# TYPE socket_io_server_total_rooms gauge\n`;
-  fullMetrics += `socket_io_server_total_rooms ${totalRooms}\n`;
+prometheus.collectDefaultMetrics({ register });
 
-  return fullMetrics;
-};
+export async function read() {
+  return await register.metrics();
+}
+
+const socketIoServerTotalClients = new prometheus.Gauge({
+  name: 'socket_io_server_total_clients',
+  help: 'Total number of connected clients',
+  labelNames: [],
+  registers: [register],
+});
+
+const socketIoServerTotalRooms = new prometheus.Gauge({
+  name: 'socket_io_server_total_rooms',
+  help: 'Total number of rooms',
+  labelNames: [],
+  registers: [register],
+});
+
+export function setSocketIoServerTotalClients(count: number) {
+  socketIoServerTotalClients.set(count);
+}
+
+export function setSocketIoServerTotalRooms(count: number) {
+  socketIoServerTotalRooms.set(count);
+}

--- a/packages/sdk-socket-server-next/src/metrics.ts
+++ b/packages/sdk-socket-server-next/src/metrics.ts
@@ -1,21 +1,21 @@
-import * as prometheus from 'prom-client';
+import { Registry, collectDefaultMetrics, Gauge } from 'prom-client';
 
-const register = new prometheus.Registry();
+const register = new Registry();
 
-prometheus.collectDefaultMetrics({ register });
+collectDefaultMetrics({ register });
 
 export async function read() {
   return await register.metrics();
 }
 
-const socketIoServerTotalClients = new prometheus.Gauge({
+const socketIoServerTotalClients = new Gauge({
   name: 'socket_io_server_total_clients',
   help: 'Total number of connected clients',
   labelNames: [],
   registers: [register],
 });
 
-const socketIoServerTotalRooms = new prometheus.Gauge({
+const socketIoServerTotalRooms = new Gauge({
   name: 'socket_io_server_total_rooms',
   help: 'Total number of rooms',
   labelNames: [],

--- a/packages/sdk-socket-server-next/src/metrics.ts
+++ b/packages/sdk-socket-server-next/src/metrics.ts
@@ -1,10 +1,10 @@
-import { Registry, collectDefaultMetrics, Gauge } from 'prom-client';
+import { collectDefaultMetrics, Gauge, Registry } from 'prom-client';
 
 const register = new Registry();
 
 collectDefaultMetrics({ register });
 
-export async function read() {
+export async function readMetrics() {
   return await register.metrics();
 }
 

--- a/packages/sdk-socket-server-next/src/socket-config.ts
+++ b/packages/sdk-socket-server-next/src/socket-config.ts
@@ -20,7 +20,10 @@ import {
 } from './protocol/handleJoinChannel';
 import { handleMessage, MessageParams } from './protocol/handleMessage';
 import { handlePing } from './protocol/handlePing';
-import * as metrics from './metrics';
+import {
+  setSocketIoServerTotalClients,
+  setSocketIoServerTotalRooms,
+} from './metrics';
 
 const logger = getLogger();
 
@@ -363,7 +366,7 @@ export const configureSocketServer = async (
 
 function watchSocketIoServerMetrics(io: Server) {
   setInterval(() => {
-    metrics.setSocketIoServerTotalClients(io.engine.clientsCount);
-    metrics.setSocketIoServerTotalRooms(io.sockets.adapter.rooms.size);
+    setSocketIoServerTotalClients(io.engine.clientsCount);
+    setSocketIoServerTotalRooms(io.sockets.adapter.rooms.size);
   }, 5_000);
 }

--- a/packages/sdk-socket-server-next/src/socket-config.ts
+++ b/packages/sdk-socket-server-next/src/socket-config.ts
@@ -20,6 +20,7 @@ import {
 } from './protocol/handleJoinChannel';
 import { handleMessage, MessageParams } from './protocol/handleMessage';
 import { handlePing } from './protocol/handlePing';
+import * as metrics from './metrics';
 
 const logger = getLogger();
 
@@ -67,6 +68,8 @@ export const configureSocketServer = async (
       credentials: true,
     },
   });
+
+  watchSocketIoServerMetrics(io);
 
   io.of('/').adapter.on('join-room', async (roomId, socketId) => {
     logger.debug(`'join-room' socket ${socketId} has joined room ${roomId}`);
@@ -357,3 +360,10 @@ export const configureSocketServer = async (
 
   return io;
 };
+
+function watchSocketIoServerMetrics(io: Server) {
+  setInterval(() => {
+    metrics.setSocketIoServerTotalClients(io.engine.clientsCount);
+    metrics.setSocketIoServerTotalRooms(io.sockets.adapter.rooms.size);
+  }, 5_000);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10305,6 +10305,7 @@ __metadata:
     lru-cache: ^10.0.0
     nodemon: ^3.1.0
     prettier: ^2.8.8
+    prom-client: ^15.1.3
     rate-limiter-flexible: ^2.3.8
     redis: ^4.6.12
     rimraf: ^4.4.0
@@ -11201,6 +11202,13 @@ __metadata:
     read-package-json-fast: ^3.0.0
     which: ^3.0.0
   checksum: 7a671d7dbeae376496e1c6242f02384928617dc66cd22881b2387272205c3668f8490ec2da4ad63e1abf979efdd2bdf4ea0926601d78578e07d83cfb233b3a1a
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:^1.4.0":
+  version: 1.9.0
+  resolution: "@opentelemetry/api@npm:1.9.0"
+  checksum: 9e88e59d53ced668f3daaecfd721071c5b85a67dd386f1c6f051d1be54375d850016c881f656ffbe9a03bedae85f7e89c2f2b635313f9c9b195ad033cdc31020
   languageName: node
   linkType: hard
 
@@ -22114,6 +22122,13 @@ __metadata:
   dependencies:
     file-uri-to-path: 1.0.0
   checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
+  languageName: node
+  linkType: hard
+
+"bintrees@npm:1.0.2":
+  version: 1.0.2
+  resolution: "bintrees@npm:1.0.2"
+  checksum: 56a52b7d3634e30002b1eda740d2517a22fa8e9e2eb088e919f37c030a0ed86e364ab59e472fc770fc8751308054bb1c892979d150e11d9e11ac33bcc1b5d16e
   languageName: node
   linkType: hard
 
@@ -41190,6 +41205,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prom-client@npm:^15.1.3":
+  version: 15.1.3
+  resolution: "prom-client@npm:15.1.3"
+  dependencies:
+    "@opentelemetry/api": ^1.4.0
+    tdigest: ^0.1.1
+  checksum: 9a57f3c16f39aa9a03da021883a4231c0bb56fc9d02f6ef9c28f913379f275640a5a33b98d9946ebf53c71011a29b580e9d2d6e3806cb1c229a3f59c65993968
+  languageName: node
+  linkType: hard
+
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -46615,6 +46640,15 @@ __metadata:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: f23832fceeba7578bf31907aac744ae21e74a66f4a17a9e94507acf460e48f6db598c7023882db33bab75b80e027c21f276d405e4a0322d58f51c7088d428268
+  languageName: node
+  linkType: hard
+
+"tdigest@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "tdigest@npm:0.1.2"
+  dependencies:
+    bintrees: 1.0.2
+  checksum: 44de8246752b6f8c2924685f969fd3d94c36949f22b0907e99bef2b2220726dd8467f4730ea96b06040b9aa2587c0866049640039d1b956952dfa962bc2075a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The current state uses a custom metrics extraction function that manually calculates and formats metrics for total connected clients and total rooms. This approach is limited in scope and requires manual maintenance to add or modify metrics.

The solution introduces the use of the Prometheus client library ('prom-client') to handle metrics collection and formatting. This change offers several advantages:

1. Standardized metrics format compatible with Prometheus
2. Automatic collection of numerous Node.js and process-level metrics out-of-the-box
3. Easy addition and customization of application-specific metrics

The changes include:
- Adding 'prom-client' as a dependency
- Replacing the custom 'extractMetrics' function with Prometheus Registry and Gauge metrics
- Updating the metrics endpoint to use the new Prometheus-based metrics collection
- Adding a function to periodically update socket server metrics

## References

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate