### PR TITLE
feat: improves the react connected hook when using extension & emit terminate when using extension

### DIFF
--- a/packages/sdk-react/src/EventsHandlers/useHandleTerminateEvent.test.tsx
+++ b/packages/sdk-react/src/EventsHandlers/useHandleTerminateEvent.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useHandleTerminateEvent } from './useHandleTerminateEvent';
+import { EventHandlerProps } from '../MetaMaskProvider';
+import * as loggerModule from '../utils/logger';
+
+describe('useHandleTerminateEvent', () => {
+  const spyLogger = jest.spyOn(loggerModule, 'logger');
+
+  const eventHandlerProps = {
+    setConnecting: jest.fn(),
+    setConnected: jest.fn(),
+    setError: jest.fn(),
+    debug: true,
+  } as unknown as EventHandlerProps;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    eventHandlerProps.setConnecting = jest.fn();
+    eventHandlerProps.setConnected = jest.fn();
+    eventHandlerProps.setError = jest.fn();
+  });
+
+  it('should handle the terminate event correctly', () => {
+    const mockReason = { message: 'Terminated due to xyz', code: -32000 };
+
+    const { result } = renderHook(() =>
+      useHandleTerminateEvent(eventHandlerProps),
+    );
+    result.current(mockReason);
+
+    expect(spyLogger).toHaveBeenCalledWith(
+      "[MetaMaskProvider: useHandleTerminateEvent()] on 'terminate' event.",
+      mockReason,
+    );
+
+    expect(eventHandlerProps.setConnecting).toHaveBeenCalledWith(false);
+    expect(eventHandlerProps.setConnected).toHaveBeenCalledWith(false);
+    expect(eventHandlerProps.setError).toHaveBeenCalledWith(mockReason);
+  });
+});

--- a/packages/sdk-react/src/EventsHandlers/useHandleTerminateEvent.ts
+++ b/packages/sdk-react/src/EventsHandlers/useHandleTerminateEvent.ts
@@ -1,0 +1,25 @@
+import { EthereumRpcError } from 'eth-rpc-errors';
+import { useCallback } from 'react';
+import { EventHandlerProps } from '../MetaMaskProvider';
+import { logger } from '../utils/logger';
+
+export const useHandleTerminateEvent = ({
+  debug,
+  setConnecting,
+  setConnected,
+  setError,
+}: EventHandlerProps) => {
+  return useCallback(
+    (reason: unknown) => {
+      logger(
+        `[MetaMaskProvider: useHandleTerminateEvent()] on 'terminate' event.`,
+        reason,
+      );
+
+      setConnecting(false);
+      setConnected(false);
+      setError(reason as EthereumRpcError<unknown>);
+    },
+    [debug, setConnecting, setConnected, setError],
+  );
+};

--- a/packages/sdk-react/src/MetaMaskProvider.spec.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.spec.tsx
@@ -117,7 +117,7 @@ describe('MetaMaskProvider Component', () => {
       });
 
       expect(mockSdkOn).toHaveBeenCalledTimes(2);
