### PR TITLE
fix: remove exports from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "rimraf": "^3.0.2",
     "serve": "^14.2.1",
     "ts-jest": "^29.0.3",
-    "typescript": "5.7.2"
+    "typescript": "4.3.5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "rimraf": "^3.0.2",
     "serve": "^14.2.1",
     "ts-jest": "^29.0.3",
-    "typescript": "^4.3.5"
+    "typescript": "5.7.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,27 +11,6 @@
     "url": "https://github.com/MetaMask/metamask-sdk",
     "directory": "packages/sdk"
   },
-  "exports": {
-    ".": {
-      "node": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/node/es/metamask-sdk.js",
-        "require": "./dist/node/cjs/metamask-sdk.js"
-      },
-      "browser": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/browser/es/metamask-sdk.js"
-      },
-      "react-native": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/react-native/es/metamask-sdk.js"
-      },
-      "default": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/browser/es/metamask-sdk.js"
-      }
-    }
-  },
   "main": "dist/node/cjs/metamask-sdk.js",
   "module": "dist/browser/es/metamask-sdk.js",
   "browser": "dist/browser/es/metamask-sdk.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38093,7 +38093,7 @@ __metadata:
     serve: ^14.2.1
     ts-jest: ^29.0.3
     ts-node: ^10.9.1
-    typescript: 5.7.2
+    typescript: 4.3.5
   languageName: unknown
   linkType: soft
 
@@ -49507,6 +49507,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:4.3.5":
+  version: 4.3.5
+  resolution: "typescript@npm:4.3.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: bab033b5e2b0790dd35b77fd005df976ef80b8d84fd2c6e63cc31808151875beae9216e5a315fe7068e8499905c3c354248fe83272cdfc13b7705635f0c66c97
+  languageName: node
+  linkType: hard
+
 "typescript@npm:4.8.4":
   version: 4.8.4
   resolution: "typescript@npm:4.8.4"
@@ -49524,16 +49534,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: bef1dcd166acfc6934b2ec4d72f93edb8961a5fab36b8dd2aaf6f4f4cd5c0210f2e0850aef4724f3b4913d5aef203a94a28ded731b370880c8bcff7e4ff91fc1
-  languageName: node
-  linkType: hard
-
-"typescript@npm:5.7.2":
-  version: 5.7.2
-  resolution: "typescript@npm:5.7.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: b55300c4cefee8ee380d14fa9359ccb41ff8b54c719f6bc49b424899d662a5ce62ece390ce769568c7f4d14af844085255e63788740084444eb12ef423b13433
   languageName: node
   linkType: hard
 
@@ -49597,6 +49597,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@patch:typescript@4.3.5#~builtin<compat/typescript>":
+  version: 4.3.5
+  resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=dba6d9"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 365df18cf979c971ef9543b2acaa8694377a803f98e1804c41d0ede0b09d7046cb0cd98f2eaf3884b0fe923c01a60af1f653841bd8805c9715d5479c09a4ebe4
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@4.8.4#~builtin<compat/typescript>":
   version: 4.8.4
   resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=1a91c8"
@@ -49614,16 +49624,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 0411be9e19bf6a547d574b3261fa8598f55a5243123f2a50a79b0dc15a017abbf541f15b8b43331294e409cc978e548ac5ae4e0c5b98ba5ae98029304de047be
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@5.7.2#~builtin<compat/typescript>":
-  version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#~builtin<compat/typescript>::version=5.7.2&hash=77c9e2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 803430c6da2ba73c25a21880d8d4f08a56d9d2444e6db2ea949ac4abceeece8e4a442b7b9b585db7d8a0b47ebda2060e45fe8ee8b8aca23e27ec1d4844987ee6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -38093,7 +38093,7 @@ __metadata:
     serve: ^14.2.1
     ts-jest: ^29.0.3
     ts-node: ^10.9.1
-    typescript: ^4.3.5
+    typescript: 5.7.2
   languageName: unknown
   linkType: soft
 
@@ -49527,7 +49527,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.3.2, typescript@npm:^4.3.5, typescript@npm:^4.7.4":
+"typescript@npm:5.7.2":
+  version: 5.7.2
+  resolution: "typescript@npm:5.7.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: b55300c4cefee8ee380d14fa9359ccb41ff8b54c719f6bc49b424899d662a5ce62ece390ce769568c7f4d14af844085255e63788740084444eb12ef423b13433
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.3.2, typescript@npm:^4.7.4":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
@@ -49607,7 +49617,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.3.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@5.7.2#~builtin<compat/typescript>":
+  version: 5.7.2
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#~builtin<compat/typescript>::version=5.7.2&hash=77c9e2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 803430c6da2ba73c25a21880d8d4f08a56d9d2444e6db2ea949ac4abceeece8e4a442b7b9b585db7d8a0b47ebda2060e45fe8ee8b8aca23e27ec1d4844987ee6
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.3.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:


### PR DESCRIPTION
## Explanation

This PR removes the `exports` field from the Metamask SDK `package.json` to resolve build issues experienced in Next.js + Wagmi integrations. It also upgrades TypeScript to ensure compatibility and maintain stable compilation after removing the `exports` configuration.

## References

No specific issue references.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
