### PR TITLE
fix(analytics): filter out some events

### DIFF
--- a/packages/sdk-socket-server-next/src/analytics-api.ts
+++ b/packages/sdk-socket-server-next/src/analytics-api.ts
@@ -279,7 +279,6 @@ app.post('/evt', evtMetricsMiddleware, async (_req, res) => {
       "personal_sign",
       "eth_signTypedData_v4",
       "wallet_requestPermissions",
-      "wallet_watchAsset",
       "metamask_connectSign"
     ];
 

--- a/packages/sdk-socket-server-next/src/analytics-api.ts
+++ b/packages/sdk-socket-server-next/src/analytics-api.ts
@@ -272,6 +272,25 @@ app.post('/evt', evtMetricsMiddleware, async (_req, res) => {
       return res.status(400).json({ error: 'wrong event name' });
     }
 
+    const toCheckEvents = ['sdk_rpc_request_done', 'sdk_rpc_request'];
+    const allowedMethods = [
+      "eth_sendTransaction",
+      "wallet_switchEthereumChain",
+      "personal_sign",
+      "eth_signTypedData_v4",
+      "wallet_requestPermissions",
+      "wallet_watchAsset",
+      "metamask_connectSign"
+    ];
+
+    // Filter: drop RPC events with unallowed methods silently, let all else through
+    if (toCheckEvents.includes(body.event) && 
+        (!body.params || 
+         !body.params.method || 
+         !allowedMethods.includes(body.params.method))) {
+      return res.json({ success: true });
+    }
+
     let channelId: string = body.id || 'sdk';
     // Prevent caching of events coming from extension since they are not re-using the same id and prevent increasing redis queue size.
     let isExtensionEvent = body.from === 'extension';


### PR DESCRIPTION
## Explanation

Only want to filter out `"sdk_rpc_request_done"` and `"sdk_rpc_request"` events when their `method` isn’t in a specific allowlist. This change adds a filter to the `/evt` endpoint to silently drop these RPC events if their method isn’t one of: `"eth_sendTransaction"`, `"wallet_switchEthereumChain"`, `"personal_sign"`, `"eth_signTypedData_v4"`, `"wallet_requestPermissions"`, `"wallet_watchAsset"`, or `"metamask_connectSign"`. All other events pass through unchanged. 

## References

- No specific issues tied to this PR.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate