### PR TITLE
docs: add Community Support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ See the full list of [JavaScript SDK options](https://docs.metamask.io/sdk/refer
 
 ## Contributing
 
+## Community Support
+
+If you need help, consider visiting the [MetaMask Help Center](https://support.metamask.io/).
+
+Please avoid opening GitHub Issues for general questions — use the official help resources instead.
+
+
 To contribute to MetaMask SDK, see the [contribution guidelines](./docs/contributing.md).
 
 ## Contacts


### PR DESCRIPTION
This PR adds a "Community Support" section to the README to help users find help resources and avoid using GitHub Issues for general questions.