-      expect(mockProviderOn).toHaveBeenCalledTimes(6);
+      expect(mockProviderOn).toHaveBeenCalledTimes(7);
 
       expect(mockSdkOn.mock.calls).toEqual([
         ['service_status', expect.any(Function)],
@@ -126,6 +126,7 @@ describe('MetaMaskProvider Component', () => {
 
       expect(mockProviderOn.mock.calls).toEqual([
         ['_initialized', expect.any(Function)],
+        ['terminate', expect.any(Function)],
         ['connecting', expect.any(Function)],
         ['connect', expect.any(Function)],
         ['disconnect', expect.any(Function)],
@@ -144,7 +145,7 @@ describe('MetaMaskProvider Component', () => {
       cleanup();
 
       expect(mockSdkRemoveListener).toHaveBeenCalledTimes(2);
-      expect(mockProviderRemoveListener).toHaveBeenCalledTimes(6);
+      expect(mockProviderRemoveListener).toHaveBeenCalledTimes(7);
 
       expect(mockSdkRemoveListener.mock.calls).toEqual([
         ['service_status', expect.any(Function)],
@@ -156,6 +157,7 @@ describe('MetaMaskProvider Component', () => {
         ['connecting', expect.any(Function)],
         ['connect', expect.any(Function)],
         ['disconnect', expect.any(Function)],
+        ['terminate', expect.any(Function)],
         ['accountsChanged', expect.any(Function)],
         ['chainChanged', expect.any(Function)],
       ]);

--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -23,6 +23,7 @@ import { useHandleInitializedEvent } from './EventsHandlers/useHandleInitialized
 import { useHandleOnConnectingEvent } from './EventsHandlers/useHandleOnConnectingEvent';
 import { useHandleProviderEvent } from './EventsHandlers/useHandleProviderEvent';
 import { useHandleSDKStatusEvent } from './EventsHandlers/useHandleSDKStatusEvent';
+import { useHandleTerminateEvent } from './EventsHandlers/useHandleTerminateEvent';
 import { logger } from './utils/logger';
 
 export interface EventHandlerProps {
@@ -130,6 +131,8 @@ const MetaMaskProviderClient = ({
   const onConnect = useHandleConnectEvent(eventHandlerProps);
 
   const onDisconnect = useHandleDisconnectEvent(eventHandlerProps);
+  
+  const onTerminate = useHandleTerminateEvent(eventHandlerProps);
 
   const onAccountsChanged = useHandleAccountsChangedEvent(eventHandlerProps);
 
@@ -262,12 +265,18 @@ const MetaMaskProviderClient = ({
       console.warn(`[MetaMaskProviderClient] activeProvider is undefined.`);
       return;
     }
-    setConnected(activeProvider.isConnected());
+
+    const isConnected = sdk.isExtensionActive()
+      ? !!account && account.length > 0
+      : activeProvider.isConnected();
+
+    setConnected(isConnected);
     setAccount(activeProvider.getSelectedAddress() || undefined);
     setProvider(activeProvider);
     setChainId(activeProvider.getChainId() || undefined);
 
     activeProvider.on('_initialized', onInitialized);
+    activeProvider.on('terminate', onTerminate);
     activeProvider.on('connecting', onConnecting);
     activeProvider.on('connect', onConnect);
     activeProvider.on('disconnect', onDisconnect);

--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -305,6 +305,7 @@ const MetaMaskProviderClient = ({
       activeProvider.removeListener('connecting', onConnecting);
       activeProvider.removeListener('connect', onConnect);
       activeProvider.removeListener('disconnect', onDisconnect);
+      activeProvider.removeListener('terminate', onTerminate);
       activeProvider.removeListener('accountsChanged', onAccountsChanged);
       activeProvider.removeListener('chainChanged', onChainChanged);
       sdk.removeListener(EventType.SERVICE_STATUS, onSDKStatusEvent);

--- a/packages/sdk-react/src/MetaMaskProvider.tsx
+++ b/packages/sdk-react/src/MetaMaskProvider.tsx
@@ -267,9 +267,9 @@ const MetaMaskProviderClient = ({
     }
 
     const isConnected = sdk.isExtensionActive()
-      ? !!account && account.length > 0
+      ? !!activeProvider.getSelectedAddress()
       : activeProvider.isConnected();
-
+     
     setConnected(isConnected);
     setAccount(activeProvider.getSelectedAddress() || undefined);
     setProvider(activeProvider);

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.test.ts
@@ -90,7 +90,7 @@ describe('terminate', () => {
       it('should not switch providers if extensionOnly option is true', async () => {
         instance.options.extensionOnly = true;
         await terminate(instance);
-        expect(mockEmit).not.toHaveBeenCalled();
+        expect(mockEmit).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
@@ -52,6 +52,7 @@ export async function terminate(instance: MetaMaskSDK) {
         MetaMaskSDKEvent.ProviderUpdate,
         PROVIDER_UPDATE_TYPE.TERMINATE,
       );
+
       logger(
         `[MetaMaskSDK: terminate()] extensionOnly --- prevent switching providers`,
       );

--- a/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ConnectionManager/terminate.ts
@@ -48,6 +48,10 @@ export async function terminate(instance: MetaMaskSDK) {
     }
 
     if (instance.options.extensionOnly) {
+      instance.emit(
+        MetaMaskSDKEvent.ProviderUpdate,
+        PROVIDER_UPDATE_TYPE.TERMINATE,
+      );
       logger(
         `[MetaMaskSDK: terminate()] extensionOnly --- prevent switching providers`,
       );


### PR DESCRIPTION
## Explanation
This PR aims to improve the react connected hook when using the extension. Previously, the connected hook would always be true when using extension because `window.ethereum.isConnected` is always true as long as the extension is being detected. This now verifies if we have an account present meaning that it is actually connected to extension. If no account is present then it assumes it has been disconnected like mobile does (even though mobile relies on socket events to do this).

### Main changes:
- terminate.ts. now emits a terminate event when extensionOnly is true (the current default)
- adds a new useHandleTerminateEvent.ts hook to handle the behavior of some connected hooks such as `connecting` and `connected`
- MetaMaskProvider.tsx now sets `connected` based on the existence of an account or not since `window.ethereum.isConnected` is always true if extension is installed

### Before

https://github.com/user-attachments/assets/43c48c91-3cea-40a1-ae12-1bad1c5ed392


### After

https://github.com/user-attachments/assets/95be33a6-8707-4c59-b549-45e31557c3c9

The Terminate event can also be caught from the dapp side when using extension:

![Screenshot 2025-01-08 at 4 18 22 PM](https://github.com/user-attachments/assets/df932344-0f4c-43fd-86e3-f72c1ac51d2b)


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
