### PR TITLE
fix: potential security issue with secp256k1

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   },
   "resolutions": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "secp256k1": "^5.0.1"
   }
 }

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -98,7 +98,7 @@
   },
   "peerDependencies": {
     "cross-fetch": "^4.0.0",
-    "eciesjs": "^0.3.16",
+    "eciesjs": "*",
     "eventemitter2": "^6.4.7",
     "readable-stream": "^3.6.2",
     "socket.io-client": "^4.5.1"
@@ -117,8 +117,5 @@
       "bufferutil": false,
       "utf-8-validate": false
     }
-  },
-  "resolutions": {
-    "secp256k1": "^5.0.1"
   }
 }

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -117,5 +117,8 @@
       "bufferutil": false,
       "utf-8-validate": false
     }
+  },
+  "resolutions": {
+    "secp256k1": "^5.0.1"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -51,7 +51,7 @@
     "bowser": "^2.9.0",
     "cross-fetch": "^4.0.0",
     "debug": "^4.3.4",
-    "eciesjs": "^0.4.8",
+    "eciesjs": "^0.4.10",
     "eth-rpc-errors": "^4.0.3",
     "eventemitter2": "^6.4.7",
     "i18next": "23.11.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5509,6 +5509,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ecies/ciphers@npm:^0.2.0":
+  version: 0.2.1
+  resolution: "@ecies/ciphers@npm:0.2.1"
+  peerDependencies:
+    "@noble/ciphers": ^1.0.0
+  checksum: 4a2012358f79ef842c6a9fdcf3d4e1f7d3d59ad3d025cca52b3e7135f62d5c35d394882cbfe8ad5aa17f707663921bf466707d20712b5027a0af5813a6ad7b08
+  languageName: node
+  linkType: hard
+
 "@egjs/hammerjs@npm:^2.0.17":
   version: 2.0.17
   resolution: "@egjs/hammerjs@npm:2.0.17"
@@ -9922,7 +9931,7 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     cross-fetch: ^4.0.0
-    eciesjs: ^0.3.16
+    eciesjs: "*"
     eventemitter2: ^6.4.7
     readable-stream: ^3.6.2
     socket.io-client: ^4.5.1
@@ -10545,7 +10554,7 @@ __metadata:
     bowser: ^2.9.0
     cross-fetch: ^4.0.0
     debug: ^4.3.4
-    eciesjs: ^0.4.8
+    eciesjs: ^0.4.10
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-import: ^2.23.4
@@ -26004,6 +26013,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eciesjs@npm:^0.4.10":
+  version: 0.4.10
+  resolution: "eciesjs@npm:0.4.10"
+  dependencies:
+    "@ecies/ciphers": ^0.2.0
+    "@noble/ciphers": ^1.0.0
+    "@noble/curves": ^1.6.0
+    "@noble/hashes": ^1.5.0
+  checksum: 4fd6588be41118f0b91b74d6de22d03430c148e38a1bcc711b5283a762d21b5163e7ed1b3308337f8e15a6410774b9c6fe41f0f4736b60e513987bfabd09693c
+  languageName: node
+  linkType: hard
+
 "eciesjs@npm:^0.4.4":
   version: 0.4.7
   resolution: "eciesjs@npm:0.4.7"
@@ -26012,17 +26033,6 @@ __metadata:
     "@noble/curves": ^1.4.0
     "@noble/hashes": ^1.4.0
   checksum: 222505d6135fe75e7f9c4bd76d4ce184cdd112f9047ace2b345763a343255c67bb304c60067a867c911b9feb078d2809f11d1786216fb3ff1ea0215a94becd0f
-  languageName: node
-  linkType: hard
-
-"eciesjs@npm:^0.4.8":
-  version: 0.4.8
-  resolution: "eciesjs@npm:0.4.8"
-  dependencies:
-    "@noble/ciphers": ^1.0.0
-    "@noble/curves": ^1.6.0
-    "@noble/hashes": ^1.5.0
-  checksum: ff9482b5ac488b63115e9b871b402670010e00ab773b17c6d94d493861dee9538765ad4187a1dc38c529f3e1810b6c408341e9463a3a7ea05039649941463c90
   languageName: node
   linkType: hard
 
@@ -26079,7 +26089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4, elliptic@npm:^6.5.3, elliptic@npm:^6.5.4":
+"elliptic@npm:6.5.4, elliptic@npm:^6.5.3":
   version: 6.5.4
   resolution: "elliptic@npm:6.5.4"
   dependencies:
@@ -26106,6 +26116,21 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: ec9105e4469eb3b32b0ee2579756c888ddf3f99d259aa0d65fccb906ee877768aaf8880caae73e3e669c9a4adeb3eb1945703aa974ec5000d2d33a239f4567eb
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:^6.5.7":
+  version: 6.6.0
+  resolution: "elliptic@npm:6.6.0"
+  dependencies:
+    bn.js: ^4.11.9
+    brorand: ^1.1.0
+    hash.js: ^1.0.0
+    hmac-drbg: ^1.0.1
+    inherits: ^2.0.4
+    minimalistic-assert: ^1.0.1
+    minimalistic-crypto-utils: ^1.0.1
+  checksum: e912349b883e694bfe65005214237a470c9a098a6ba36fd24396d0ab07feb399920c0738aeed1aed6cf5dca9c64fd479e212faed3a75c9d81453671ef0de5157
   languageName: node
   linkType: hard
 
@@ -44471,27 +44496,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secp256k1@npm:^4.0.1":
-  version: 4.0.3
-  resolution: "secp256k1@npm:4.0.3"
+"secp256k1@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "secp256k1@npm:5.0.1"
   dependencies:
-    elliptic: ^6.5.4
-    node-addon-api: ^2.0.0
-    node-gyp: latest
-    node-gyp-build: ^4.2.0
-  checksum: 21e219adc0024fbd75021001358780a3cc6ac21273c3fcaef46943af73969729709b03f1df7c012a0baab0830fb9a06ccc6b42f8d50050c665cb98078eab477b
-  languageName: node
-  linkType: hard
-
-"secp256k1@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "secp256k1@npm:5.0.0"
-  dependencies:
-    elliptic: ^6.5.4
+    elliptic: ^6.5.7
     node-addon-api: ^5.0.0
     node-gyp: latest
     node-gyp-build: ^4.2.0
-  checksum: a0719dff4687c38d385b5e0b7e811c51a4ea24893128be9d097aee99f879eb0ea52582590deb15a49da627a3db23c6b028ad5c9c6ac1fca92ce760153b8cf21c
+  checksum: e21fb801502fe03a233f04c294cfdf16bd6087c36caa6514ccc5eac38ebd5ff50090a59d0ee7d50adf87f6d508a8211d09b905290fac97b4d43751967b7dfd9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Updates `secp256k1` to version 5.0.1 and related ECIES dependencies to prevent a vulnerability where private keys could be extracted through malicious ECDH operations using invalid curve points.

- Pin `secp256k1` to `^5.0.1` in resolutions
- Update `eciesjs` dependencies across SDK packages
- Adjust peer dependency requirements for `eciesjs`

### Security Impact
Prevents an attack vector where an attacker could extract private keys using specially crafted public keys with low-cardinality curves through as few as 11 ECDH sessions.

## References

- https://github.com/advisories/GHSA-584q-6j8j-r5pm
- https://consensyssoftware.atlassian.net/jira/software/projects/SDK/boards/711?selectedIssue=SDK-131&sprintStarted=true

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
