### PR TITLE
fix: chainId for sepolia in infura rpc map

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupInfuraProvider.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupInfuraProvider.ts
@@ -16,7 +16,7 @@ export const setupInfuraProvider = async (instance: MetaMaskSDK) => {
     // Goerli
     '0x5': `https://goerli.infura.io/v3/${infuraAPIKey}`,
     // Sepolia 11155111
-    '0x2a': `https://sepolia.infura.io/v3/${infuraAPIKey}`,
+    '0xaa36a7': `https://sepolia.infura.io/v3/${infuraAPIKey}`,
     // ###### Linea ######
     // Mainnet Alpha
     '0xe708': `https://linea-mainnet.infura.io/v3/${infuraAPIKey}`,


### PR DESCRIPTION

## Explanation

This fixes issues with using read-only RPCs with Infura on Sepolia. This was caused by the wrong chainId being mapped to Sepolia in the Infura RPC URL map


## References

N/A

## Checklist

- [N/A] I've updated the test suite for new or updated code as appropriate
- [N/A] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [N/A] I've highlighted breaking changes using the "BREAKING" category above as appropriate
