### PR TITLE
fix: multichain core - stores adapters and client implementation

### DIFF
--- a/packages/sdk-multichain/src/domain/store/client.ts
+++ b/packages/sdk-multichain/src/domain/store/client.ts
@@ -1,34 +1,11 @@
 /* c8 ignore start */
-export interface ChannelConfig {
-  channelId: string;
-  validUntil: number;
-  otherKey?: string;
-  localKey?: string;
-  walletVersion?: string;
-  deeplinkProtocolAvailable?: boolean;
-  relayPersistence?: boolean; // Set if the session has full relay persistence (can exchange message without the other side connected)
-  /**
-   * lastActive: ms value of the last time connection was ready CLIENTS_READY event.
-   * */
-  lastActive?: number;
-}
 
 export abstract class StoreClient {
   abstract getAnonId(): Promise<string | null>;
-
   abstract getExtensionId(): Promise<string | null>;
-
-  abstract getChannelConfig(): Promise<ChannelConfig | null>;
-
   abstract setExtensionId(extensionId: string): Promise<void>;
-
   abstract setAnonId(anonId: string): Promise<void>;
-
-  abstract setChannelConfig(channelConfig: ChannelConfig): Promise<void>;
-
   abstract removeExtensionId(): Promise<void>;
-
   abstract removeAnonId(): Promise<void>;
-
   abstract getDebug(): Promise<string | null>;
 }

--- a/packages/sdk-multichain/src/store/adapters/node.ts
+++ b/packages/sdk-multichain/src/store/adapters/node.ts
@@ -1,0 +1,37 @@
+import { StoreAdapter } from "../../domain";
+import fs from 'fs'
+import path from 'path';
+
+const CONFIG_FILE = path.resolve(process.cwd(), '.metamask.json');
+
+export class StoreAdapterNode extends StoreAdapter {
+
+  async getItem(key: string): Promise<string | null> {
+    if (!fs.existsSync(CONFIG_FILE)) {
+      return null;
+    }
+    const contents = fs.readFileSync(CONFIG_FILE, 'utf8');
+    const config = JSON.parse(contents);
+     return config[key] || null;
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    if (!fs.existsSync(CONFIG_FILE)) {
+      fs.writeFileSync(CONFIG_FILE, '{}');
+    }
+    const contents = fs.readFileSync(CONFIG_FILE, 'utf8');
+    const config = JSON.parse(contents);
+    config[key] = value;
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+  }
+
+  async deleteItem(key: string): Promise<void> {
+    if (!fs.existsSync(CONFIG_FILE)) {
+      return;
+    }
+    const contents = fs.readFileSync(CONFIG_FILE, 'utf8');
+    const config = JSON.parse(contents);
+    delete config[key];
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+  }
+}

--- a/packages/sdk-multichain/src/store/adapters/node.ts
+++ b/packages/sdk-multichain/src/store/adapters/node.ts
@@ -6,13 +6,25 @@ const CONFIG_FILE = path.resolve(process.cwd(), '.metamask.json');
 
 export class StoreAdapterNode extends StoreAdapter {
 
+
+  private safeParse(contents: string): Record<string, string> {
+    try {
+      return JSON.parse(contents);
+    } catch (e) {
+      return {};
+    }
+  }
+
   async getItem(key: string): Promise<string | null> {
     if (!fs.existsSync(CONFIG_FILE)) {
       return null;
     }
     const contents = fs.readFileSync(CONFIG_FILE, 'utf8');
-    const config = JSON.parse(contents);
-     return config[key] || null;
+    const config = this.safeParse(contents);
+    if (config[key] !== undefined) {
+      return config[key];
+    }
+    return null;
   }
 
   async setItem(key: string, value: string): Promise<void> {
@@ -20,7 +32,7 @@ export class StoreAdapterNode extends StoreAdapter {
       fs.writeFileSync(CONFIG_FILE, '{}');
     }
     const contents = fs.readFileSync(CONFIG_FILE, 'utf8');
-    const config = JSON.parse(contents);
+    const config = this.safeParse(contents);
     config[key] = value;
     fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
   }
@@ -30,7 +42,7 @@ export class StoreAdapterNode extends StoreAdapter {
       return;
     }
     const contents = fs.readFileSync(CONFIG_FILE, 'utf8');
-    const config = JSON.parse(contents);
+    const config = this.safeParse(contents);
     delete config[key];
     fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
   }

