### PR TITLE
fix: Tell webpack about dynamic import + fixed polyfills

### DIFF
--- a/packages/sdk-install-modal-web/stencil.config.ts
+++ b/packages/sdk-install-modal-web/stencil.config.ts
@@ -11,7 +11,7 @@ export const config: Config = {
     },
   ],
   enableCache: true,
-  buildEs5: true,
+  buildEs5: false,
   // Add hash for file names for better caching
   hashFileNames: true,
   excludeUnusedDependencies: true,

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -98,6 +98,7 @@
     "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-jscc": "^2.0.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-polyfill-node": "^0.13.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.36.0",

--- a/packages/sdk-react/rollup.config.js
+++ b/packages/sdk-react/rollup.config.js
@@ -4,6 +4,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import external from 'rollup-plugin-peer-deps-external';
 import { terser } from 'rollup-plugin-terser';
+import globals from 'rollup-plugin-polyfill-node';
 
 const packageJson = require('./package.json');
 
@@ -35,8 +36,16 @@ const config = [
         browser: true,
       }),
       commonjs(),
+      globals({
+        include: null,
+      }),
       json(),
-      terser(),
+      terser({
+        format: {
+          // keep all /* webpack*: * */ comments and /* vite-*: * */ comments
+          comments: (_, comment) => comment.value.includes("webpack") || comment.value.includes("vite")
+        }
+      }),
     ],
   },
   {
@@ -60,8 +69,16 @@ const config = [
         preferBuiltins: true,
       }),
       commonjs(),
+      globals({
+        include: null,
+      }),
       json(),
-      terser(),
+      terser({
+        format: {
+          // keep all /* webpack*: * */ comments and /* vite-*: * */ comments
+          comments: (_, comment) => comment.value.includes("webpack") || comment.value.includes("vite")
+        }
+      }),
     ],
   }
 ];

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -131,7 +131,6 @@
     "rollup-plugin-jscc": "^2.0.0",
     "rollup-plugin-natives": "^0.7.5",
     "rollup-plugin-node-builtins": "^2.1.2",
-    "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "rollup-plugin-sizes": "^1.0.6",
     "rollup-plugin-typescript2": "^0.31.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11269,6 +11269,7 @@ __metadata:
     rollup-plugin-node-builtins: ^2.1.2
     rollup-plugin-node-globals: ^1.4.0
     rollup-plugin-peer-deps-external: ^2.2.4
+    rollup-plugin-polyfill-node: ^0.13.0
     rollup-plugin-postcss: ^4.0.2
     rollup-plugin-terser: ^7.0.2
     rollup-plugin-typescript2: ^0.36.0
@@ -11606,7 +11607,6 @@ __metadata:
     rollup-plugin-jscc: ^2.0.0
     rollup-plugin-natives: ^0.7.5
     rollup-plugin-node-builtins: ^2.1.2
-    rollup-plugin-node-globals: ^1.4.0
     rollup-plugin-polyfill-node: ^0.13.0
     rollup-plugin-sizes: ^1.0.6
     rollup-plugin-typescript2: ^0.31.2


### PR DESCRIPTION
## Explanation

This PR fixes a few things when bundling the SDK with projects using WebPack

1. Disable `es5Builds` in StencilJS
    - This is not needed and is causing issues with not including webpack/vite magic comments in import statements 
2. Add a `/* webpackIgnore: true */` comment to the generated dynamic import that StencilJS creates
    - This is done via a custom rollup plugin to inject the comment via a regex match
3. Replace the `globals()` plugin with a more modern polyfill
    - Since StencilJS is no longer building es5, the old `globals()` plugin was having parsing issues. This plugin has been replaced with the [modern replacement](https://www.npmjs.com/package/rollup-plugin-polyfill-node)
    - The configuration for this plugin needs `include: null` to ensure that all files (including source files) are included in the plugin transformation (`Pass in null to transform all files, including all files including any source files.` from [here](https://www.npmjs.com/package/rollup-plugin-polyfill-node#options))
4. Instruct terser to **not** strip magic comments relating to `vite` and `webpack`
    - This is needed so other downstream bundlers know how to resolve the dynamic import introduced by StencilJS

I've tested that this fixes the existing issue with Rainbowkit + that devnext + react-demo all work.

## References

Fixes wevm/wagmi#4429

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [N/A] I've highlighted breaking changes using the "BREAKING" category above as appropriate
