### PR TITLE
feat: add MetaMask Flask provider support for EIP-6963

### DIFF
--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -16,7 +16,7 @@ export const METAMASK_DEEPLINK_BASE = 'metamask://connect';
 
 export const METAMASK_EIP_6369_PROVIDER_INFO = {
   NAME: 'MetaMask',
-  RDNS: 'io.metamask',
+  RDNS: ['io.metamask', 'io.metamask.flask'],
 };
 
 export const UUID_V4_REGEX =

--- a/packages/sdk/src/utils/eip6963RequestProvider.test.ts
+++ b/packages/sdk/src/utils/eip6963RequestProvider.test.ts
@@ -32,13 +32,42 @@ describe('eip6963RequestProvider', () => {
     );
   });
 
-  it('should resolve with valid provider', async () => {
+  it('should resolve with valid provider for MetaMask Main', async () => {
     const mockProvider: SDKProvider = {} as SDKProvider;
     const mockInfo: EIP6963ProviderInfo = {
       uuid: 'a1d2c588-106f-4d05-958d-5e7d6c57c822',
       name: 'MetaMask Main',
       icon: 'icon-path',
       rdns: 'io.metamask',
+    };
+    const mockEventDetail: EIP6963ProviderDetail = {
+      info: mockInfo,
+      provider: mockProvider,
+    };
+
+    (window.addEventListener as jest.Mock).mockImplementationOnce(
+      (eventName, callback) => {
+        if (eventName === EIP6963EventNames.Announce) {
+          callback({
+            type: EIP6963EventNames.Announce,
+            detail: mockEventDetail,
+          });
+        }
+      },
+    );
+
+    const requestProviderPromise = await eip6963RequestProvider();
+
+    expect(requestProviderPromise).toBe(mockProvider);
+  });
+
+  it('should resolve with valid provider for MetaMask Flask', async () => {
+    const mockProvider: SDKProvider = {} as SDKProvider;
+    const mockInfo: EIP6963ProviderInfo = {
+      uuid: 'a1d2c588-106f-4d05-958d-5e7d6c57c822',
+      name: 'MetaMask Flask',
+      icon: 'icon-path',
+      rdns: 'io.metamask.flask',
     };
     const mockEventDetail: EIP6963ProviderDetail = {
       info: mockInfo,

--- a/packages/sdk/src/utils/eip6963RequestProvider.ts
+++ b/packages/sdk/src/utils/eip6963RequestProvider.ts
@@ -43,7 +43,7 @@ export function eip6963RequestProvider(): Promise<MetaMaskInpageProvider> {
         const isValid =
           UUID_V4_REGEX.test(uuid) &&
           (name as string).startsWith(METAMASK_EIP_6369_PROVIDER_INFO.NAME) &&
-          rdns === METAMASK_EIP_6369_PROVIDER_INFO.RDNS;
+          METAMASK_EIP_6369_PROVIDER_INFO.RDNS.includes(rdns);
 
         if (isValid) {
           clearTimeout(timeoutId);


### PR DESCRIPTION
# Description
This PR extends our EIP-6963 provider detection to support MetaMask Flask alongside the main MetaMask provider.

### Changes Overview
- Added support for MetaMask Flask RDNS identifier (`io.metamask.flask`)
- Updated provider validation logic to check against multiple RDNS values
- Added test coverage for Flask provider detection

### Technical Implementation
- Modified `METAMASK_EIP_6369_PROVIDER_INFO.RDNS` to be an array that includes both `io.metamask` and `io.metamask.flask`
- Updated the provider validation logic in `eip6963RequestProvider.ts` to use `includes()` for RDNS checking
- Added a new test case specifically for MetaMask Flask provider detection

### Impact
This change is backwards compatible and doesn't require any migration steps. It simply adds support for detecting MetaMask Flask providers while maintaining existing functionality for regular MetaMask installations.


### Note:
This is currently working when using Flask alone, there is no possibility to chose which MetaMask variant to connect to. Please disable the MetaMask extension when using Flask with the SDK.