### PR TITLE
Use client pool for redis connections

### DIFF
--- a/packages/sdk-socket-server-next/package.json
+++ b/packages/sdk-socket-server-next/package.json
@@ -47,6 +47,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
+    "generic-pool": "^3.9.0",
     "helmet": "^5.1.1",
     "ioredis": "^5.3.2",
     "logform": "^2.6.0",

--- a/packages/sdk-socket-server-next/src/analytics-api.ts
+++ b/packages/sdk-socket-server-next/src/analytics-api.ts
@@ -186,8 +186,8 @@ export const getGlobalRedisClient = () => {
 
 export const pubClient = getGlobalRedisClient();
 export const pubClientPool = genericPool.createPool(redisFactory, {
-  max: 15,
-  min: 4,
+  max: 35,
+  min: 15,
 });
 
 const app = express();

--- a/packages/sdk-socket-server-next/src/analytics-api.ts
+++ b/packages/sdk-socket-server-next/src/analytics-api.ts
@@ -123,15 +123,6 @@ export const buildRedisClient = (usePipelining: boolean = true) => {
 
   newRedisClient.on('ready', () => {
     logger.info('Redis ready');
-
-    if (newRedisClient instanceof Cluster) {
-      logger.error('Refreshing Redis Cluster slots cache');
-      try {
-        newRedisClient?.refreshSlotsCache();
-      } catch (error) {
-        logger.error('Error refreshing Redis Cluster slots cache:', error);
-      }
-    }
   });
 
   newRedisClient.on('error', (error) => {

--- a/packages/sdk-socket-server-next/src/analytics-api.ts
+++ b/packages/sdk-socket-server-next/src/analytics-api.ts
@@ -25,6 +25,7 @@ import {
   incrementAnalyticsEvents,
   incrementRedisCacheOperation,
 } from './metrics';
+import genericPool from "generic-pool";
 
 const logger = getLogger();
 
@@ -54,8 +55,6 @@ if (redisNodes.length === 0) {
   process.exit(1);
 }
 
-let redisClient: Cluster | Redis | undefined;
-
 export const getRedisOptions = (
   isTls: boolean,
   password: string | undefined,
@@ -79,15 +78,6 @@ export const getRedisOptions = (
       const targetErrors = [/MOVED/, /READONLY/, /ETIMEDOUT/];
 
       logger.error('Redis reconnect error:', error);
-      if (error.message.includes('MOVED') && redisClient instanceof Cluster) {
-        logger.error('Refreshing Redis Cluster slots cache');
-        try {
-          redisClient?.refreshSlotsCache();
-        } catch (error) {
-          logger.error('Error refreshing Redis Cluster slots cache:', error);
-        }
-      }
-
       return targetErrors.some((targetError) =>
         targetError.test(error.message),
       );
@@ -99,83 +89,106 @@ export const getRedisOptions = (
   return options;
 };
 
-export const getRedisClient = () => {
-  if (!redisClient) {
-    if (redisCluster) {
-      logger.info('Connecting to Redis Cluster...');
+export const buildRedisClient = (usePipelining: boolean = true) => {
+  let newRedisClient: Cluster | Redis | undefined;
 
-      const redisOptions = getRedisOptions(
-        redisTLS,
-        process.env.REDIS_PASSWORD,
-      );
-      const redisClusterOptions: ClusterOptions = {
-        dnsLookup: (address, callback) => callback(null, address),
-        scaleReads: 'slave',
-        slotsRefreshTimeout: 5000,
-        showFriendlyErrorStack: true,
-        slotsRefreshInterval: 2000,
-        clusterRetryStrategy: (times) => Math.min(times * 30, 1000),
-        enableAutoPipelining: true,
-        redisOptions,
-      };
+  if (redisCluster) {
+    logger.info('Connecting to Redis Cluster...');
 
-      logger.debug(
-        'Redis Cluster options:',
-        JSON.stringify(redisClusterOptions, null, 2),
-      );
+    const redisOptions = getRedisOptions(
+      redisTLS,
+      process.env.REDIS_PASSWORD,
+    );
+    const redisClusterOptions: ClusterOptions = {
+      dnsLookup: (address, callback) => callback(null, address),
+      scaleReads: 'slave',
+      slotsRefreshTimeout: 5000,
+      showFriendlyErrorStack: true,
+      slotsRefreshInterval: 2000,
+      clusterRetryStrategy: (times) => Math.min(times * 30, 1000),
+      enableAutoPipelining: usePipelining,
+      redisOptions,
+    };
 
-      redisClient = new Cluster(redisNodes, redisClusterOptions);
-    } else {
-      logger.info('Connecting to single Redis node');
-      redisClient = new Redis(redisNodes[0]);
-    }
+    logger.debug(
+      'Redis Cluster options:',
+      JSON.stringify(redisClusterOptions, null, 2),
+    );
+
+    newRedisClient = new Cluster(redisNodes, redisClusterOptions);
+  } else {
+    logger.info('Connecting to single Redis node');
+    newRedisClient = new Redis(redisNodes[0]);
   }
 
-  redisClient.on('ready', () => {
+  newRedisClient.on('ready', () => {
     logger.info('Redis ready');
 
-    if (redisClient instanceof Cluster) {
+    if (newRedisClient instanceof Cluster) {
       logger.error('Refreshing Redis Cluster slots cache');
       try {
-        redisClient?.refreshSlotsCache();
+        newRedisClient?.refreshSlotsCache();
       } catch (error) {
         logger.error('Error refreshing Redis Cluster slots cache:', error);
       }
     }
   });
 
-  redisClient.on('error', (error) => {
+  newRedisClient.on('error', (error) => {
     logger.error('Redis error:', error);
   });
 
-  redisClient.on('connect', () => {
+  newRedisClient.on('connect', () => {
     logger.info('Connected to Redis Cluster successfully');
   });
 
-  redisClient.on('close', () => {
+  newRedisClient.on('close', () => {
     logger.info('Disconnected from Redis Cluster');
   });
 
-  redisClient.on('reconnecting', () => {
+  newRedisClient.on('reconnecting', () => {
     logger.info('Reconnecting to Redis Cluster');
   });
 
-  redisClient.on('end', () => {
+  newRedisClient.on('end', () => {
     logger.info('Redis Cluster connection ended');
   });
 
-  redisClient.on('wait', () => {
+  newRedisClient.on('wait', () => {
     logger.info('Redis Cluster waiting for connection');
   });
 
-  redisClient.on('select', (node) => {
+  newRedisClient.on('select', (node) => {
     logger.info('Redis Cluster selected node:', node);
   });
+
+  return newRedisClient;
+}
+
+const redisFactory = {
+  create: () => {
+    return Promise.resolve(buildRedisClient(false));
+  },
+  destroy: (client: Cluster | Redis) => {
+    return Promise.resolve(client.disconnect());
+  },
+};
+
+let redisClient: Cluster | Redis | undefined;
+
+export const getGlobalRedisClient = () => {
+  if (!redisClient) {
+    redisClient = buildRedisClient();
+  }
 
   return redisClient;
 };
 
-export const pubClient = getRedisClient();
+export const pubClient = getGlobalRedisClient();
+export const pubClientPool = genericPool.createPool(redisFactory, {
+  max: 15,
+  min: 4,
+});
 
 const app = express();
 

--- a/packages/sdk-socket-server-next/src/protocol/handleJoinChannel.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleJoinChannel.ts
@@ -1,7 +1,7 @@
 // protocol/handleJoinChannel.ts
 import { Server, Socket } from 'socket.io';
 import { validate } from 'uuid';
-import { pubClient } from '../analytics-api';
+import { pubClient, pubClientPool } from '../analytics-api';
 import { MAX_CLIENTS_PER_ROOM, config, isDevelopment } from '../config';
 import { getLogger } from '../logger';
 import { rateLimiter } from '../rate-limiter';
@@ -182,11 +182,15 @@ export const handleJoinChannel = async ({
           JSON.stringify(channelConfig),
         );
 
-        await pubClient.setex(
+        const client = await pubClientPool.acquire();
+
+        await client.setex(
           channelConfigKey,
           config.channelExpiry,
           JSON.stringify(channelConfig),
         ); // 1 week expiration
+
+        await pubClientPool.release(client);
       }
     }
 

--- a/packages/sdk-socket-server-next/src/redis-check.ts
+++ b/packages/sdk-socket-server-next/src/redis-check.ts
@@ -2,7 +2,7 @@
 import dotenv from 'dotenv';
 // Dotenv must be loaded before importing local files
 dotenv.config();
-import { getRedisClient } from './analytics-api';
+import { getGlobalRedisClient } from './analytics-api';
 
 import { createLogger } from './logger';
 
@@ -34,7 +34,7 @@ if (redisNodes.length === 0) {
 async function testRedisOperations() {
   try {
     // Connect to Redis
-    const cluster = getRedisClient();
+    const cluster = getGlobalRedisClient();
     logger.info('Connected to Redis Cluster successfully');
 
     // Set a key in Redis

--- a/yarn.lock
+++ b/yarn.lock
@@ -11613,6 +11613,7 @@ __metadata:
     eslint-plugin-prettier: ^3.4.0
     express: ^4.18.2
     express-rate-limit: ^7.1.5
+    generic-pool: ^3.9.0
     helmet: ^5.1.1
     ioredis: ^5.3.2
     jest: ^29.6.4
@@ -32806,7 +32807,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"generic-pool@npm:3.9.0":
+"generic-pool@npm:3.9.0, generic-pool@npm:^3.9.0":
   version: 3.9.0
   resolution: "generic-pool@npm:3.9.0"
   checksum: 3d89e9b2018d2e3bbf44fec78c76b2b7d56d6a484237aa9daf6ff6eedb14b0899dadd703b5d810219baab2eb28e5128fb18b29e91e602deb2eccac14492d8ca8


### PR DESCRIPTION
## Explanation

This PR introduces a client pool to allow some write operations to be performed by their own redis client without pipelining. The redis client pool size has a minimum of 15 connections and a maximum of 35 connections. Currently, the client pool is only used in 3 places, `leave-room`, `handleJoinChannel` and `handleChannelReject`

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
