### PR TITLE
chore: removes sdk terminate when accountsChanged comes in empty

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
@@ -80,12 +80,9 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
           }
 
           if (isExtensionActive && (accounts as string[])?.length === 0) {
-            instance.terminate().catch((error) => {
-              logger(
-                `[MetaMaskSDK: setupExtensionPreferences()] Error terminating`,
-                error,
-              );
-            });
+            logger(
+              `[MetaMaskSDK: setupExtensionPreferences()] permissions were revoked on extension or extension was locked`,
+            );
           }
         },
       );


### PR DESCRIPTION
## Explanation
Historically, when creating the initial versions of the SDK we wanted to create a mechanism to detect when a connection was terminated while the dapp was not on focus both on mobile and extension.
On mobile to mobile and mobile - desktop interactions we're able to do this async via socket server but with extension since we're wrapping the already existent injected provider, we don't make use of socket.io code so for the initial versions of the MMSDK we assumed that getting an event `accountsChanged=[]` would mean that the permitted accounts were removed from extension and thus the connection is no longer valid. 
The problem with this approach is that when MetaMask extension is simply locked while keeping permissions it sends an `accountsChanged=[]` event as required by EIP-1193.

This PR addresses this issue removing the terminate from extension following the same behavior as when using wallet_api.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
