### PR TITLE
Fix/adapt update example dapps script

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,10 +40,6 @@ jobs:
     - name: Install Dependencies
       run: yarn --immutable
 
-    - name: Update Examples Dapps
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.IS_RELEASE == 'true'
-      run: bash ./scripts/update-examples-dapps.sh
-
     - name: Build All Static Example Projects
       env:
         IS_RELEASE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.IS_RELEASE == 'true' || false }}

--- a/scripts/update-examples-dapps.sh
+++ b/scripts/update-examples-dapps.sh
@@ -28,11 +28,15 @@ sdk_react_version=$(get_version "$SDK_REACT_DIR/package.json")
 sdk_react_ui_version=$(get_version "$SDK_REACT_UI_DIR/package.json")
 sdk_react_native_version=$(get_version "$SDK_REACT_NATIVE_DIR/package.json")
 
-echo "Latest versions:"
+echo "\n---------------------------------------------------"
+echo "Updating examples dapps to the latest versions"
 echo "@metamask/sdk: $sdk_version"
 echo "@metamask/sdk-react: $sdk_react_version"
 echo "@metamask/sdk-react-ui: $sdk_react_ui_version"
 echo "@metamask/sdk-react-native: $sdk_react_native_version"
+echo "-----------------------------------------------------\n"
+
+
 
 # Define the path to the examples folder
 EXAMPLES_DIR="$SDK_WORKSPACE_DIR/packages/examples"
@@ -53,7 +57,9 @@ for app in "$EXAMPLES_DIR"/*; do
         echo "Updating @metamask/sdk in $app from $current_version to $latest_version"
 
         # using yarn instead to allow upgrading to happen on ci
+        cd "$app"
         yarn up @metamask/sdk
+        cd "$SDK_WORKSPACE_DIR"
         # jq '.dependencies["@metamask/sdk"] = "'"$latest_version"'"' "$PACKAGE_JSON" > "$PACKAGE_JSON.tmp" && mv "$PACKAGE_JSON.tmp" "$PACKAGE_JSON"
       fi
 
@@ -65,7 +71,9 @@ for app in "$EXAMPLES_DIR"/*; do
         echo "Updating @metamask/sdk-react in $app from $current_version to $latest_version"
 
         # using yarn instead to allow upgrading to happen on ci
+        cd "$app"
         yarn up @metamask/sdk-react
+        cd "$SDK_WORKSPACE_DIR"
         # jq '.dependencies["@metamask/sdk-react"] = "'"$latest_version"'"' "$PACKAGE_JSON" > "$PACKAGE_JSON.tmp" && mv "$PACKAGE_JSON.tmp" "$PACKAGE_JSON"
       fi
 
@@ -77,7 +85,9 @@ for app in "$EXAMPLES_DIR"/*; do
         echo "Updating @metamask/sdk-react-ui in $app from $current_version to $latest_version"
 
         # using yarn instead to allow upgrading to happen on ci
+        cd "$app"
         yarn up @metamask/sdk-react-ui
+        cd "$SDK_WORKSPACE_DIR"
         # jq '.dependencies["@metamask/sdk-react-ui"] = "'"$latest_version"'"' "$PACKAGE_JSON" > "$PACKAGE_JSON.tmp" && mv "$PACKAGE_JSON.tmp" "$PACKAGE_JSON"
       fi
 
@@ -89,7 +99,9 @@ for app in "$EXAMPLES_DIR"/*; do
         echo "Updating @metamask/sdk-react-native in $app from $current_version to $latest_version"
 
         # using yarn instead to allow upgrading to happen on ci
+        cd "$app"
         yarn up @metamask/sdk-react-native
+        cd "$SDK_WORKSPACE_DIR"
         # jq '.dependencies["@metamask/sdk-react-native"] = "'"$latest_version"'"' "$PACKAGE_JSON" > "$PACKAGE_JSON.tmp" && mv "$PACKAGE_JSON.tmp" "$PACKAGE_JSON"
       fi
 


### PR DESCRIPTION
## Explanation
- improves the update-example-dapps script to bump individual dapp packages instead of using a jq replacement. This helps update the `yarn.lock` as well.
- Removes the call to update the example dapps when the trigger is `workflow_dispatch` + `IS_RELEASE=true` since this check and trigger happens on the build-dapps script.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
