### PR TITLE
fix: add publishConfig too release for sdk-analytics package

### DIFF
--- a/packages/sdk-analytics/package.json
+++ b/packages/sdk-analytics/package.json
@@ -33,6 +33,10 @@
     "typescript-eslint": "^8.6.0",
     "vitest": "^3.1.2"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "license": "MIT",
   "dependencies": {
     "openapi-fetch": "^0.13.5"


### PR DESCRIPTION
## Explanation
Just adding the publishConfig to publish a package inside a namespace @metamask. Required to publish the package in npm registry.
