### PR TITLE
fix(analytics): improve dapp details tracking and SDK RPC request analytics

### DIFF
--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -1,3 +1,8 @@
+import {
+  TrackingEvents,
+  SendAnalytics,
+  DEFAULT_SERVER_URL,
+} from '@metamask/sdk-communication-layer';
 import { RemoteCommunicationPostMessageStream } from '../../PostMessageStream/RemoteCommunicationPostMessageStream';
 import { METHODS_TO_REDIRECT, RPC_METHODS } from '../../config';
 import {
@@ -67,6 +72,24 @@ export async function write(
         .catch((err: unknown) => {
           logger(`[RCPMS: _write()] error sending message`, err);
         });
+    } else {
+      try {
+        // Only send analytics if we are not sending via network.
+        await SendAnalytics(
+          {
+            id: channelId,
+            event: TrackingEvents.SDK_RPC_REQUEST,
+            params: {
+              method: targetMethod,
+              from: 'mobile',
+            },
+          },
+          instance.state.remote?.state.communicationServerUrl ??
+            DEFAULT_SERVER_URL,
+        );
+      } catch (error) {
+        logger(`[RCPMS: _write()] error sending analytics`, error);
+      }
     }
 
     if (!isSecure) {


### PR DESCRIPTION
# Description
This PR addresses two critical analytics-related issues that were causing missing dapp details and incomplete event tracking:

## Issue 1: Missing SDK RPC Request Analytics
When using the deeplink protocol, the SDK would directly open the deeplink without going through the network path, causing analytics events to be missed. This PR ensures analytics events are properly tracked regardless of the communication method used.

### Changes:
- Added analytics tracking for SDK RPC requests when not using network communication
- Implemented `SendAnalytics` function to log `SDK_RPC_REQUEST` events with method and source information
- Maintained existing network path analytics while adding coverage for direct deeplink interactions

## Issue 2: Invalid Cached Dapp Details
The system was not properly validating cached dapp information in Redis, leading to events being sent without proper dapp details.

### Changes:
- Enhanced validation of cached channel information
- Added explicit checks for URL and dappId presence in cached data
- Improved logging for cases with empty or invalid cached channel info
- Refactored cache operation tracking for better monitoring
- Removed deprecated SDK version ID constant

### Technical Implementation:
- Added validation logic to verify cached channel info contains valid URL
- Improved error logging for debugging cache-related issues
- Refactored Redis cache operation tracking for better clarity
- Enhanced type safety with proper null checks and boolean operations

## Breaking Changes
None. This PR maintains backward compatibility while improving analytics tracking reliability.

## Testing Instructions
1. Test SDK RPC Request Analytics:
   - Connect to a dapp using deeplink protocol
   - Verify analytics events are sent for RPC requests
   - Check that method and source information are correctly captured

2. Test Dapp Details Caching:
   - Connect to a dapp and verify proper caching of dapp details
   - Refresh the dapp and confirm cached details are properly validated
   - Verify analytics events contain complete dapp information

# Related Issues
- Fixes SDK-199: Missing dapp details in analytics

