### PR TITLE
fix: correct event handler binding in modal components

### DIFF
--- a/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
+++ b/packages/sdk-install-modal-web/src/components/mm-install-modal/mm-install-modal.tsx
@@ -96,11 +96,11 @@ export class InstallModal {
 
     return (
       <WidgetWrapper className="install-model">
-        <div class='backdrop' onClick={this.onClose}></div>
+        <div class='backdrop' onClick={() => this.onClose()}></div>
         <div class='modal'>
           <div class='closeButtonContainer'>
             <div class='right'>
-              <span class='closeButton' onClick={this.onClose}>
+              <span class='closeButton' onClick={() => this.onClose()}>
                 <CloseButton />
               </span>
             </div>
@@ -170,7 +170,7 @@ export class InstallModal {
 
               <button
                 class='button'
-                onClick={this.onStartDesktopOnboardingHandler}
+                onClick={() => this.onStartDesktopOnboardingHandler()}
               >
                 <InstallIcon />
                 <span class='installExtensionText'>

--- a/packages/sdk-install-modal-web/src/components/mm-select-modal/mm-select-modal.tsx
+++ b/packages/sdk-install-modal-web/src/components/mm-select-modal/mm-select-modal.tsx
@@ -157,7 +157,7 @@ export class SelectModal {
                 {t('SELECT_MODAL.CRYPTO_TAKE_CONTROL_TEXT')}
               </div>
 
-              <button class='button' onClick={this.connectWithExtensionHandler}>
+              <button class='button' onClick={() => this.connectWithExtensionHandler()}>
                 <ConnectIcon />
                 <span class='installExtensionText'>
                   {t('CONNECT_WITH_EXTENSION')}


### PR DESCRIPTION
# Description
## Overview
This PR fixes a scope-related bug in the modal components where event handlers were losing their `this` context. The issue affected click handlers in both the install and select modal components, potentially causing undefined errors when attempting to invoke methods.

## Impact
These changes fix potential runtime errors that could occur when users interact with modal buttons and overlays. No breaking changes or migration steps are required as this is a bug fix that maintains the existing API.
