### PR TITLE
chore: call getPermissions on accountsChanged when using extension

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.test.ts
@@ -1,6 +1,8 @@
 import { TrackingEvents } from '@metamask/sdk-communication-layer';
 import { MetaMaskSDK } from '../../../sdk';
+import { SDKProvider } from '../../../provider/SDKProvider';
 import { getBrowserExtension } from '../../../utils/get-browser-extension';
+import { EXTENSION_EVENTS, RPC_METHODS } from '../../../config';
 import { setupExtensionPreferences } from './setupExtensionPreferences';
 
 jest.mock('../../../utils/get-browser-extension');
@@ -80,5 +82,37 @@ describe('setupExtensionPreferences', () => {
     expect(instance.analytics?.send).toHaveBeenCalledWith({
       event: TrackingEvents.SDK_USE_EXTENSION,
     });
+  });
+
+  it('should terminate instance if permissions are revoked', async () => {
+    const mockTerminate = jest.fn().mockResolvedValue(undefined);
+    const mockRequest = jest.fn().mockResolvedValue([]);
+
+    instance.getProvider = jest.fn().mockReturnValue({
+      request: mockRequest,
+    }) as unknown as () => SDKProvider;
+
+    instance.terminate = mockTerminate;
+    instance.extensionActive = true; // Ensure extension is active
+
+    const mockBrowserExtension = {
+      on: jest.fn((event: string, callback: (accounts: string[]) => void) => {
+        if (event === EXTENSION_EVENTS.ACCOUNTS_CHANGED) {
+          // Directly call the callback to simulate the event
+          callback([]);
+        }
+      }),
+    };
+
+    (getBrowserExtension as jest.Mock).mockReturnValue(mockBrowserExtension);
+
+    await setupExtensionPreferences(instance);
+
+    expect(mockRequest).toHaveBeenCalledWith({
+      method: RPC_METHODS.WALLET_GETPERMISSIONS,
+      params: [],
+    });
+
+    expect(mockTerminate).toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/setupExtensionPreferences.ts
@@ -1,7 +1,11 @@
 import { TrackingEvents } from '@metamask/sdk-communication-layer';
 import { logger } from '../../../utils/logger';
 import { SDKProvider } from '../../../provider/SDKProvider';
-import { EXTENSION_EVENTS, RPC_METHODS, STORAGE_PROVIDER_TYPE } from '../../../config';
+import {
+  EXTENSION_EVENTS,
+  RPC_METHODS,
+  STORAGE_PROVIDER_TYPE,
+} from '../../../config';
 import { MetaMaskSDK } from '../../../sdk';
 import { getBrowserExtension } from '../../../utils/get-browser-extension';
 import { Ethereum } from '../../Ethereum';
@@ -80,10 +84,12 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
           }
 
           if (isExtensionActive && (accounts as string[])?.length === 0) {
-            instance.getProvider()?.request({
-              method: RPC_METHODS.WALLET_GETPERMISSIONS,
-              params: [],
-            })
+            instance
+              .getProvider()
+              ?.request({
+                method: RPC_METHODS.WALLET_GETPERMISSIONS,
+                params: [],
+              })
               .then((getPermissionsResponse) => {
                 const permissions = getPermissionsResponse as {
                   caveats: { type: string; value: string[] }[];
@@ -93,10 +99,12 @@ export async function setupExtensionPreferences(instance: MetaMaskSDK) {
                   `[MetaMaskSDK: setupExtensionPreferences()] permissions`,
                   permissions,
                 );
+
                 if (permissions.length === 0) {
                   instance.terminate().catch((error) => {
                     logger(
-                      `[MetaMaskSDK: setupExtensionPreferences()] error terminating on permissions revoked`, error,
+                      `[MetaMaskSDK: setupExtensionPreferences()] error terminating on permissions revoked`,
+                      error,
                     );
                   });
                 }


### PR DESCRIPTION
## Explanation
Historically, we used to call sdk.terminate() when receiving an accountsChanged=[] event thinking that permissions had been revoked from the extension. 

The problem with this is that EIP-1193 requires the extension to send accountsChanged=[] when locking the extension (to be changed) meaning that the accounts are no longer available and that it needs to e unlocked for them to be available again. 

It is scheduled for extension to stop emitting this event but because we need to keep backward compatibility until most users have the new extension version, we need to implement a workaround for this specific case. Upon discussing with wallet-api members it was decided that SDK would call getPermissions when receiving accountsChanged=[] since this call returns permissions even when the wallet is locked.
 

The flow should then be:
1. Catch accountsChanged=[] 
2. Call wallet_getPermissions
    a) if no permissions are returned → Terminate
    b) If permissions are received do nothing



<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
