### PR TITLE
refactor(sdk): always send RPC requests via network and deeplink

### DIFF
--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -1,8 +1,3 @@
-import {
-  TrackingEvents,
-  SendAnalytics,
-  DEFAULT_SERVER_URL,
-} from '@metamask/sdk-communication-layer';
 import { RemoteCommunicationPostMessageStream } from '../../PostMessageStream/RemoteCommunicationPostMessageStream';
 import { METHODS_TO_REDIRECT, RPC_METHODS } from '../../config';
 import {

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -63,6 +63,23 @@ export async function write(
 
   try {
     if (!activeDeeplinkProtocol || triggeredInstaller) {
+      // Add to rpc method tracker first then send the event to simulate sending from network.
+      const rpcMethodTracker = instance.state.remote?.getRPCMethodTracker();
+      if (rpcMethodTracker) {
+        const rpcId = data?.data?.id;
+        console.warn(
+          `[RCPMS: _write()] rpcId=${rpcId} targetMethod=${targetMethod}`,
+        );
+
+        if (rpcId) {
+          rpcMethodTracker[rpcId] = {
+            id: rpcId,
+            method: targetMethod,
+            timestamp: Date.now(),
+          };
+        }
+      }
+
       // The only reason not to send via network is because the rpc call will be sent in the deeplink
       instance.state.remote
         ?.sendMessage(data?.data)
@@ -74,6 +91,10 @@ export async function write(
         });
     } else {
       try {
+        console.warn(
+          `[RCPMS: _write()] sending analytics method=${targetMethod}`,
+        );
+
         // Only send analytics if we are not sending via network.
         await SendAnalytics(
           {

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -63,23 +63,6 @@ export async function write(
 
   try {
     if (!activeDeeplinkProtocol || triggeredInstaller) {
-      // Add to rpc method tracker first then send the event to simulate sending from network.
-      const rpcMethodTracker = instance.state.remote?.getRPCMethodTracker();
-      if (rpcMethodTracker) {
-        const rpcId = data?.data?.id;
-        console.warn(
-          `[RCPMS: _write()] rpcId=${rpcId} targetMethod=${targetMethod}`,
-        );
-
-        if (rpcId) {
-          rpcMethodTracker[rpcId] = {
-            id: rpcId,
-            method: targetMethod,
-            timestamp: Date.now(),
-          };
-        }
-      }
-
       // The only reason not to send via network is because the rpc call will be sent in the deeplink
       instance.state.remote
         ?.sendMessage(data?.data)
@@ -91,9 +74,24 @@ export async function write(
         });
     } else {
       try {
-        console.warn(
-          `[RCPMS: _write()] sending analytics method=${targetMethod}`,
-        );
+        // Add to rpc method tracker first then send the event to simulate sending from network.
+        const rpcMethodTracker = instance.state.remote?.getRPCMethodTracker();
+        if (rpcMethodTracker) {
+          const rpcId = data?.data?.id;
+          if (rpcId) {
+            rpcMethodTracker[rpcId] = {
+              id: rpcId,
+              method: targetMethod,
+              timestamp: Date.now(),
+            };
+          }
+
+          logger(
+            `[RCPMS: _write()] rpcMethodTracker`,
+            rpcMethodTracker,
+            data?.data,
+          );
+        }
 
         // Only send analytics if we are not sending via network.
         await SendAnalytics(


### PR DESCRIPTION
# Description
This PR simplifies the RPC message handling strategy by sending requests through both network and deeplink channels simultaneously, allowing the wallet to process whichever arrives first. This approach eliminates edge cases and improves reliability while maintaining backward compatibility.

## Technical Details
- Previously, we conditionally sent RPC requests either via network or deeplink based on protocol availability
- Now, we:
  1. Always send RPC requests via network for consistency and reliability
  2. Allow deeplink protocol to handle requests in parallel when available
  3. Let the wallet deduplicate and process only the first received request
  4. Remove conditional analytics sending since it's now handled uniformly

## Migration
No migration steps required. This is a transparent change that maintains backward compatibility.

Related:
- Follow-up to #1179
- Improves reliability of RPC tracking and request handling