### PR TITLE
Relay Server - Fix race condition

### DIFF
--- a/packages/sdk-socket-server-next/src/protocol/handleJoinChannel.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleJoinChannel.ts
@@ -228,6 +228,9 @@ export const handleJoinChannel = async ({
       await socket.join(channelId);
     }
 
+    // Dirty fix for race condition between socket.join and pubClient.get
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     channelOccupancy = parseInt(
       (await pubClient.get(channelOccupancyKey)) ?? '1',
       10,


### PR DESCRIPTION
## Explanation

There is a race condition between setting and getting a value in redis that some part of the protocol relies on. This PR adds artificial delay as a short term fix.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
