### PR TITLE
feat(root): expose global github hooks while using husky

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Call your personal global hook if it exists
+if [ -x "$HOME/.config/git/hooks/prepare-commit-msg" ]; then
+  "$HOME/.config/git/hooks/prepare-commit-msg" "$1" "$2" "$3"
+fi


### PR DESCRIPTION
## Explanation

Because the monorepo uses husky, it prevents calling the user installed global git hooks.
This allow user to still run their custom git hooks.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
