### PR TITLE
Set initial modal tab based on preferDesktop option

### DIFF
--- a/packages/sdk-install-modal-web/src/components.d.ts
+++ b/packages/sdk-install-modal-web/src/components.d.ts
@@ -27,6 +27,7 @@ export namespace Components {
           * The QR code link
          */
         "link": string;
+        "preferDesktop": boolean;
         "sdkVersion"?: string;
     }
 }
@@ -133,6 +134,7 @@ declare namespace LocalJSX {
         "link"?: string;
         "onClose"?: (event: MmSelectModalCustomEvent<{ shouldTerminate?: boolean }>) => void;
         "onConnectWithExtension"?: (event: MmSelectModalCustomEvent<any>) => void;
+        "preferDesktop"?: boolean;
         "sdkVersion"?: string;
     }
     interface IntrinsicElements {

--- a/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
+++ b/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
@@ -42,7 +42,7 @@ export class InstallModal {
     this.onStartDesktopOnboardingHandler = this.onStartDesktopOnboardingHandler.bind(this);
     this.setTab = this.setTab.bind(this);
     this.render = this.render.bind(this);
-    this.setTab(2);
+    this.setTab(this.preferDesktop ? 1 : 2);
 
     this.i18nInstance = new SimpleI18n();
   }

--- a/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
+++ b/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
@@ -33,6 +33,8 @@ export class InstallModal {
 
   @State() tab: number = 1;
 
+  @State() isDefaultTab: boolean = true;
+
   @Element() el: HTMLElement;
 
   @State() private translationsLoaded: boolean = false;
@@ -65,10 +67,6 @@ export class InstallModal {
 
   @Watch('link')
   updateLink(newLink: string) {
-    if (!this.translationsLoaded || this.tab !== 2) {
-      return;
-    }
-
     const svgElement = encodeQR(newLink, "svg", {
       ecc: "medium",
       scale: 2
@@ -113,6 +111,7 @@ export class InstallModal {
 
   setTab(newTab: number) {
     this.tab = newTab
+    this.isDefaultTab = false;
   }
 
   componentDidLoad() {
@@ -125,6 +124,8 @@ export class InstallModal {
     }
 
     const t = (key: string) => this.i18nInstance.t(key);
+
+    const currentTab = this.isDefaultTab ? this.preferDesktop ? 1 : 2 : this.tab
 
     return (
       <WidgetWrapper className="install-model">
@@ -145,19 +146,19 @@ export class InstallModal {
               <div class='flexContainer'>
                 <div
                   onClick={() => this.setTab(1)}
-                  class={`tab flexItem ${this.tab === 1 ? 'tabactive': ''}`}
+                  class={`tab flexItem ${currentTab === 1 ? 'tabactive': ''}`}
                 >
                   {t('DESKTOP')}
                 </div>
                 <div
                   onClick={() => this.setTab(2)}
-                  class={`tab flexItem ${this.tab === 2 ? 'tabactive': ''}`}
+                  class={`tab flexItem ${currentTab === 2 ? 'tabactive': ''}`}
                 >
                   {t('MOBILE')}
                 </div>
               </div>
             </div>
-            <div style={{ display: this.tab === 1 ? 'none' : 'block' }}>
+            <div style={{ display: currentTab === 1 ? 'none' : 'block' }}>
               <div class='flexContainer'>
                 <div
                   class='flexItem'
@@ -177,7 +178,7 @@ export class InstallModal {
                 </div>
               </div>
             </div>
-            <div style={{ display: this.tab === 2 ? 'none' : 'block' }}>
+            <div style={{ display: currentTab === 2 ? 'none' : 'block' }}>
               <div class='item'>
                 <AdvantagesListItem
                   Icon={HeartIcon}

--- a/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
+++ b/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
@@ -65,44 +65,6 @@ export class InstallModal {
     }
   }
 
-  @Watch('link')
-  updateLink(newLink: string) {
-    const svgElement = encodeQR(newLink, "svg", {
-      ecc: "medium",
-      scale: 2
-    });
-
-    if (!this.el.shadowRoot) {
-      console.warn('Shadow root not found, will try again in 100ms');
-      setTimeout(() => this.updateLink(newLink), 100);
-      return;
-    }
-
-    const qrcodeDiv = this.el.shadowRoot.querySelector("#sdk-mm-qrcode");
-
-    if (!qrcodeDiv) {
-      console.warn('QR code div not found, will try again in 100ms');
-      setTimeout(() => this.updateLink(newLink), 100);
-      return;
-    }
-
-    qrcodeDiv.innerHTML = svgElement;
-  }
-
-  @Watch('translationsLoaded')
-  onTranslationsLoaded(isLoaded: boolean) {
-    if (isLoaded && this.tab === 2) {
-      this.updateLink(this.link);
-    }
-  }
-
-  @Watch('tab')
-  onTabChange(newTab: number) {
-    if (newTab === 2 && this.translationsLoaded) {
-      this.updateLink(this.link);
-    }
-  }
-
   onClose() {
     this.close.emit();
   }
@@ -116,10 +78,6 @@ export class InstallModal {
     this.isDefaultTab = false;
   }
 
-  componentDidLoad() {
-    this.updateLink(this.link);
-  }
-
   render() {
     if (!this.translationsLoaded) {
       return null; // or a loading state
@@ -128,6 +86,13 @@ export class InstallModal {
     const t = (key: string) => this.i18nInstance.t(key);
 
     const currentTab = this.isDefaultTab ? this.preferDesktop ? 1 : 2 : this.tab
+
+    const svgElement = encodeQR(this.link, "svg", {
+      ecc: "medium",
+      scale: 2
+    });
+
+    console.log(`Showing modal with link ${this.link} and SVG QRCode ${svgElement}`)
 
     return (
       <WidgetWrapper className="install-model">
@@ -169,8 +134,11 @@ export class InstallModal {
                     marginTop: '4',
                   }}
                 >
-                  <div id="sdk-mm-qrcode" class='center'>
-                  </div>
+                  {
+                    svgElement && (
+                      <div id="sdk-mm-qrcode" class='center' innerHTML={svgElement} />
+                    )
+                  }
                   <div class='connectMobileText'>
                     {t('SCAN_TO_CONNECT')} <br />
                     <span class='blue'>

--- a/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
+++ b/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
@@ -73,14 +73,16 @@ export class InstallModal {
     });
 
     if (!this.el.shadowRoot) {
-      console.warn('Shadow root not found');
+      console.warn('Shadow root not found, will try again in 100ms');
+      setTimeout(() => this.updateLink(newLink), 100);
       return;
     }
 
     const qrcodeDiv = this.el.shadowRoot.querySelector("#sdk-mm-qrcode");
 
     if (!qrcodeDiv) {
-      console.warn('QR code div not found');
+      console.warn('QR code div not found, will try again in 100ms');
+      setTimeout(() => this.updateLink(newLink), 100);
       return;
     }
 

--- a/packages/sdk-install-modal-web/src/components/mm-select-modal/mm-select-modal.tsx
+++ b/packages/sdk-install-modal-web/src/components/mm-select-modal/mm-select-modal.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, Event, EventEmitter, State, Watch, Element } from '@stencil/core';
+import { Component, Prop, h, Event, EventEmitter, State, Element, Watch } from '@stencil/core';
 import { WidgetWrapper } from '../widget-wrapper/widget-wrapper';
 import SDKVersion from '../misc/SDKVersion';
 import CloseButton from '../misc/CloseButton';
@@ -21,6 +21,8 @@ export class SelectModal {
 
   @Prop() sdkVersion?: string;
 
+  @Prop() preferDesktop: boolean;
+
   private i18nInstance: SimpleI18n;
 
   @Event() close: EventEmitter<{ shouldTerminate?: boolean }>;
@@ -29,12 +31,15 @@ export class SelectModal {
 
   @State() tab: number = 1;
 
+  @State() isDefaultTab: boolean = true;
+
   @Element() el: HTMLElement;
 
   @State() private translationsLoaded: boolean = false;
 
   constructor() {
     this.i18nInstance = new SimpleI18n();
+    this.setTab(this.preferDesktop ? 1 : 2);
   }
 
   async connectedCallback() {
@@ -54,30 +59,20 @@ export class SelectModal {
 
   setTab(tab: number) {
     this.tab = tab;
-  }
-
-  @Watch('link')
-  updateLink(newLink: string) {
-    const svgElement = encodeQR(newLink, "svg", {
-      ecc: "medium",
-      scale: 2
-    })
-
-    if (!this.el.shadowRoot) {
-      return;
-    }
-
-    const qrcodeDiv = this.el.shadowRoot.querySelector("#sdk-mm-qrcode");
-
-    if (!qrcodeDiv) {
-      return;
-    }
-
-    qrcodeDiv.innerHTML = svgElement
+    this.isDefaultTab = false;
   }
 
   disconnectedCallback() {
     this.onClose();
+  }
+
+  @Watch('preferDesktop')
+  updatePreferDesktop(newValue: boolean) {
+    if (newValue) {
+      this.setTab(1);
+    } else {
+      this.setTab(2);
+    }
   }
 
   render() {
@@ -88,6 +83,13 @@ export class SelectModal {
     const t = (key: string) => this.i18nInstance.t(key);
 
     const sdkVersion = this.sdkVersion
+
+    const currentTab = this.isDefaultTab ? this.preferDesktop ? 1 : 2 : this.tab
+
+    const svgElement = encodeQR(this.link, "svg", {
+      ecc: "medium",
+      scale: 2
+    })
 
     return (
       <WidgetWrapper className="select-modal">
@@ -108,19 +110,19 @@ export class SelectModal {
               <div class='flexContainer'>
                 <div
                   onClick={() => this.setTab(1)}
-                  class={`tab flexItem ${this.tab === 1 ? 'tabactive' : ''}`}
+                  class={`tab flexItem ${currentTab === 1 ? 'tabactive' : ''}`}
                 >
                   {t('DESKTOP')}
                 </div>
                 <div
                   onClick={() => this.setTab(2)}
-                  class={`tab flexItem ${this.tab === 2 ? 'tabactive' : ''}`}
+                  class={`tab flexItem ${currentTab === 2 ? 'tabactive' : ''}`}
                 >
                   {t('MOBILE')}
                 </div>
               </div>
             </div>
-            <div style={{ display: this.tab === 1 ? 'none' : 'block' }}>
+            <div style={{ display: currentTab === 1 ? 'none' : 'block' }}>
               <div class='flexContainer'>
                 <div
                   class='flexItem'
@@ -129,7 +131,7 @@ export class SelectModal {
                     marginTop: '4',
                   }}
                 >
-                  <div class='center' id="sdk-mm-qrcode" />
+                  <div class='center' id="sdk-mm-qrcode" innerHTML={svgElement} />
                   <div class='connectMobileText'>
                     {t('SCAN_TO_CONNECT')}
                     <br />
@@ -140,7 +142,7 @@ export class SelectModal {
                 </div>
               </div>
             </div>
-            <div style={{ display: this.tab === 2 ? 'none' : 'block' }}>
+            <div style={{ display: currentTab === 2 ? 'none' : 'block' }}>
               <div
                 style={{
                   display: 'flex',

--- a/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/InstallModal-web.ts
@@ -81,6 +81,7 @@ const sdkWebInstallModal = ({
           },
           onClose: unmount,
           link,
+          preferDesktop: preferDesktop ?? false,
         })
         .catch((err) => {
           console.error(err);

--- a/packages/sdk/src/ui/InstallModal/Modal-web.ts
+++ b/packages/sdk/src/ui/InstallModal/Modal-web.ts
@@ -92,6 +92,7 @@ export default class ModalLoader {
     ) as HTMLMmSelectModalElement;
     modal.link = props.link;
     modal.sdkVersion = props.sdkVersion ?? this.sdkVersion;
+    modal.preferDesktop = props.preferDesktop;
     modal.addEventListener('close', ({ detail: { shouldTerminate } }) =>
       props.onClose(shouldTerminate),
     );


### PR DESCRIPTION
## Explanation

This PR fixes a bug that was introduced when migrating to the new web component based modals. The initial tab displayed was always mobile, even if `preferDesktop` was set to `true`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [N/A] I've highlighted breaking changes using the "BREAKING" category above as appropriate
