### PR TITLE
fix(socket): reconnect on moved errors

### DIFF
--- a/packages/sdk-socket-server-next/src/analytics-api.ts
+++ b/packages/sdk-socket-server-next/src/analytics-api.ts
@@ -76,7 +76,7 @@ export const getRedisOptions = (
     retryStrategy: (times) => Math.min(times * 30, 1000),
     reconnectOnError: (error) => {
       // eslint-disable-next-line require-unicode-regexp
-      const targetErrors = [/READONLY/, /ETIMEDOUT/];
+      const targetErrors = [/MOVED/, /READONLY/, /ETIMEDOUT/];
       return targetErrors.some((targetError) =>
         targetError.test(error.message),
       );


### PR DESCRIPTION
## Explanation

This PR updates the redis cluster config to reconnect on `MOVED` errors

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