--- a/packages/sdk-multichain/src/store/adapters/rn.ts
+++ b/packages/sdk-multichain/src/store/adapters/rn.ts
@@ -1,0 +1,16 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { StoreAdapter } from "../../domain";
+
+export class StoreAdapterRN extends StoreAdapter {
+  async getItem(key: string): Promise<string | null> {
+    return AsyncStorage.getItem(key);
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    return AsyncStorage.setItem(key, value);
+  }
+
+  async deleteItem(key: string): Promise<void> {
+    return AsyncStorage.removeItem(key);
+  }
+}

--- a/packages/sdk-multichain/src/store/adapters/web.ts
+++ b/packages/sdk-multichain/src/store/adapters/web.ts
@@ -1,0 +1,21 @@
+import { StoreAdapter } from "../../domain";
+
+export class StoreAdapterWeb extends StoreAdapter {
+  private get internal() {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      throw new Error('localStorage is not available in this environment');
+    }
+    return window.localStorage;
+  }
+  async getItem(key: string): Promise<string | null> {
+    return this.internal.getItem(key);
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    this.internal.setItem(key, value);
+  }
+
+  async deleteItem(key: string): Promise<void> {
+    this.internal.removeItem(key);
+  }
+}

--- a/packages/sdk-multichain/src/store/index.test.ts
+++ b/packages/sdk-multichain/src/store/index.test.ts
@@ -1,5 +1,6 @@
 import * as t from 'vitest'
 import fs from 'fs'
