### PR TITLE
chore: add metrics to analytics

### DIFF
--- a/packages/sdk-socket-server-next/src/metrics.ts
+++ b/packages/sdk-socket-server-next/src/metrics.ts
@@ -1,4 +1,10 @@
-import { collectDefaultMetrics, Gauge, Registry } from 'prom-client';
+import {
+  collectDefaultMetrics,
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+} from 'prom-client';
 
 const register = new Registry();
 
@@ -22,10 +28,87 @@ const socketIoServerTotalRooms = new Gauge({
   registers: [register],
 });
 
+const analyticsRequestsTotal = new Counter({
+  name: 'analytics_requests_total',
+  help: 'Total number of requests to the analytics endpoint',
+  labelNames: ['status'],
+  registers: [register],
+});
+
+const analyticsRequestDuration = new Histogram({
+  name: 'analytics_request_duration_seconds',
+  help: 'Duration of analytics requests',
+  labelNames: [],
+  buckets: [0.05, 0.1, 0.2, 0.5, 1], // buckets in seconds
+  registers: [register],
+});
+
+const analyticsEventsTotal = new Counter({
+  name: 'analytics_events_total',
+  help: 'Total number of analytics events',
+  labelNames: [
+    'from',
+    'with_channel_id',
+    'event_name',
+    'platform',
+    'sdk_version',
+  ],
+  registers: [register],
+});
+
+const analyticsErrors = new Counter({
+  name: 'analytics_errors_total',
+  help: 'Total number of errors in analytics processing',
+  labelNames: ['error_type'],
+  registers: [register],
+});
+
+const redisCacheOperations = new Counter({
+  name: 'redis_cache_operations_total',
+  help: 'Total number of Redis cache operations',
+  labelNames: ['operation', 'result'],
+  registers: [register],
+});
+
 export function setSocketIoServerTotalClients(count: number) {
   socketIoServerTotalClients.set(count);
 }
 
 export function setSocketIoServerTotalRooms(count: number) {
   socketIoServerTotalRooms.set(count);
+}
+
+export function setAnalyticsRequestsTotal(status: number) {
+  analyticsRequestsTotal.inc({ status });
+}
+
+export function setAnalyticsRequestDuration(duration: number) {
+  analyticsRequestDuration.observe(duration);
+}
+
+export function incrementAnalyticsEvents(
+  from: string,
+  withChannelId: boolean,
+  eventName: string,
+  platform: string,
+  sdkVersion: string,
+) {
+  analyticsEventsTotal.inc({
+    from: from,
+    with_channel_id: withChannelId ? 'true' : 'false',
+    event_name: eventName,
+    platform: platform,
+    sdk_version: sdkVersion,
+  });
+}
+
+export function incrementAnalyticsError(errorType: string) {
+  analyticsErrors.inc({ error_type: errorType });
+}
+
+export function incrementRedisCacheOperation(
+  operation: string,
+  isHit: boolean,
+) {
+  redisCacheOperations.inc({ operation, result: isHit ? 'hit' : 'miss' });
 }

--- a/packages/sdk-socket-server-next/src/middleware-metrics.ts
+++ b/packages/sdk-socket-server-next/src/middleware-metrics.ts
@@ -1,0 +1,21 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+    setAnalyticsRequestDuration,
+    setAnalyticsRequestsTotal,
+} from './metrics';
+
+export function evtMetricsMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+): void {
+    const startTime = Date.now();
+
+    res.on('finish', () => {
+        const duration = (Date.now() - startTime) / 1000;
+        setAnalyticsRequestsTotal(res.statusCode);
+        setAnalyticsRequestDuration(duration);
+    });
+
+    next();
+}


### PR DESCRIPTION
## Explanation

The current analytics endpoint ('/evt') lacks comprehensive monitoring and observability features, making it difficult to:
- Track request performance and error rates
- Monitor Redis cache effectiveness
- Understand SDK usage patterns and event distributions
- Debug issues in production

This PR adds metrics to addresses these gaps by:
1. Implementing a new metrics middleware that tracks request duration and status codes
2. Adding detailed counters for analytics events with dimensions for platform, SDK version, and event types
3. Tracking Redis cache hit/miss rates
4. Adding error tracking with error type categorization

## References

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate