### PR TITLE
Fix nextjs localstorage issue

### DIFF
--- a/packages/sdk/src/Platform/PlatfformManager.ts
+++ b/packages/sdk/src/Platform/PlatfformManager.ts
@@ -89,7 +89,7 @@ export class PlatformManager {
     return this.state.platformType === PlatformType.MobileWeb;
   }
 
-  isNotBrowser() {
+  static isNotBrowser() {
     return (
       typeof window === 'undefined' ||
       !window?.navigator ||
@@ -99,12 +99,20 @@ export class PlatformManager {
     );
   }
 
-  isNodeJS() {
-    return this.isNotBrowser() && !this.isReactNative();
+  isNotBrowser() {
+    return PlatformManager.isNotBrowser();
+  }
+
+  static isBrowser() {
+    return !this.isNotBrowser();
   }
 
   isBrowser() {
-    return !this.isNotBrowser();
+    return PlatformManager.isBrowser();
+  }
+
+  isNodeJS() {
+    return this.isNotBrowser() && !this.isReactNative();
   }
 
   isUseDeepLink() {

--- a/packages/sdk/src/storage-manager/getStorageManager.ts
+++ b/packages/sdk/src/storage-manager/getStorageManager.ts
@@ -3,6 +3,7 @@ import {
   StorageManager,
   StorageManagerProps,
 } from '@metamask/sdk-communication-layer';
+import { PlatformManager } from 'src/Platform/PlatfformManager';
 
 /* #if _NODEJS
 import { StorageManagerNode as SMDyn } from './StorageManagerNode';
@@ -17,14 +18,21 @@ import { StorageManagerAS as SMDyn } from './StorageManagerAS';
 //#endif
 
 export const getStorageManager = (
-  // platformManager: PlatformManager,
   options: StorageManagerProps,
 ): StorageManager => {
-  // TODO uncomment and test to use similar dynamic imports for each platforms and drop support for JSCC
-  // Currently might have an issue with NextJS and server side rendering
-  // if (platformManager.isNotBrowser()) {
-  //   const { StorageManagerNode } = await import('./StorageManagerNode');
-  //   return new StorageManagerNode(options);
-  // }
-  return new SMDyn(options);
+  if (PlatformManager.isBrowser()) {
+    return new SMDyn(options);
+  }
+
+  const noopStorageManager: StorageManager = {
+    persistChannelConfig: async () => undefined,
+    getPersistedChannelConfig: async () => undefined,
+    persistAccounts: async () => undefined,
+    getCachedAccounts: async () => [],
+    persistChainId: async () => undefined,
+    getCachedChainId: async () => undefined,
+    terminate: async () => undefined,
+  } as StorageManager;
+
+  return noopStorageManager;
 };


### PR DESCRIPTION
## Explanation

Fixed a critical issue with Next.js 15+ server components where the SDK would attempt to access `localStorage` in non-browser environments, causing runtime errors. The bug was occurring because the storage manager was unconditionally initialized with browser-specific storage, even in server-side contexts.

The solution:
1. Made `PlatformManager` environment detection methods static for better reusability
2. Added environment-aware storage manager initialization that returns:
   - Regular storage manager for browser environments
   - No-op implementation for non-browser environments (server-side, SSR)

Example error that this fixes:
```
ReferenceError: localStorage is not defined
    at StorageManagerWeb.getPersistedChannelConfig
```

This change ensures the SDK works reliably in all Next.js environments while maintaining full functionality in browser contexts. The no-op storage manager gracefully handles all storage operations when running server-side, preventing runtime errors without requiring changes to application code.

## References

Related to OpenSea's reported issue with Wagmi + Next.js 15

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate  
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate  
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate