### PR TITLE
fix: Fix analytics for unwanted events when using extension

### DIFF
--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -49,9 +49,9 @@ export const METHODS_TO_REDIRECT: { [method: string]: boolean } = {
   [RPC_METHODS.METAMASK_OPEN]: true,
 };
 
-export const lcAnalyticsRPCs = Object.keys(METHODS_TO_REDIRECT).map((method) =>
-  method.toLowerCase(),
-);
+export const lcAnalyticsRPCs = Object.keys(METHODS_TO_REDIRECT)
+  .filter((method) => METHODS_TO_REDIRECT[method] === true)
+  .map((method) => method.toLowerCase());
 
 // unsupported extension connectWith methods
 export const rpcWithAccountParam = [


### PR DESCRIPTION
## Explanation
This PR fixes sending analytics when using extension and inapp-browser. 
Before this fix all these methods were being tracked when using one of these two platforms:
- eth_requestAccounts
- eth_sendTransaction
- eth_signTransaction
- eth_sign
- personal_sign
- eth_signTypedData
- eth_signTypedData_v3
- eth_signTypedData_v4
- wallet_requestPermissions
- wallet_getPermissions
- wallet_watchAsset
- wallet_addEthereumChain
- wallet_switchEthereumChain
- metamask_connectSign
- metamask_connectWith
- personal_ecRecover
- metamask_batch
- metamask_open

These methods are not being bypassed as they are being cached on the dapp side and not redirection occurs:
- eth_accounts
- eth_chainId

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
