### PR TITLE
fix: re-create nextjs build fix pr

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,27 +11,6 @@
     "url": "https://github.com/MetaMask/metamask-sdk",
     "directory": "packages/sdk"
   },
-  "exports": {
-    ".": {
-      "node": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/node/es/metamask-sdk.js",
-        "require": "./dist/node/cjs/metamask-sdk.js"
-      },
-      "browser": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/browser/es/metamask-sdk.js"
-      },
-      "react-native": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/react-native/es/metamask-sdk.js"
-      },
-      "default": {
-        "types": "./dist/types/src/index.d.ts",
-        "import": "./dist/browser/es/metamask-sdk.js"
-      }
-    }
-  },
   "main": "dist/node/cjs/metamask-sdk.js",
   "module": "dist/browser/es/metamask-sdk.js",
   "browser": "dist/browser/es/metamask-sdk.js",


### PR DESCRIPTION
## Explanation
This PR removes the exports field from the Metamask SDK package.json to resolve build issues experienced in Next.js + Wagmi integrations. It also upgrades TypeScript to ensure compatibility and maintain stable compilation after removing the exports configuration.

Re-create https://github.com/MetaMask/metamask-sdk/pull/1161

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