+import path from 'path';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 
@@ -34,198 +35,217 @@ function createStoreTests(
   setupMocks?: () => void,
   cleanupMocks?: () => void
 ) {
-  t.describe(`Store with ${adapterName}`, () => {
-    let store: Store;
-    let adapter: StoreAdapter;
+  let store: Store;
+  let adapter: StoreAdapter;
 
-    t.beforeEach(async () => {
-      setupMocks?.();
-      adapter = createAdapter();
-      store = new Store(adapter);
+  t.beforeEach(async () => {
+    setupMocks?.();
+    adapter = createAdapter();
+    store = new Store(adapter);
+  });
+
+  t.afterEach(async () => {
+    nativeStorageStub.data.clear()
+    cleanupMocks?.();
+  });
+
+  t.describe(`${adapterName} constructor`, () => {
+    t.it('should create a Store instance with the provided adapter', () => {
+      t.expect(store).toBeInstanceOf(Store);
+    });
+  });
+
+  t.describe(`${adapterName} getAnonId`, () => {
+    t.it('should return the anonymous ID when it exists', async () => {
+      await adapter.setItem('anonId', 'test-anon-id');
+      const result = await store.getAnonId();
+      t.expect(result).toBe('test-anon-id');
     });
 
-    t.afterEach(async () => {
-      nativeStorageStub.data.clear()
-      cleanupMocks?.();
+    t.it('should return null when anonymous ID does not exist', async () => {
+      const result = await store.getAnonId();
+      t.expect(result).toBeNull();
+    });
+  });
+
+  t.describe(`${adapterName} setAnonId`, () => {
+    t.it('should set the anonymous ID successfully', async () => {
+      await store.setAnonId('new-anon-id');
+      const result = await adapter.getItem('anonId');
+      t.expect(result).toBe('new-anon-id');
+    });
+  });
+
+  t.describe(`${adapterName} removeAnonId`, () => {
+    t.it('should remove the anonymous ID successfully', async () => {
+      await adapter.setItem('anonId', 'test-anon-id');
+      const beforeRemove = await adapter.getItem('anonId');
+      t.expect(beforeRemove).toBe('test-anon-id');
+
+      await store.removeAnonId();
+      const afterRemove = await adapter.getItem('anonId');
+      t.expect(afterRemove).toBeNull();
+    });
+  });
+
+  t.describe(`${adapterName} getExtensionId`, () => {
+    t.it('should return the extension ID when it exists', async () => {
+      await adapter.setItem('extensionId', 'test-extension-id');
+      const result = await store.getExtensionId();
+      t.expect(result).toBe('test-extension-id');
     });
 
-    t.describe(`${adapterName} constructor`, () => {
-      t.it('should create a Store instance with the provided adapter', () => {
-        t.expect(store).toBeInstanceOf(Store);
-      });
+    t.it('should return null when extension ID does not exist', async () => {
+      const result = await store.getExtensionId();
+      t.expect(result).toBeNull();
+    });
+  });
+
+  t.describe(`${adapterName} setExtensionId`, () => {
+    t.it('should set the extension ID successfully', async () => {
+      await store.setExtensionId('new-extension-id');
+      const result = await adapter.getItem('extensionId');
+      t.expect(result).toBe('new-extension-id');
+    });
+  });
+
+  t.describe(`${adapterName} removeExtensionId`, () => {
+    t.it('should remove the extension ID successfully', async () => {
+      await adapter.setItem('extensionId', 'test-extension-id');
+      const beforeRemove = await adapter.getItem('extensionId');
+      t.expect(beforeRemove).toBe('test-extension-id');
+
+      await store.removeExtensionId();
+      const afterRemove = await adapter.getItem('extensionId');
+      t.expect(afterRemove).toBeNull();
+    });
+  });
+
+  t.describe(`${adapterName} getChannelConfig`, () => {
+    t.it('should return the channel config when it exists and is valid JSON', async () => {
+      const channelConfig: ChannelConfig = {
+        channelId: 'test-channel',
+        validUntil: Date.now() + 3600000,
+        otherKey: 'other-key',
+        localKey: 'local-key',
+        walletVersion: '1.0.0',
+        deeplinkProtocolAvailable: true,
+        relayPersistence: false,
+        lastActive: Date.now()
+      };
+
+      await adapter.setItem('channelConfig', JSON.stringify(channelConfig));
+      const result = await store.getChannelConfig();
+
+      t.expect(result).toEqual(channelConfig);
     });
 
-    t.describe(`${adapterName} getAnonId`, () => {
-      t.it('should return the anonymous ID when it exists', async () => {
-        await adapter.setItem('anonId', 'test-anon-id');
-        const result = await store.getAnonId();
-        t.expect(result).toBe('test-anon-id');
-      });
-
-      t.it('should return null when anonymous ID does not exist', async () => {
-        const result = await store.getAnonId();
-        t.expect(result).toBeNull();
-      });
+    t.it('should return null when channel config does not exist', async () => {
+      const result = await store.getChannelConfig();
+      t.expect(result).toBeNull();
     });
 
-    t.describe(`${adapterName} setAnonId`, () => {
-      t.it('should set the anonymous ID successfully', async () => {
-        await store.setAnonId('new-anon-id');
-        const result = await adapter.getItem('anonId');
-        t.expect(result).toBe('new-anon-id');
-      });
+    t.it('should throw an error when stored JSON is invalid', async () => {
+      await adapter.setItem('channelConfig', 'invalid-json');
+      await t.expect(store.getChannelConfig()).rejects.toThrow();
+    });
+  });
+
+  t.describe(`${adapterName} setChannelConfig`, () => {
+    t.it('should set the channel config successfully', async () => {
+      const channelConfig: ChannelConfig = {
+        channelId: 'test-channel',
+        validUntil: Date.now() + 3600000,
+        otherKey: 'other-key',
+        localKey: 'local-key'
+      };
+
+      await store.setChannelConfig(channelConfig);
+
+      const storedValue = await adapter.getItem('channelConfig');
+      t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
     });
 
-    t.describe(`${adapterName} removeAnonId`, () => {
-      t.it('should remove the anonymous ID successfully', async () => {
-        await adapter.setItem('anonId', 'test-anon-id');
-        const beforeRemove = await adapter.getItem('anonId');
-        t.expect(beforeRemove).toBe('test-anon-id');
+    t.it('should handle minimal channel config', async () => {
+      const channelConfig: ChannelConfig = {
+        channelId: 'minimal-channel',
+        validUntil: Date.now() + 3600000
+      };
 
-        await store.removeAnonId();
-        const afterRemove = await adapter.getItem('anonId');
-        t.expect(afterRemove).toBeNull();
-      });
+      await store.setChannelConfig(channelConfig);
+
+      const storedValue = await adapter.getItem('channelConfig');
+      t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
+    });
+  });
+
+  t.describe(`${adapterName} getDebug`, () => {
+    t.it('should return the debug value when it exists', async () => {
+      await adapter.setItem('DEBUG', 'metamask-sdk:*');
+      const result = await store.getDebug();
+      t.expect(result).toBe('metamask-sdk:*');
     });
 
-    t.describe(`${adapterName} getExtensionId`, () => {
-      t.it('should return the extension ID when it exists', async () => {
-        await adapter.setItem('extensionId', 'test-extension-id');
-        const result = await store.getExtensionId();
-        t.expect(result).toBe('test-extension-id');
-      });
-
-      t.it('should return null when extension ID does not exist', async () => {
-        const result = await store.getExtensionId();
-        t.expect(result).toBeNull();
-      });
-    });
-
-    t.describe(`${adapterName} setExtensionId`, () => {
-      t.it('should set the extension ID successfully', async () => {
-        await store.setExtensionId('new-extension-id');
-        const result = await adapter.getItem('extensionId');
-        t.expect(result).toBe('new-extension-id');
-      });
-    });
-
-    t.describe(`${adapterName} removeExtensionId`, () => {
-      t.it('should remove the extension ID successfully', async () => {
-        await adapter.setItem('extensionId', 'test-extension-id');
-        const beforeRemove = await adapter.getItem('extensionId');
-        t.expect(beforeRemove).toBe('test-extension-id');
-
-        await store.removeExtensionId();
-        const afterRemove = await adapter.getItem('extensionId');
-        t.expect(afterRemove).toBeNull();
-      });
-    });
-
-    t.describe(`${adapterName} getChannelConfig`, () => {
-      t.it('should return the channel config when it exists and is valid JSON', async () => {
-        const channelConfig: ChannelConfig = {
-          channelId: 'test-channel',
-          validUntil: Date.now() + 3600000,
-          otherKey: 'other-key',
-          localKey: 'local-key',
-          walletVersion: '1.0.0',
-          deeplinkProtocolAvailable: true,
-          relayPersistence: false,
-          lastActive: Date.now()
-        };
-
-        await adapter.setItem('channelConfig', JSON.stringify(channelConfig));
-        const result = await store.getChannelConfig();
-
-        t.expect(result).toEqual(channelConfig);
-      });
-
-      t.it('should return null when channel config does not exist', async () => {
-        const result = await store.getChannelConfig();
-        t.expect(result).toBeNull();
-      });
-
-      t.it('should throw an error when stored JSON is invalid', async () => {
-        await adapter.setItem('channelConfig', 'invalid-json');
-        await t.expect(store.getChannelConfig()).rejects.toThrow();
-      });
-    });
-
-    t.describe(`${adapterName} setChannelConfig`, () => {
-      t.it('should set the channel config successfully', async () => {
-        const channelConfig: ChannelConfig = {
-          channelId: 'test-channel',
-          validUntil: Date.now() + 3600000,
-          otherKey: 'other-key',
-          localKey: 'local-key'
-        };
-
-        await store.setChannelConfig(channelConfig);
-
-        const storedValue = await adapter.getItem('channelConfig');
-        t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
-      });
-
-      t.it('should handle minimal channel config', async () => {
-        const channelConfig: ChannelConfig = {
-          channelId: 'minimal-channel',
-          validUntil: Date.now() + 3600000
-        };
-
-        await store.setChannelConfig(channelConfig);
-
-        const storedValue = await adapter.getItem('channelConfig');
-        t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
-      });
-    });
-
-    t.describe(`${adapterName} getDebug`, () => {
-      t.it('should return the debug value when it exists', async () => {
-        await adapter.setItem('DEBUG', 'metamask-sdk:*');
-        const result = await store.getDebug();
-        t.expect(result).toBe('metamask-sdk:*');
-      });
-
-      t.it('should return null when debug value does not exist', async () => {
-        const result = await store.getDebug();
-        t.expect(result).toBeNull();
-      });
+    t.it('should return null when debug value does not exist', async () => {
+      const result = await store.getDebug();
+      t.expect(result).toBeNull();
     });
   });
 }
 
 
+t.describe(`Store with NodeAdapter`, () => {
+  // Test with Node Adapter and mocked file system
+  createStoreTests(
+    'NodeAdapter',
+    () => new StoreAdapterNode(),
+    async () => {
+      const memfs = new Map<string, any>()
+      t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => memfs.has(path.toString()))
+      t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => memfs.set(path.toString(), data))
+      t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => memfs.get(path.toString()))
+    }
+  );
 
-// Test with Node Adapter and mocked file system
-createStoreTests(
-  'NodeAdapter',
-  () => new StoreAdapterNode(),
-  async () => {
-    const memfs = new Map<string, any>()
-    t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => memfs.has(path.toString()))
-    t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => memfs.set(path.toString(), data))
-    t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => memfs.get(path.toString()))
-  }
-);
+  t.it("Should gracefully manage deleteItem even if the config file does not exist", async () => {
+    const CONFIG_FILE = path.resolve(process.cwd(), '.metamask.json');
+    t.vi.spyOn(fs, 'existsSync').mockImplementation(() => false)
+    const store = new Store(new StoreAdapterNode())
+    await store.removeExtensionId()
+    t.expect(fs.existsSync).toHaveBeenCalledWith(CONFIG_FILE)
+  })
+});
 
-//Test browser storage with mocked local storage
-createStoreTests(
-  'WebAdapter',
-  () => new StoreAdapterWeb(),
-  () => {
+t.describe(`Store with WebAdapter`, () => {
+  //Test browser storage with mocked local storage
+  createStoreTests(
+    'WebAdapter',
+    () => new StoreAdapterWeb(),
+    () => {
+      t.vi.stubGlobal('window', {
+        localStorage: nativeStorageStub,
+      });
+    }
+  );
+
+  t.it("Should throw an exception if we try using the store with a browser that doesn't support localStorage", async () => {
     t.vi.stubGlobal('window', {
-      localStorage: nativeStorageStub,
+      localStorage: null,
     });
-  }
-);
+    const store = new Store(new StoreAdapterWeb());
+    await t.expect(() => store.getAnonId()).rejects.toThrow();
+  });
+});
 
-// Test RN storage with mocked AsyncStorage
-createStoreTests(
-  'RNAdapter',
-  () => new StoreAdapterRN(),
-  () => {
-    t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => nativeStorageStub.getItem(key))
-    t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => nativeStorageStub.setItem(key, value))
-    t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.removeItem(key))
-  }
-);
+t.describe(`Store with RNAdapter`, () => {
+  // Test RN storage with mocked AsyncStorage
+  createStoreTests(
+    'RNAdapter',
+    () => new StoreAdapterRN(),
+    () => {
+      t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => nativeStorageStub.getItem(key))
+      t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => nativeStorageStub.setItem(key, value))
+      t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.removeItem(key))
+    }
+  );
+});

--- a/packages/sdk-multichain/src/store/index.test.ts
+++ b/packages/sdk-multichain/src/store/index.test.ts
@@ -1,0 +1,231 @@
+import * as t from 'vitest'
+import fs from 'fs'
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+
+
+import { Store } from './index';
+import { StoreAdapter, type ChannelConfig } from '../domain';
+import { StoreAdapterWeb } from './adapters/web';
+import { StoreAdapterRN } from './adapters/rn';
+import { StoreAdapterNode } from './adapters/node';
+
+/**
+ * Dummy mocked storage to keep track of data between tests
+ */
+const nativeStorageStub = {
+  data: new Map<string, string>(),
+  getItem: t.vi.fn((key: string) => nativeStorageStub.data.get(key) || null),
+  setItem: t.vi.fn((key: string, value: string) => {
+    nativeStorageStub.data.set(key, value);
+  }),
+  removeItem: t.vi.fn((key: string) => {
+    nativeStorageStub.data.delete(key);
+  }),
+  clear: t.vi.fn(() => {
+    nativeStorageStub.data.clear();
+  }),
+}
+
+// Reusable test function that can be used with any adapter
+function createStoreTests(
+  adapterName: string,
+  createAdapter: () => StoreAdapter,
+  setupMocks?: () => void,
+  cleanupMocks?: () => void
+) {
+  t.describe(`Store with ${adapterName}`, () => {
+    let store: Store;
+    let adapter: StoreAdapter;
+
+    t.beforeEach(async () => {
+      setupMocks?.();
+      adapter = createAdapter();
+      store = new Store(adapter);
+    });
+
+    t.afterEach(async () => {
+      nativeStorageStub.data.clear()
+      cleanupMocks?.();
+    });
+
+    t.describe(`${adapterName} constructor`, () => {
+      t.it('should create a Store instance with the provided adapter', () => {
+        t.expect(store).toBeInstanceOf(Store);
+      });
+    });
+
+    t.describe(`${adapterName} getAnonId`, () => {
+      t.it('should return the anonymous ID when it exists', async () => {
+        await adapter.setItem('anonId', 'test-anon-id');
+        const result = await store.getAnonId();
+        t.expect(result).toBe('test-anon-id');
+      });
+
+      t.it('should return null when anonymous ID does not exist', async () => {
+        const result = await store.getAnonId();
+        t.expect(result).toBeNull();
+      });
+    });
+
+    t.describe(`${adapterName} setAnonId`, () => {
+      t.it('should set the anonymous ID successfully', async () => {
+        await store.setAnonId('new-anon-id');
+        const result = await adapter.getItem('anonId');
+        t.expect(result).toBe('new-anon-id');
+      });
+    });
+
+    t.describe(`${adapterName} removeAnonId`, () => {
+      t.it('should remove the anonymous ID successfully', async () => {
+        await adapter.setItem('anonId', 'test-anon-id');
+        const beforeRemove = await adapter.getItem('anonId');
+        t.expect(beforeRemove).toBe('test-anon-id');
+
+        await store.removeAnonId();
+        const afterRemove = await adapter.getItem('anonId');
+        t.expect(afterRemove).toBeNull();
+      });
+    });
+
+    t.describe(`${adapterName} getExtensionId`, () => {
+      t.it('should return the extension ID when it exists', async () => {
+        await adapter.setItem('extensionId', 'test-extension-id');
+        const result = await store.getExtensionId();
+        t.expect(result).toBe('test-extension-id');
+      });
+
+      t.it('should return null when extension ID does not exist', async () => {
+        const result = await store.getExtensionId();
+        t.expect(result).toBeNull();
+      });
+    });
+
+    t.describe(`${adapterName} setExtensionId`, () => {
+      t.it('should set the extension ID successfully', async () => {
+        await store.setExtensionId('new-extension-id');
+        const result = await adapter.getItem('extensionId');
+        t.expect(result).toBe('new-extension-id');
+      });
+    });
+
+    t.describe(`${adapterName} removeExtensionId`, () => {
+      t.it('should remove the extension ID successfully', async () => {
+        await adapter.setItem('extensionId', 'test-extension-id');
+        const beforeRemove = await adapter.getItem('extensionId');
+        t.expect(beforeRemove).toBe('test-extension-id');
+
+        await store.removeExtensionId();
+        const afterRemove = await adapter.getItem('extensionId');
+        t.expect(afterRemove).toBeNull();
+      });
+    });
+
+    t.describe(`${adapterName} getChannelConfig`, () => {
+      t.it('should return the channel config when it exists and is valid JSON', async () => {
+        const channelConfig: ChannelConfig = {
+          channelId: 'test-channel',
+          validUntil: Date.now() + 3600000,
+          otherKey: 'other-key',
+          localKey: 'local-key',
+          walletVersion: '1.0.0',
+          deeplinkProtocolAvailable: true,
+          relayPersistence: false,
+          lastActive: Date.now()
+        };
+
+        await adapter.setItem('channelConfig', JSON.stringify(channelConfig));
+        const result = await store.getChannelConfig();
+
+        t.expect(result).toEqual(channelConfig);
+      });
+
+      t.it('should return null when channel config does not exist', async () => {
+        const result = await store.getChannelConfig();
+        t.expect(result).toBeNull();
+      });
+
+      t.it('should throw an error when stored JSON is invalid', async () => {
+        await adapter.setItem('channelConfig', 'invalid-json');
+        await t.expect(store.getChannelConfig()).rejects.toThrow();
+      });
+    });
+
+    t.describe(`${adapterName} setChannelConfig`, () => {
+      t.it('should set the channel config successfully', async () => {
+        const channelConfig: ChannelConfig = {
+          channelId: 'test-channel',
+          validUntil: Date.now() + 3600000,
+          otherKey: 'other-key',
+          localKey: 'local-key'
+        };
+
+        await store.setChannelConfig(channelConfig);
+
+        const storedValue = await adapter.getItem('channelConfig');
+        t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
+      });
+
+      t.it('should handle minimal channel config', async () => {
+        const channelConfig: ChannelConfig = {
+          channelId: 'minimal-channel',
+          validUntil: Date.now() + 3600000
+        };
+
+        await store.setChannelConfig(channelConfig);
+
+        const storedValue = await adapter.getItem('channelConfig');
+        t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
+      });
+    });
+
+    t.describe(`${adapterName} getDebug`, () => {
+      t.it('should return the debug value when it exists', async () => {
+        await adapter.setItem('DEBUG', 'metamask-sdk:*');
+        const result = await store.getDebug();
+        t.expect(result).toBe('metamask-sdk:*');
+      });
+
+      t.it('should return null when debug value does not exist', async () => {
+        const result = await store.getDebug();
+        t.expect(result).toBeNull();
+      });
+    });
+  });
+}
+
+
+
+// Test with Node Adapter and mocked file system
+createStoreTests(
+  'NodeAdapter',
+  () => new StoreAdapterNode(),
+  async () => {
+    const memfs = new Map<string, any>()
+    t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => memfs.has(path.toString()))
+    t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => memfs.set(path.toString(), data))
+    t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => memfs.get(path.toString()))
+  }
+);
+
+//Test browser storage with mocked local storage
+createStoreTests(
+  'WebAdapter',
+  () => new StoreAdapterWeb(),
+  () => {
+    t.vi.stubGlobal('window', {
+      localStorage: nativeStorageStub,
+    });
+  }
+);
+
+// Test RN storage with mocked AsyncStorage
+createStoreTests(
+  'RNAdapter',
+  () => new StoreAdapterRN(),
+  () => {
+    t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => nativeStorageStub.getItem(key))
+    t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => nativeStorageStub.setItem(key, value))
+    t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.removeItem(key))
+  }
+);

