### PR TITLE
docs(README): fix broken link to React usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm i @metamask/sdk
 See the following examples:
 
 - [Next.js](./packages/examples/nextjs-demo/README.md)
-- [React](./packages/examples/create-react-app/README.md)
+- [React](./packages/examples/react-demo/README.md)
 - [Vue.js](./packages/examples/vuejs/README.md)
 - [Pure JavaScript](./packages/examples/pure-javascript/README.md)
 


### PR DESCRIPTION
The README contained a broken link to the React usage example, making it difficult for developers to find the correct implementation details.

- Updated the broken link to the correct URL (/packages/examples/react-demo/README.md).
- Verified the link resolves correctly.

This improves the developer experience by ensuring proper documentation.