### PR TITLE
Refactor: backwards compatible originator info

### DIFF
--- a/packages/sdk-communication-layer/src/types/OriginatorInfo.ts
+++ b/packages/sdk-communication-layer/src/types/OriginatorInfo.ts
@@ -3,7 +3,7 @@ export interface OriginatorInfo {
   title: string;
   platform: string;
   dappId: string;
-  anonId: string;
+  anonId?: string;
   icon?: string;
   scheme?: string;
   source?: string;


### PR DESCRIPTION
## Explanation

Making the `OriginatorInfo.anonId` backwards compatible. The `sdk-communication-layer` package is also being used in the mobile codebase and we can expect that some dApps won't upgrade to the latest version, causing that field to be missing on mobile. This fixes the type so it will be checked correctly.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