--- a/packages/sdk-multichain/src/store/index.test.ts
+++ b/packages/sdk-multichain/src/store/index.test.ts
@@ -6,7 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 
 import { Store } from './index';
-import { StoreAdapter, type ChannelConfig } from '../domain';
+import { StoreAdapter } from '../domain';
 import { StoreAdapterWeb } from './adapters/web';
 import { StoreAdapterRN } from './adapters/rn';
 import { StoreAdapterNode } from './adapters/node';
@@ -118,64 +118,6 @@ function createStoreTests(
       await store.removeExtensionId();
       const afterRemove = await adapter.getItem('extensionId');
       t.expect(afterRemove).toBeNull();
-    });
-  });
-
-  t.describe(`${adapterName} getChannelConfig`, () => {
-    t.it('should return the channel config when it exists and is valid JSON', async () => {
-      const channelConfig: ChannelConfig = {
-        channelId: 'test-channel',
-        validUntil: Date.now() + 3600000,
-        otherKey: 'other-key',
-        localKey: 'local-key',
-        walletVersion: '1.0.0',
-        deeplinkProtocolAvailable: true,
-        relayPersistence: false,
-        lastActive: Date.now()
-      };
-
-      await adapter.setItem('channelConfig', JSON.stringify(channelConfig));
-      const result = await store.getChannelConfig();
-
-      t.expect(result).toEqual(channelConfig);
-    });
-
-    t.it('should return null when channel config does not exist', async () => {
-      const result = await store.getChannelConfig();
-      t.expect(result).toBeNull();
-    });
-
-    t.it('should throw an error when stored JSON is invalid', async () => {
-      await adapter.setItem('channelConfig', 'invalid-json');
-      await t.expect(store.getChannelConfig()).rejects.toThrow();
-    });
-  });
-
-  t.describe(`${adapterName} setChannelConfig`, () => {
-    t.it('should set the channel config successfully', async () => {
-      const channelConfig: ChannelConfig = {
-        channelId: 'test-channel',
-        validUntil: Date.now() + 3600000,
-        otherKey: 'other-key',
-        localKey: 'local-key'
-      };
-
-      await store.setChannelConfig(channelConfig);
-
-      const storedValue = await adapter.getItem('channelConfig');
-      t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
-    });
-
-    t.it('should handle minimal channel config', async () => {
-      const channelConfig: ChannelConfig = {
-        channelId: 'minimal-channel',
-        validUntil: Date.now() + 3600000
-      };
-
-      await store.setChannelConfig(channelConfig);
-
-      const storedValue = await adapter.getItem('channelConfig');
-      t.expect(JSON.parse(storedValue!)).toEqual(channelConfig);
     });
   });
 

