### PR TITLE
fix(MetaMaskInstaller): replace delete with assignment to undefined for window.ethereum

### DIFF
--- a/packages/sdk/src/services/MetaMaskInstaller/startDesktopOnboarding.ts
+++ b/packages/sdk/src/services/MetaMaskInstaller/startDesktopOnboarding.ts
@@ -18,7 +18,9 @@ export async function startDesktopOnboarding() {
   );
 
   Ethereum.destroy();
-  delete window.ethereum;
+  if (window.ethereum) {
+    window.ethereum = undefined;
+  }
   const onboardingExtension = new MetaMaskOnboarding();
   onboardingExtension.startOnboarding();
 }


### PR DESCRIPTION
## Explanation

The change replaces delete window.ethereum with window.ethereum = undefined to safely clear the ethereum property without removing it from the window object. This approach ensures safer handling of the ethereum provider and avoids side effects from property deletion.

## References

Fixes #1131

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
