### PR TITLE
fix: reverts the removal of some publish steps

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,10 +35,29 @@ jobs:
             ./dist
             ./node_modules/.yarn-state.yml
 
+  publish-npm-dry-run:
+    runs-on: ubuntu-latest
+    needs: publish-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
+      - name: Dry Run Publish
+        uses: MetaMask/action-npm-publish@v4
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          subteam: S042S7RE4AE # @metamask-npm-publishers
+        env:
+          SKIP_PREPACK: true
+
   publish-npm:
+    environment: npm-publish
     needs: publish-release
     runs-on: ubuntu-latest
-    environment: npm-publish
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +74,3 @@ jobs:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
         uses: MetaMask/action-npm-publish@v4
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN }}
-        env:
-          SKIP_PREPACK: true


### PR DESCRIPTION
## Explanation

This PR brings back some of the `publish-npm-dry-run` removed by this [PR](https://github.com/MetaMask/metamask-sdk/pull/1209/files#diff-8b87cbf4077dc8eb1e5e1dd371b96d601e94a8cb3cbeb8ff4096779dd65e2a44) which includes sending a notification via Slack.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