--- a/packages/sdk-multichain/src/store/index.ts
+++ b/packages/sdk-multichain/src/store/index.ts
@@ -1,0 +1,50 @@
+import type { ChannelConfig, StoreClient, StoreAdapter } from "../domain";
+
+
+export class Store implements StoreClient {
+  readonly #adapter: StoreAdapter;
+
+  constructor(adapter: StoreAdapter) {
+    this.#adapter = adapter;
+  }
+
+  async getAnonId(): Promise<string | null> {
+    return this.#adapter.getItem('anonId');
+  }
+
+  async getExtensionId(): Promise<string | null> {
+    return this.#adapter.getItem('extensionId');
+  }
+
+  async getChannelConfig(): Promise<ChannelConfig | null> {
+    const channelConfig = await this.#adapter.getItem('channelConfig');
+    if (!channelConfig) {
+      return null;
+    }
+    return JSON.parse(channelConfig)
+  }
+
+  async setChannelConfig(channelConfig: ChannelConfig): Promise<void> {
+    return this.#adapter.setItem('channelConfig', JSON.stringify(channelConfig));
+  }
+
+  async setAnonId(anonId: string): Promise<void> {
+    return this.#adapter.setItem('anonId', anonId);
+  }
+
+  async setExtensionId(extensionId: string): Promise<void> {
+    return this.#adapter.setItem('extensionId', extensionId);
+  }
+
+  async removeExtensionId(): Promise<void> {
+    return this.#adapter.deleteItem('extensionId');
+  }
+
+  async removeAnonId(): Promise<void> {
+    return this.#adapter.deleteItem('anonId');
+  }
+
+  async getDebug(): Promise<string | null> {
+    return this.#adapter.getItem('DEBUG');
+  }
+}

