### PR TITLE
fix(socket): type errors

### DIFF
--- a/packages/sdk-socket-server-next/src/logger.ts
+++ b/packages/sdk-socket-server-next/src/logger.ts
@@ -2,7 +2,7 @@ import winston, { format } from 'winston';
 
 const customFormat = format.printf((ti) => {
   const { level, message, timestamp } = ti;
-  const args = ti[Symbol.for('splat')];
+  const args = ti[Symbol.for('splat')] as unknown[];
 
   const color = {
     info: '\x1b[36m',
@@ -31,7 +31,7 @@ const customFormat = format.printf((ti) => {
       })
       .join(' ') ?? '';
 
-  const searchContext = message;
+  const searchContext = message as string;
   if (searchContext.indexOf('wallet') !== -1) {
     msg += `\x1b[36m${message} ${extras}\x1b[0m`;
     // eslint-disable-next-line no-negated-condition


### PR DESCRIPTION
## Explanation

This PR fixes the following type errors that surfaced during deployment

```shell
#12 [builder 6/6] RUN yarn build
#12 0.231 yarn run v1.22.22
#12 0.276 $ tsc
#12 4.061 src/logger.ts(26,9): error TS2339: Property 'map' does not exist on type '{}'.
#12 4.063 src/logger.ts(35,7): error TS18046: 'searchContext' is of type 'unknown'.
#12 4.063 src/logger.ts(38,14): error TS18046: 'searchContext' is of type 'unknown'.
#12 4.092 error Command failed with exit code 2.
#12 4.093 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#12 ERROR: process "/bin/sh -c yarn build" did not complete successfully: exit code: 2
------
 > [builder 6/6] RUN yarn build:
0.231 yarn run v1.22.22
0.276 $ tsc
4.061 src/logger.ts(26,9): error TS2339: Property 'map' does not exist on type '{}'.
4.063 src/logger.ts(35,7): error TS18046: 'searchContext' is of type 'unknown'.
4.063 src/logger.ts(38,14): error TS18046: 'searchContext' is of type 'unknown'.
4.092 error Command failed with exit code 2.
4.093 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
Dockerfile:9
--------------------
   7 |     RUN yarn install
   8 |     COPY . .
   9 | >>> RUN yarn build
  10 |     
  11 |     # Runtime stage
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn build" did not complete successfully: exit code: 2
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c yarn build" did not complete successfully: exit code: 2
```

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
