### PR TITLE
fix: fixes the CDN deploy workflow to use main

### DIFF
--- a/.github/workflows/deploy-cdn.yml
+++ b/.github/workflows/deploy-cdn.yml
@@ -13,10 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
+    - name: Checkout repository at tag
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.tag }}
+
+    # Fetch deploy script from main instead of using the one in the tag
+    - name: Fetch deploy script from main
+      run: |
+        git fetch origin main
+        git checkout origin/main -- scripts/deploy-cdn.sh
 
     - name: Set up Node.js
       uses: actions/setup-node@v3
@@ -29,7 +35,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --immutable
 
-    - name: Run deploy script
+    - name: Run deploy CDN script
       env:
         tag: ${{ github.event.inputs.tag }}
       run: bash ./scripts/deploy-cdn.sh


### PR DESCRIPTION
## Explanation
Because we need to checkout the tag coming from the workflow input, the script executing ends up being the one on the tag instead of the one on main.
This ensures that we fetch the `deploy-cdn.sh` script from main.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
