### PR TITLE
chore(security): remove GitHub Actions caching to prevent cache poisoning

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -128,7 +128,7 @@ jobs:
         if: ${{ matrix.node-version == '18.x' }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.package-name }}-${{ github.sha }}
           path: |
             stub
             ${{ steps.get-coverage-folder.outputs.coverage-folder }}/**/coverage-final.json

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn lint
       - name: Require clean working directory
         shell: bash
@@ -66,7 +66,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn workspace ${{ matrix.package-name }} lint:changelog
       - name: Require clean working directory
         shell: bash
@@ -90,7 +90,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -114,7 +114,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn build
       - run: yarn workspace ${{ matrix.package-name }} run test:ci
       - name: Get coverage folder

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -128,10 +128,8 @@ jobs:
         if: ${{ matrix.node-version == '18.x' }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.package-name }}-${{ github.sha }}
-          path: |
-            stub
-            ${{ steps.get-coverage-folder.outputs.coverage-folder }}/**/coverage-final.json
+          name: coverage-${{ github.sha }}
+          path: packages/**/coverage-final.json
           if-no-files-found: warn
           retention-days: 1
       - name: Require clean working directory

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -149,8 +149,8 @@ jobs:
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
-          name: coverage-${{ steps.get-coverage-folder.outputs.sanitized-name }}-${{ github.sha }}
-          path: packages/**/coverage-final.json
+          pattern: 'coverage-*-${{ github.sha }}'
+          merge-multiple: true
       - name: Upload coverage results
         uses: codecov/codecov-action@6d798873df2b1b8e5846dba6fb86631229fbcb17
         with:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -117,11 +117,18 @@ jobs:
       - run: yarn --immutable
       - run: yarn build
       - run: yarn workspace ${{ matrix.package-name }} run test:ci
+      - name: Get coverage folder
+        id: get-coverage-folder
+        run: |
+          SANITIZED_NAME=$(echo "${{ matrix.package-name }}" | sed 's/\//-/g')
+          echo "coverage-folder=$(yarn workspaces list --json | grep "\"name\":\"${{ matrix.package-name }}\"" | jq -r '.location')/coverage" >> "$GITHUB_OUTPUT"
+          echo "sanitized-name=$SANITIZED_NAME" >> "$GITHUB_OUTPUT"
+        shell: bash
       - name: Upload coverage artifact
         if: ${{ matrix.node-version == '18.x' }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.package-name }}-${{ github.sha }}
+          name: coverage-${{ steps.get-coverage-folder.outputs.sanitized-name }}-${{ github.sha }}
           path: packages/**/coverage-final.json
           if-no-files-found: warn
           retention-days: 1

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -126,7 +126,7 @@ jobs:
         shell: bash
       - name: Upload coverage artifact
         if: ${{ matrix.node-version == '18.x' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -117,18 +117,11 @@ jobs:
       - run: yarn --immutable
       - run: yarn build
       - run: yarn workspace ${{ matrix.package-name }} run test:ci
-      - name: Get coverage folder
-        id: get-coverage-folder
-        run: |
-          echo "Package Name: ${{ matrix.package-name }}"
-          echo "stub" >> stub
-          echo "coverage-folder=$(yarn workspaces list --json | grep "\"name\":\"${{ matrix.package-name }}\"" | jq -r '.location')/coverage" >> "$GITHUB_OUTPUT"
-        shell: bash
       - name: Upload coverage artifact
         if: ${{ matrix.node-version == '18.x' }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ github.sha }}
+          name: coverage-${{ matrix.package-name }}-${{ github.sha }}
           path: packages/**/coverage-final.json
           if-no-files-found: warn
           retention-days: 1

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -145,9 +145,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download coverage artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
       - name: Upload coverage results

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
       - run: yarn --immutable
       - name: Fetch workspace package names
         id: workspace-package-names
@@ -43,7 +42,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
       - run: yarn --immutable --immutable-cache
       - run: yarn lint
       - name: Require clean working directory
@@ -68,7 +66,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
       - run: yarn --immutable --immutable-cache
       - run: yarn workspace ${{ matrix.package-name }} lint:changelog
       - name: Require clean working directory
@@ -93,7 +90,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
       - run: yarn --immutable --immutable-cache
       - run: yarn build
       - name: Require clean working directory
@@ -118,7 +114,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
       - run: yarn --immutable --immutable-cache
       - run: yarn build
       - run: yarn workspace ${{ matrix.package-name }} run test:ci

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -149,7 +149,8 @@ jobs:
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ steps.get-coverage-folder.outputs.sanitized-name }}-${{ github.sha }}
+          path: packages/**/coverage-final.json
       - name: Upload coverage results
         uses: codecov/codecov-action@6d798873df2b1b8e5846dba6fb86631229fbcb17
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,62 +14,45 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - name: Install Corepack via Node
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ./packages/**/dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
-      - uses: MetaMask/action-publish-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Yarn
+        run: corepack enable
       - run: yarn --immutable
       - run: yarn build
-
-  publish-npm-dry-run:
-    runs-on: ubuntu-latest
-    needs: publish-release
-    steps:
-      - uses: actions/checkout@v3
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
-          ref: ${{ github.sha }}
-      - uses: actions/cache@v3
-        with:
+          name: publish-release-artifacts-${{ github.sha }}
+          retention-days: 4
+          include-hidden-files: true
           path: |
-            ./packages/**/dist
+            ./dist
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
-      - name: Dry Run Publish
-        # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v4
-        with:
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          subteam: S042S7RE4AE # @metamask-npm-publishers
-        env:
-          SKIP_PREPACK: true
 
   publish-npm:
-    environment: npm-publish
+    needs: publish-release
     runs-on: ubuntu-latest
-    needs: publish-npm-dry-run
+    environment: npm-publish
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
-      - uses: actions/cache@v3
+      - name: Install Corepack via Node
+        uses: actions/setup-node@v4
         with:
-          path: |
-            ./packages/**/dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          node-version-file: '.nvmrc'
+      - name: Install Yarn
+        run: corepack enable
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
         uses: MetaMask/action-npm-publish@v4
         with:


### PR DESCRIPTION
# Description
## Context
This PR updates our GitHub Actions workflows to use artifacts instead of caching for better control over build outputs. The changes affect the `lint-build-test.yml` and `publish-release.yml` workflows.

## Changes
- Removed `cache: yarn` configurations from all Node.js setup steps in `lint-build-test.yml`
- Updated `publish-release.yml` workflow to:
  - Replace caching mechanism with GitHub Artifacts for build outputs
  - Upgrade GitHub Actions to newer versions (`checkout@v4`, `setup-node@v4`)
  - Remove the npm publish dry-run step for a more streamlined release process
  - Implement proper artifact handling between jobs using `upload-artifact@v4` and `download-artifact@v4`

## Implementation Details
This change replaces the GitHub Actions caching mechanism with artifacts for managing build outputs between jobs. This provides more explicit control over how build artifacts are handled and transferred throughout the workflow.

## Performance Considerations
Build times may slightly increase without caching, but the artifact implementation ensures efficient transfer of build outputs between jobs. We can monitor and optimize if needed.

## Breaking Changes
None. This is an internal workflow change that doesn't affect the published packages or their consumers.

# Testing Instructions
1. Create a test release to verify the complete workflow
2. Monitor build times to assess performance impact
3. Verify that build artifacts are properly transferred between the release and publish jobs

# Related Issues
#3925 - Remove usage of GitHub action caching from critical workflows