### PR TITLE
fix: missing export of esmodule on sdk-analytics

### DIFF
--- a/packages/sdk-analytics/package.json
+++ b/packages/sdk-analytics/package.json
@@ -6,7 +6,7 @@
   "module":"dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.ts --dts",
+    "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint src --ext .ts,.tsx --ignore-pattern 'src/schema.ts'",
     "lint:fix": "eslint src --ext .ts,.tsx --fix --ignore-pattern 'src/schema.ts'",
     "lint:changelog": "../../scripts/validate-changelog.sh @metamask/sdk-analytics",

--- a/packages/sdk-analytics/package.json
+++ b/packages/sdk-analytics/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.5",
   "description": "Analytics package for MetaMask SDK",
   "main": "dist/index.js",
+  "module":"dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --dts",

--- a/packages/sdk-analytics/package.json
+++ b/packages/sdk-analytics/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.5",
   "description": "Analytics package for MetaMask SDK",
   "main": "dist/index.js",
-  "module":"dist/index.mjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",


### PR DESCRIPTION
## Explanation
Adding missing esmodule export in analytics package json.
If a library using Analytics requests esm the file will not be available and cause some exceptions.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
