### PR TITLE
fix: remove code

### DIFF
--- a/packages/sdk-multichain/src/domain/ui/types.ts
+++ b/packages/sdk-multichain/src/domain/ui/types.ts
@@ -6,9 +6,6 @@ export interface InstallWidgetProps extends Components.MmInstallModal {
 	metaMaskInstaller: {
 		startDesktopOnboarding: () => void;
 	};
-	//TODO: remove this as its no longer needed
-	// biome-ignore lint/suspicious/noExplicitAny: will be removed soon
-	onAnalyticsEvent: (event: { event: any; params?: Record<string, unknown> }) => void;
 }
 
 export interface PendingWidgetProps extends Components.MmPendingModal {

--- a/packages/sdk-multichain/src/ui/index.test.ts
+++ b/packages/sdk-multichain/src/ui/index.test.ts
@@ -144,7 +144,6 @@ t.describe('UIModule', () => {
 				expect(document.body.contains(mockContainer)).toBe(true);
 
 				expect(mockFactoryOptions.installModal.render).toHaveBeenCalledWith({
-					onAnalyticsEvent: expect.any(Function),
 					onClose: expect.any(Function),
 					metaMaskInstaller: {
 						startDesktopOnboarding: expect.any(Function),

--- a/packages/sdk-multichain/src/ui/index.ts
+++ b/packages/sdk-multichain/src/ui/index.ts
@@ -71,9 +71,6 @@ export class UIModule extends ModalFactory {
 		await preload();
 		const container = this.getMountedContainer();
 		const modalProps: InstallWidgetProps = {
-			onAnalyticsEvent: () => {
-				//TODO: Remove in a later PR
-			},
 			onClose: this.unload.bind(this),
 			metaMaskInstaller: {
 				startDesktopOnboarding: () => {

--- a/packages/sdk-multichain/src/ui/web/install.ts
+++ b/packages/sdk-multichain/src/ui/web/install.ts
@@ -13,8 +13,6 @@ export class InstallModal extends AbstractInstallModal {
 
 		modal.addEventListener('startDesktopOnboarding', options.metaMaskInstaller.startDesktopOnboarding);
 
-		modal.addEventListener('trackAnalytics', ((e: CustomEvent) => options.onAnalyticsEvent?.(e.detail)) as EventListener);
-
 		return {
 			mount: () => {
 				options.parentElement?.appendChild(modal);


### PR DESCRIPTION
## Explanation
We remove onAnalytics event listener in the new modal abstraction as it is no longer needed. Whichever package can directly use the globally Analytics instance by just importing the package and it will just work.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
