### PR TITLE
feat: deprecate getUniversalLink in favor or display_uri

### DIFF
--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -374,6 +374,10 @@ export class MetaMaskSDK extends EventEmitter2 {
     return this.sdkProvider;
   }
 
+  /**
+   * @deprecated use 'display_uri' event on from sdk instance instead.
+   * @returns {string} - The QRCode Link.
+   */
   getUniversalLink() {
     const universalLink = this.remoteConnection?.getUniversalLink();
 


### PR DESCRIPTION
## Explanation

We now recommend using `display_uri` event for implementing custom display related action.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
