### PR TITLE
Release 101.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "100.0.0",
+  "version": "101.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-communication-layer",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2]
+### Uncategorized
+- align version with sdk
+
 ## [0.30.0]
 
 ## [0.29.2]
@@ -154,7 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub actions workflows ([#102](https://github.com/MetaMask/metamask-sdk/pull/102))
 - [FEAT] Yarn v3 migration ([#100](https://github.com/MetaMask/metamask-sdk/pull/100))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.30.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.30.2...HEAD
+[0.30.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.30.0...@metamask/sdk-install-modal-web@0.30.2
 [0.30.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.29.2...@metamask/sdk-install-modal-web@0.30.0
 [0.29.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.29.1...@metamask/sdk-install-modal-web@0.29.2
 [0.29.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-install-modal-web@0.28.1...@metamask/sdk-install-modal-web@0.29.1

--- a/packages/sdk-install-modal-web/package.json
+++ b/packages/sdk-install-modal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-install-modal-web",
-  "version": "0.30.0",
+  "version": "0.30.2",
   "description": "MetaMask SDK Install Modal for Web",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {

--- a/packages/sdk-react/CHANGELOG.md
+++ b/packages/sdk-react/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2]
+### Uncategorized
+- align version with sdk
+
 ## [0.30.0]
 
 ## [0.29.2]
@@ -270,7 +274,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] publishing config ([#135](https://github.com/MetaMask/metamask-sdk/pull/135))
 - [feat] initial beta released
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.30.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.30.2...HEAD
+[0.30.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.30.0...@metamask/sdk-react@0.30.2
 [0.30.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.29.2...@metamask/sdk-react@0.30.0
 [0.29.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.29.1...@metamask/sdk-react@0.29.2
 [0.29.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-react@0.29.0...@metamask/sdk-react@0.29.1

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-react",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "A react component and react hooks to connect and use MetaMask",
   "homepage": "https://github.com/MetaMask/metamask-sdk",
   "bugs": {

--- a/packages/sdk-ui/CHANGELOG.md
+++ b/packages/sdk-ui/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2]
+### Uncategorized
+- chore: force new version detection ([#1121](https://github.com/MetaMask/metamask-sdk/pull/1121))
+
 ## [0.30.0]
 
 ## [0.29.1]
@@ -97,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: optimize rollup builds ([#496](https://github.com/MetaMask/metamask-sdk/pull/496))
 - fix: linting changelog issue after updating scripts ([#509](https://github.com/MetaMask/metamask-sdk/pull/509))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.30.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.30.2...HEAD
+[0.30.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.30.0...@metamask/sdk-ui@0.30.2
 [0.30.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.29.1...@metamask/sdk-ui@0.30.0
 [0.29.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.29.0...@metamask/sdk-ui@0.29.1
 [0.29.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-ui@0.28.0...@metamask/sdk-ui@0.29.0

--- a/packages/sdk-ui/package.json
+++ b/packages/sdk-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-ui",
-  "version": "0.30.0",
+  "version": "0.30.2",
   "description": "MetaMask SDK cross-platform ui library",
   "module": "dist/esm/index.js",
   "types": "dist/esm/dist/src/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## sdk [0.30.2]
### Added
- fix: potential security issue with secp256k1 ([#1111](https://github.com/MetaMask/metamask-sdk/pull/1111))
- chore: remove the alert of 'SDK Connection has been terminated' ([#1095](https://github.com/MetaMask/metamask-sdk/pull/1095))
- fix: chainId for sepolia in infura rpc map ([#1105](https://github.com/MetaMask/metamask-sdk/pull/1105))
