### PR TITLE
fix: use underscore for all event names and adjust tests + trigger

### DIFF
--- a/packages/sdk-multichain/src/connect.test.ts
+++ b/packages/sdk-multichain/src/connect.test.ts
@@ -101,7 +101,7 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 			t.expect(sdk.storage).toBeDefined();
 			t.expect(mockedData.mockTransport.connect).toHaveBeenCalled();
 			t.expect(mockMultichainClient.getSession).toHaveBeenCalled();
-			t.expect(mockedData.emitSpy).toHaveBeenCalledWith('sessionChanged', mockSessionData);
+			t.expect(mockedData.emitSpy).toHaveBeenCalledWith('session_changed', mockSessionData);
 
 			mockedData.mockTransport.connect.mockReset();
 

--- a/packages/sdk-multichain/src/domain/events/types/index.ts
+++ b/packages/sdk-multichain/src/domain/events/types/index.ts
@@ -2,7 +2,7 @@ import type { SessionData } from '@metamask/multichain-api-client';
 
 export type SDKEvents = {
 	display_uri: [evt: string];
-	sessionChanged: [evt: SessionData | undefined];
+	session_changed: [evt: SessionData | undefined];
 };
 
 export type EventTypes = SDKEvents;

--- a/packages/sdk-multichain/src/init.test.ts
+++ b/packages/sdk-multichain/src/init.test.ts
@@ -117,7 +117,7 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 			t.expect(sdk.state).toBe('loaded');
 
 			// Check that sessionChanged event was emitted with the expected session data during initialization
-			t.expect(emitSpy).toHaveBeenCalledWith('sessionChanged', mockSessionData);
+			t.expect(emitSpy).toHaveBeenCalledWith('session_changed', mockSessionData);
 
 			// Restore the spy
 			emitSpy.mockRestore();

--- a/packages/sdk-multichain/src/multichain/index.ts
+++ b/packages/sdk-multichain/src/multichain/index.ts
@@ -137,9 +137,9 @@ export class MultichainSDK extends MultichainCore {
 			//TODO: We also should report this as an issue, sessions with no sessionScopes should be undefined, is there any reason
 			//why the object comes empty?
 			if (Object.keys(session?.sessionScopes ?? {}).length > 0) {
-				this.emit('sessionChanged', session);
+				this.emit('session_changed', session);
 			} else {
-				this.emit('sessionChanged', undefined);
+				this.emit('session_changed', undefined);
 			}
 		}
 	}
@@ -172,7 +172,7 @@ export class MultichainSDK extends MultichainCore {
 			this.listeners.push(listener);
 			const session = await this.getCurrentSession();
 			if (Object.keys(session?.sessionScopes ?? {}).length > 0) {
-				this.emit('sessionChanged', session);
+				this.emit('session_changed', session);
 			}
 		}
 	}
@@ -218,7 +218,7 @@ export class MultichainSDK extends MultichainCore {
 		const isSameScopes = currentScopes.every((scope) => proposedScopes.includes(scope)) && proposedScopes.every((scope) => currentScopes.includes(scope));
 
 		if (isSameScopes) {
-			this.emit('sessionChanged', session);
+			this.emit('session_changed', session);
 			return;
 		}
 
@@ -231,7 +231,7 @@ export class MultichainSDK extends MultichainCore {
 		const sessionRequest: CreateSessionParams<RPCAPI> = { optionalScopes };
 
 		const newSession = await this.provider.createSession(sessionRequest);
-		this.emit('sessionChanged', newSession);
+		this.emit('session_changed', newSession);
 	}
 
 	private getTransportForPlatformType(platformType: PlatformType) {
@@ -314,7 +314,7 @@ export class MultichainSDK extends MultichainCore {
 		__transport = undefined;
 		__provider = undefined;
 
-		this.emit('sessionChanged', undefined);
+		this.emit('session_changed', undefined);
 		this.listeners = [];
 
 		await this.storage.removeTransport();

--- a/packages/sdk-multichain/src/session.test.ts
+++ b/packages/sdk-multichain/src/session.test.ts
@@ -63,7 +63,7 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 			t.expect(sdk.storage).toBeDefined();
 			t.expect(mockedData.mockTransport.connect).toHaveBeenCalled();
 			t.expect(mockMultichainClient.getSession).toHaveBeenCalled();
-			t.expect(mockedData.emitSpy).toHaveBeenCalledWith('sessionChanged', mockSessionData);
+			t.expect(mockedData.emitSpy).toHaveBeenCalledWith('session_changed', mockSessionData);
 
 			const mockedSessionUpgradeData: SessionData = {
 				...mockSessionData,
@@ -88,7 +88,7 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 				optionalScopes: mockedSessionUpgradeData.sessionScopes,
 			});
 			// sessionChanged should be emitted with the full session data returned from createSession, not just the scopes
-			t.expect(mockedData.emitSpy).toHaveBeenCalledWith('sessionChanged', mockedSessionUpgradeData);
+			t.expect(mockedData.emitSpy).toHaveBeenCalledWith('session_changed', mockedSessionUpgradeData);
 		});
 
 		t.it(`${platform} should handle session retrieval when no session exists`, async () => {


### PR DESCRIPTION
## Explanation
The display_uri event is still not in use. The event is used when headless: true is enabled and will trigger an event when we should be displaying the modal with the QRCode.

SessionChange event is renamed to session_change and the code is improved to use that one instead of the camelCase version

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
