### PR TITLE
Release 112.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "111.0.0",
+  "version": "112.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk-analytics/CHANGELOG.md
+++ b/packages/sdk-analytics/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3]
+### Fixed
+- fix: add publishConfig too release for sdk-analytics package ([#1284](https://github.com/MetaMask/metamask-sdk/pull/1284))
+
 ## [0.0.2]
 ### Added
 - Add New Analytics Client ([#1270](https://github.com/MetaMask/metamask-sdk/pull/1270))
@@ -18,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-analytics@0.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-analytics@0.0.3...HEAD
+[0.0.3]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-analytics@0.0.2...@metamask/sdk-analytics@0.0.3
 [0.0.2]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk-analytics@0.0.0...@metamask/sdk-analytics@0.0.2
 [0.0.0]: https://github.com/MetaMask/metamask-sdk/releases/tag/@metamask/sdk-analytics@0.0.0

--- a/packages/sdk-analytics/package.json
+++ b/packages/sdk-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk-analytics",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Analytics package for MetaMask SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Update @metamask/sdk-analytics
## [0.0.3]
### Fixed
- fix: add publishConfig too release for sdk-analytics package ([#1284](https://github.com/MetaMask/metamask-sdk/pull/1284))