--- a/packages/sdk-multichain/src/store/index.ts
+++ b/packages/sdk-multichain/src/store/index.ts
@@ -1,4 +1,4 @@
-import type { ChannelConfig, StoreClient, StoreAdapter } from "../domain";
+import type {StoreClient, StoreAdapter } from "../domain";
 
 
 export class Store implements StoreClient {
@@ -14,18 +14,6 @@ export class Store implements StoreClient {
 
   async getExtensionId(): Promise<string | null> {
     return this.#adapter.getItem('extensionId');
-  }
-
-  async getChannelConfig(): Promise<ChannelConfig | null> {
-    const channelConfig = await this.#adapter.getItem('channelConfig');
-    if (!channelConfig) {
-      return null;
-    }
-    return JSON.parse(channelConfig)
-  }
-
-  async setChannelConfig(channelConfig: ChannelConfig): Promise<void> {
-    return this.#adapter.setItem('channelConfig', JSON.stringify(channelConfig));
   }
 
   async setAnonId(anonId: string): Promise<void> {


### PR DESCRIPTION
## Explanation
Storage adapters are used by the SDK and dApps to store specific values in the native storage, example, the anonId needed for Analytics. 

This PR integrates the Storage wrapper, a simple class that will be used across the SDK to abstract from the storage and provide a simple to use interface with, setAnonId, removeAnonId and other utility functions for other attributes.

We also integrate 3 different storages, RN, Browser and Node.
RN is using internally @react-native-async-storage/async-storage
Browser is using internally localstorage
Node is using internally FS

Added basic unitary test coverage

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
