### PR TITLE
fix(socket|redis): convert global channels key to per-channel key and use hash tags

### DIFF
--- a/packages/sdk-socket-server-next/src/protocol/handleAck.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleAck.ts
@@ -23,7 +23,8 @@ export const handleAck = async ({
   socket,
   clientType,
 }: ACKParams): Promise<void> => {
-  const queueKey = `queue:${channelId}:${clientType}`;
+  // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
+  const queueKey = `queue:{${channelId}}:${clientType}`;
   let messages: string[] = [];
 
   const socketId = socket.id;

--- a/packages/sdk-socket-server-next/src/protocol/handleChannelRejected.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleChannelRejected.ts
@@ -27,7 +27,8 @@ export const handleChannelRejected = async (
   const socketId = socket.id;
   const clientIp = socket.request.socket.remoteAddress;
 
-  const channelConfigKey = `channel_config:${channelId}`;
+  // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
+  const channelConfigKey = `channel_config:{${channelId}}`;
   const existingConfig = await pubClient.get(channelConfigKey);
   let channelConfig: ChannelConfig | null = existingConfig
     ? (JSON.parse(existingConfig) as ChannelConfig)

--- a/packages/sdk-socket-server-next/src/protocol/handleCheckRoom.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleCheckRoom.ts
@@ -35,8 +35,10 @@ export const handleCheckRoom = async ({
 
   const room = io.sockets.adapter.rooms.get(channelId);
   const occupancy = room ? room.size : 0;
+  // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
+  const channelOccupancyKey = `channel_occupancy:{${channelId}}`; 
   const channelOccupancy =
-    (await pubClient.hget('channels', channelId)) ?? undefined;
+    (await pubClient.get(channelOccupancyKey)) ?? undefined;
 
   logger.info(
     `[check_room] occupancy=${occupancy}, channelOccupancy=${channelOccupancy}`,

--- a/packages/sdk-socket-server-next/src/protocol/handleJoinChannel.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleJoinChannel.ts
@@ -115,10 +115,12 @@ export const handleJoinChannel = async ({
     }
 
     let channelConfig: ChannelConfig | null = null;
+    // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
+    const channelOccupancyKey = `channel_occupancy:{${channelId}}`;
 
     if (clientType) {
       // New protocol when clientType is available
-      const channelConfigKey = `channel_config:${channelId}`;
+      const channelConfigKey = `channel_config:{${channelId}}`;
       const existingConfig = await pubClient.get(channelConfigKey);
       channelConfig = existingConfig ? JSON.parse(existingConfig) : null;
       const now = Date.now();
@@ -188,7 +190,7 @@ export const handleJoinChannel = async ({
       }
     }
 
-    const sRedisChannelOccupancy = await pubClient.hget('channels', channelId);
+    const sRedisChannelOccupancy = await pubClient.get(channelOccupancyKey);
     let channelOccupancy = 0;
 
     logger.debug(
@@ -202,7 +204,7 @@ export const handleJoinChannel = async ({
         `[handleJoinChannel] ${channelId} from ${socketId} -- room not found -- creating it now`,
       );
 
-      await pubClient.hset('channels', channelId, 0);
+      await pubClient.set(channelOccupancyKey, 0);
     }
 
     // room should be < MAX_CLIENTS_PER_ROOM since we haven't joined yet
@@ -227,7 +229,7 @@ export const handleJoinChannel = async ({
     }
 
     channelOccupancy = parseInt(
-      (await pubClient.hget('channels', channelId)) ?? '1',
+      (await pubClient.get(channelOccupancyKey)) ?? '1',
       10,
     );
     //  Refresh the room occupancy -it should now matches channel occupancy

--- a/packages/sdk-socket-server-next/src/protocol/handleMessage.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleMessage.ts
@@ -90,7 +90,7 @@ export const handleMessage = async ({
         channelConfig = { ...channelConfig, ready };
 
         await pubClient.set(
-          `channel_config:${channelId}`,
+          `channel_config:{${channelId}}`,
           JSON.stringify(channelConfig),
         );
 

--- a/packages/sdk-socket-server-next/src/protocol/handleMessage.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleMessage.ts
@@ -60,7 +60,8 @@ export const handleMessage = async ({
   try {
     if (clientType) {
       // new protocol, get channelConfig
-      const channelConfigKey = `channel_config:${channelId}`;
+      // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
+      const channelConfigKey = `channel_config:{${channelId}}`;
       const existingConfig = await pubClient.get(channelConfigKey);
       channelConfig = existingConfig ? JSON.parse(existingConfig) : null;
       ready = channelConfig?.ready ?? false;
@@ -113,7 +114,8 @@ export const handleMessage = async ({
       ackId = uuidv4();
       // Store in the correct message queue
       const otherQueue = clientType === 'dapp' ? 'wallet' : 'dapp';
-      const queueKey = `queue:${channelId}:${otherQueue}`;
+      // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})  
+      const queueKey = `queue:{${channelId}}:${otherQueue}`;
       const persistedMsg: QueuedMessage = {
         message,
         ackId,

--- a/packages/sdk-socket-server-next/src/protocol/retrieveMessages.ts
+++ b/packages/sdk-socket-server-next/src/protocol/retrieveMessages.ts
@@ -12,7 +12,8 @@ export const retrieveMessages = async ({
   channelId: string;
   clientType: ClientType;
 }): Promise<QueuedMessage[]> => {
-  const queueKey = `queue:${channelId}:${clientType}`;
+  // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
+  const queueKey = `queue:{${channelId}}:${clientType}`;
   try {
     const messageData = await pubClient.lrange(queueKey, 0, -1);
     const messages = messageData


### PR DESCRIPTION
## Explanation

This PR does a couple of things

* Adds redis [hash tags](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) to enforce similar keys to fall under the same slot allocation group (by hashing the channelId whenever possible)
* Converts the global `channels` key (which kept track of channel occupancy) to a per-channel key

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
