### PR TITLE
fix: get storage interfaces closer to mwp

### DIFF
--- a/packages/sdk-multichain/src/domain/store/adapter.ts
+++ b/packages/sdk-multichain/src/domain/store/adapter.ts
@@ -5,10 +5,7 @@ export type StoreOptions = Record<string, any>;
 export abstract class StoreAdapter {
 	abstract platform: 'web' | 'rn' | 'node';
 	constructor(public options?: StoreOptions) {}
-
-	abstract getItem(key: string): Promise<string | null>;
-
-	abstract setItem(key: string, value: string): Promise<void>;
-
-	abstract deleteItem(key: string): Promise<void>;
+	abstract get(key: string): Promise<string | null>;
+	abstract set(key: string, value: string): Promise<void>;
+	abstract delete(key: string): Promise<void>;
 }

--- a/packages/sdk-multichain/src/fixtures.test.ts
+++ b/packages/sdk-multichain/src/fixtures.test.ts
@@ -62,13 +62,17 @@ vi.mock('@metamask/multichain-api-client', () => {
 	};
 });
 
+type GetItem = (key: string) => string | null;
+type SetItem = (key: string, value: string) => void;
+type RemoveItem = (key: string) => void;
+type Clear = () => void;
+
 export type NativeStorageStub = {
-	platform: 'web' | 'rn' | 'node';
 	data: Map<string, string>;
-	getItem: t.Mock<(key: string) => Promise<string | null>>;
-	setItem: t.Mock<(key: string, value: string) => Promise<void>>;
-	deleteItem: t.Mock<(key: string) => Promise<void>>;
-	clear: t.Mock<() => void>;
+	getItem: t.Mock<GetItem>;
+	setItem: t.Mock<SetItem>;
+	removeItem: t.Mock<RemoveItem>;
+	clear: t.Mock<Clear>;
 };
 
 export type MockedData = {
@@ -161,18 +165,17 @@ export const createTest: CreateTestFN = ({ platform, options, createSDK, setupMo
 		mockMultichainClient.createSession.mockResolvedValue(mockSessionData);
 		mockMultichainClient.getSession.mockResolvedValue(mockSessionData);
 
-		// Create storage stub
+		// Create storage stub using the mocked class
 		nativeStorageStub = {
-			platform,
 			data: new Map<string, string>(),
-			getItem: vi.fn((key: string) => Promise.resolve(nativeStorageStub.data.get(key) || null)),
-			setItem: vi.fn((key: string, value: string) => {
+			getItem: t.vi.fn((key: string) => nativeStorageStub.data.get(key) || null),
+			setItem: t.vi.fn((key: string, value: string) => {
 				nativeStorageStub.data.set(key, value);
 			}),
-			deleteItem: vi.fn((key: string) => {
+			removeItem: t.vi.fn((key: string) => {
 				nativeStorageStub.data.delete(key);
 			}),
-			clear: vi.fn(() => {
+			clear: t.vi.fn(() => {
 				nativeStorageStub.data.clear();
 			}),
 		};

--- a/packages/sdk-multichain/src/init.test.ts
+++ b/packages/sdk-multichain/src/init.test.ts
@@ -38,7 +38,18 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 					enabled: platform !== 'node',
 					integrationType: 'test',
 				},
-				storage: new Store(mockedData.nativeStorageStub),
+				storage: new Store({
+					platform: platform as 'web' | 'rn' | 'node',
+					get(key) {
+						return Promise.resolve(mockedData.nativeStorageStub.getItem(key));
+					},
+					set(key, value) {
+						return Promise.resolve(mockedData.nativeStorageStub.setItem(key, value));
+					},
+					delete(key) {
+						return Promise.resolve(mockedData.nativeStorageStub.removeItem(key));
+					},
+				}),
 			};
 		});
 
@@ -152,14 +163,11 @@ createTest({
 	...baseTestOptions,
 	platform: 'node',
 	createSDK: createMetamaskSDKNode,
-	setupMocks: (nativeStorageStub) => {
+	setupMocks: () => {
 		const memfs = new Map<string, any>();
 		t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => memfs.has(path.toString()));
 		t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => memfs.set(path.toString(), data));
 		t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => memfs.get(path.toString()));
-		t.vi.spyOn(nodeStorage, 'StoreAdapterNode').mockImplementation(() => {
-			return nativeStorageStub as any;
-		});
 	},
 });
 
@@ -170,10 +178,7 @@ createTest({
 	setupMocks: (nativeStorageStub) => {
 		t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => nativeStorageStub.getItem(key));
 		t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => nativeStorageStub.setItem(key, value));
-		t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.deleteItem(key));
-		t.vi.spyOn(rnStorage, 'StoreAdapterRN').mockImplementation(() => {
-			return nativeStorageStub as any;
-		});
+		t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.removeItem(key));
 	},
 });
 
@@ -198,8 +203,5 @@ createTest({
 		t.vi.stubGlobal('window', globalStub);
 		t.vi.stubGlobal('location', dom.window.location);
 		t.vi.stubGlobal('document', dom.window.document);
-		t.vi.spyOn(webStorage, 'StoreAdapterWeb').mockImplementation(() => {
-			return nativeStorageStub as any;
-		});
 	},
 });

--- a/packages/sdk-multichain/src/invoke.test.ts
+++ b/packages/sdk-multichain/src/invoke.test.ts
@@ -45,7 +45,18 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 					enabled: platform !== 'node',
 					integrationType: 'test',
 				},
-				storage: new Store(mockedData.nativeStorageStub),
+				storage: new Store({
+					platform: platform as 'web' | 'rn' | 'node',
+					get(key) {
+						return Promise.resolve(mockedData.nativeStorageStub.getItem(key));
+					},
+					set(key, value) {
+						return Promise.resolve(mockedData.nativeStorageStub.setItem(key, value));
+					},
+					delete(key) {
+						return Promise.resolve(mockedData.nativeStorageStub.removeItem(key));
+					},
+				}),
 			};
 		});
 
@@ -130,14 +141,11 @@ createTest({
 	...baseTestOptions,
 	platform: 'node',
 	createSDK: createMetamaskSDKNode,
-	setupMocks: (nativeStorageStub) => {
+	setupMocks: () => {
 		const memfs = new Map<string, any>();
 		t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => memfs.has(path.toString()));
 		t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => memfs.set(path.toString(), data));
 		t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => memfs.get(path.toString()));
-		t.vi.spyOn(nodeStorage, 'StoreAdapterNode').mockImplementation(() => {
-			return nativeStorageStub as any;
-		});
 	},
 });
 
@@ -148,10 +156,7 @@ createTest({
 	setupMocks: (nativeStorageStub) => {
 		t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => nativeStorageStub.getItem(key));
 		t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => nativeStorageStub.setItem(key, value));
-		t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.deleteItem(key));
-		t.vi.spyOn(rnStorage, 'StoreAdapterRN').mockImplementation(() => {
-			return nativeStorageStub as any;
-		});
+		t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.removeItem(key));
 	},
 });
 
@@ -182,8 +187,5 @@ createTest({
 		t.vi.stubGlobal('document', dom.window.document);
 		t.vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
 		t.vi.stubGlobal('requestAnimationFrame', t.vi.fn());
-		t.vi.spyOn(webStorage, 'StoreAdapterWeb').mockImplementation(() => {
-			return nativeStorageStub as any;
-		});
 	},
 });

--- a/packages/sdk-multichain/src/store/adapters/node.ts
+++ b/packages/sdk-multichain/src/store/adapters/node.ts
@@ -15,7 +15,7 @@ export class StoreAdapterNode extends StoreAdapter {
 		}
 	}
 
-	async getItem(key: string): Promise<string | null> {
+	async get(key: string): Promise<string | null> {
 		if (!fs.existsSync(CONFIG_FILE)) {
 			return null;
 		}
@@ -27,7 +27,7 @@ export class StoreAdapterNode extends StoreAdapter {
 		return null;
 	}
 
-	async setItem(key: string, value: string): Promise<void> {
+	async set(key: string, value: string): Promise<void> {
 		if (!fs.existsSync(CONFIG_FILE)) {
 			fs.writeFileSync(CONFIG_FILE, '{}');
 		}
@@ -37,7 +37,7 @@ export class StoreAdapterNode extends StoreAdapter {
 		fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
 	}
 
-	async deleteItem(key: string): Promise<void> {
+	async delete(key: string): Promise<void> {
 		if (!fs.existsSync(CONFIG_FILE)) {
 			return;
 		}

--- a/packages/sdk-multichain/src/store/adapters/rn.ts
+++ b/packages/sdk-multichain/src/store/adapters/rn.ts
@@ -3,15 +3,15 @@ import { StoreAdapter } from '../../domain';
 
 export class StoreAdapterRN extends StoreAdapter {
 	readonly platform = 'rn';
-	async getItem(key: string): Promise<string | null> {
+	async get(key: string): Promise<string | null> {
 		return AsyncStorage.getItem(key);
 	}
 
-	async setItem(key: string, value: string): Promise<void> {
+	async set(key: string, value: string): Promise<void> {
 		return AsyncStorage.setItem(key, value);
 	}
 
-	async deleteItem(key: string): Promise<void> {
+	async delete(key: string): Promise<void> {
 		return AsyncStorage.removeItem(key);
 	}
 }

--- a/packages/sdk-multichain/src/store/adapters/web.ts
+++ b/packages/sdk-multichain/src/store/adapters/web.ts
@@ -9,15 +9,15 @@ export class StoreAdapterWeb extends StoreAdapter {
 		}
 		return window.localStorage;
 	}
-	async getItem(key: string): Promise<string | null> {
+	async get(key: string): Promise<string | null> {
 		return this.internal.getItem(key);
 	}
 
-	async setItem(key: string, value: string): Promise<void> {
+	async set(key: string, value: string): Promise<void> {
 		return this.internal.setItem(key, value);
 	}
 
-	async deleteItem(key: string): Promise<void> {
+	async delete(key: string): Promise<void> {
 		return this.internal.removeItem(key);
 	}
 }

--- a/packages/sdk-multichain/src/store/index.test.ts
+++ b/packages/sdk-multichain/src/store/index.test.ts
@@ -53,7 +53,7 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 
 	t.describe(`${adapterName} getAnonId`, () => {
 		t.it('should return the anonymous ID when it exists', async () => {
-			await adapter.setItem('anonId', 'test-anon-id');
+			await adapter.set('anonId', 'test-anon-id');
 			const result = await store.getAnonId();
 			t.expect(result).toBe('test-anon-id');
 		});
@@ -67,26 +67,26 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 	t.describe(`${adapterName} setAnonId`, () => {
 		t.it('should set the anonymous ID successfully', async () => {
 			await store.setAnonId('new-anon-id');
-			const result = await adapter.getItem('anonId');
+			const result = await adapter.get('anonId');
 			t.expect(result).toBe('new-anon-id');
 		});
 	});
 
 	t.describe(`${adapterName} removeAnonId`, () => {
 		t.it('should remove the anonymous ID successfully', async () => {
-			await adapter.setItem('anonId', 'test-anon-id');
-			const beforeRemove = await adapter.getItem('anonId');
+			await adapter.set('anonId', 'test-anon-id');
+			const beforeRemove = await adapter.get('anonId');
 			t.expect(beforeRemove).toBe('test-anon-id');
 
 			await store.removeAnonId();
-			const afterRemove = await adapter.getItem('anonId');
+			const afterRemove = await adapter.get('anonId');
 			t.expect(afterRemove).toBeNull();
 		});
 	});
 
 	t.describe(`${adapterName} getExtensionId`, () => {
 		t.it('should return the extension ID when it exists', async () => {
-			await adapter.setItem('extensionId', 'test-extension-id');
+			await adapter.set('extensionId', 'test-extension-id');
 			const result = await store.getExtensionId();
 			t.expect(result).toBe('test-extension-id');
 		});
@@ -100,26 +100,26 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 	t.describe(`${adapterName} setExtensionId`, () => {
 		t.it('should set the extension ID successfully', async () => {
 			await store.setExtensionId('new-extension-id');
-			const result = await adapter.getItem('extensionId');
+			const result = await adapter.get('extensionId');
 			t.expect(result).toBe('new-extension-id');
 		});
 	});
 
 	t.describe(`${adapterName} removeExtensionId`, () => {
 		t.it('should remove the extension ID successfully', async () => {
-			await adapter.setItem('extensionId', 'test-extension-id');
-			const beforeRemove = await adapter.getItem('extensionId');
+			await adapter.set('extensionId', 'test-extension-id');
+			const beforeRemove = await adapter.get('extensionId');
 			t.expect(beforeRemove).toBe('test-extension-id');
 
 			await store.removeExtensionId();
-			const afterRemove = await adapter.getItem('extensionId');
+			const afterRemove = await adapter.get('extensionId');
 			t.expect(afterRemove).toBeNull();
 		});
 	});
 
 	t.describe(`${adapterName} getDebug`, () => {
 		t.it('should return the debug value when it exists', async () => {
-			await adapter.setItem('DEBUG', 'metamask-sdk:*');
+			await adapter.set('DEBUG', 'metamask-sdk:*');
 			const result = await store.getDebug();
 			t.expect(result).toBe('metamask-sdk:*');
 		});
@@ -132,19 +132,19 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 
 	t.describe(`${adapterName} getTransport`, () => {
 		t.it('should return the transport value when it exists - Browser', async () => {
-			await adapter.setItem('multichain-transport', 'browser');
+			await adapter.set('multichain-transport', 'browser');
 			const result = await store.getTransport();
 			t.expect(result).toBe(TransportType.Browser);
 		});
 
 		t.it('should return the transport value when it exists - MPW', async () => {
-			await adapter.setItem('multichain-transport', 'mwp');
+			await adapter.set('multichain-transport', 'mwp');
 			const result = await store.getTransport();
 			t.expect(result).toBe(TransportType.MPW);
 		});
 
 		t.it('should return UNKNOWN for unknown transport types', async () => {
-			await adapter.setItem('multichain-transport', 'unknown-transport');
+			await adapter.set('multichain-transport', 'unknown-transport');
 			const result = await store.getTransport();
 			t.expect(result).toBe(TransportType.UNKNOWN);
 		});
@@ -158,31 +158,31 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 	t.describe(`${adapterName} setTransport`, () => {
 		t.it('should set the transport successfully - Browser', async () => {
 			await store.setTransport(TransportType.Browser);
-			const result = await adapter.getItem('multichain-transport');
+			const result = await adapter.get('multichain-transport');
 			t.expect(result).toBe('browser');
 		});
 
 		t.it('should set the transport successfully - MPW', async () => {
 			await store.setTransport(TransportType.MPW);
-			const result = await adapter.getItem('multichain-transport');
+			const result = await adapter.get('multichain-transport');
 			t.expect(result).toBe('mwp');
 		});
 
 		t.it('should set the transport successfully - UNKNOWN', async () => {
 			await store.setTransport(TransportType.UNKNOWN);
-			const result = await adapter.getItem('multichain-transport');
+			const result = await adapter.get('multichain-transport');
 			t.expect(result).toBe('unknown');
 		});
 	});
 
 	t.describe(`${adapterName} removeTransport`, () => {
 		t.it('should remove the transport successfully', async () => {
-			await adapter.setItem('multichain-transport', 'browser');
-			const beforeRemove = await adapter.getItem('multichain-transport');
+			await adapter.set('multichain-transport', 'browser');
+			const beforeRemove = await adapter.get('multichain-transport');
 			t.expect(beforeRemove).toBe('browser');
 
 			await store.removeTransport();
-			const afterRemove = await adapter.getItem('multichain-transport');
+			const afterRemove = await adapter.get('multichain-transport');
 			t.expect(afterRemove).toBeNull();
 		});
 	});
@@ -191,7 +191,7 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 	t.describe(`${adapterName} error handling`, () => {
 		t.it('should throw StorageGetErr when fetching a key fails', async () => {
 			const errorMessage = 'getItem failed';
-			t.vi.spyOn(adapter, 'getItem').mockRejectedValue(new Error(errorMessage));
+			t.vi.spyOn(adapter, 'get').mockRejectedValue(new Error(errorMessage));
 			await t.expect(store.getAnonId()).rejects.toBeInstanceOf(StorageGetErr);
 			await t.expect(store.getExtensionId()).rejects.toBeInstanceOf(StorageGetErr);
 			await t.expect(store.getDebug()).rejects.toBeInstanceOf(StorageGetErr);
@@ -200,7 +200,7 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 
 		t.it('should throw StorageSetErr when setting a key fails', async () => {
 			const errorMessage = 'setItem failed';
-			t.vi.spyOn(adapter, 'setItem').mockRejectedValue(new Error(errorMessage));
+			t.vi.spyOn(adapter, 'set').mockRejectedValue(new Error(errorMessage));
 			await t.expect(store.setAnonId('test-id')).rejects.toThrow(StorageSetErr);
 			await t.expect(store.setExtensionId('test-id')).rejects.toThrow(StorageSetErr);
 			await t.expect(store.setTransport(TransportType.Browser)).rejects.toThrow(StorageSetErr);
@@ -208,7 +208,7 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 
 		t.it('should throw StorageDeleteErr when removing a key fails', async () => {
 			const errorMessage = 'deleteItem failed';
-			t.vi.spyOn(adapter, 'deleteItem').mockRejectedValue(new Error(errorMessage));
+			t.vi.spyOn(adapter, 'delete').mockRejectedValue(new Error(errorMessage));
 			await t.expect(store.removeAnonId()).rejects.toThrow(StorageDeleteErr);
 			await t.expect(store.removeExtensionId()).rejects.toThrow(StorageDeleteErr);
 			await t.expect(store.removeTransport()).rejects.toThrow(StorageDeleteErr);

--- a/packages/sdk-multichain/src/store/index.ts
+++ b/packages/sdk-multichain/src/store/index.ts
@@ -13,7 +13,7 @@ export class Store implements StoreClient {
 
 	async getTransport(): Promise<TransportType | null> {
 		try {
-			const transport = await this.#adapter.getItem('multichain-transport');
+			const transport = await this.#adapter.get('multichain-transport');
 			if (!transport) {
 				return null;
 			}
@@ -25,7 +25,7 @@ export class Store implements StoreClient {
 
 	async setTransport(transport: TransportType): Promise<void> {
 		try {
-			await this.#adapter.setItem('multichain-transport', transport);
+			await this.#adapter.set('multichain-transport', transport);
 		} catch (err) {
 			throw new StorageSetErr(this.#adapter.platform, 'multichain-transport', err.message);
 		}
@@ -33,7 +33,7 @@ export class Store implements StoreClient {
 
 	async removeTransport(): Promise<void> {
 		try {
-			await this.#adapter.deleteItem('multichain-transport');
+			await this.#adapter.delete('multichain-transport');
 		} catch (err) {
 			throw new StorageDeleteErr(this.#adapter.platform, 'multichain-transport', err.message);
 		}
@@ -41,12 +41,12 @@ export class Store implements StoreClient {
 
 	async getAnonId(): Promise<string> {
 		try {
-			const anonId = await this.#adapter.getItem('anonId');
+			const anonId = await this.#adapter.get('anonId');
 			if (anonId) {
 				return anonId;
 			}
 			const newAnonId = uuid.v4();
-			await this.#adapter.setItem('anonId', newAnonId);
+			await this.#adapter.set('anonId', newAnonId);
 			return newAnonId;
 		} catch (err) {
 			throw new StorageGetErr(this.#adapter.platform, 'anonId', err.message);
@@ -55,7 +55,7 @@ export class Store implements StoreClient {
 
 	async getExtensionId(): Promise<string | null> {
 		try {
-			return await this.#adapter.getItem('extensionId');
+			return await this.#adapter.get('extensionId');
 		} catch (err) {
 			throw new StorageGetErr(this.#adapter.platform, 'extensionId', err.message);
 		}
@@ -63,7 +63,7 @@ export class Store implements StoreClient {
 
 	async setAnonId(anonId: string): Promise<void> {
 		try {
-			return await this.#adapter.setItem('anonId', anonId);
+			return await this.#adapter.set('anonId', anonId);
 		} catch (err) {
 			throw new StorageSetErr(this.#adapter.platform, 'anonId', err.message);
 		}
@@ -71,7 +71,7 @@ export class Store implements StoreClient {
 
 	async setExtensionId(extensionId: string): Promise<void> {
 		try {
-			return await this.#adapter.setItem('extensionId', extensionId);
+			return await this.#adapter.set('extensionId', extensionId);
 		} catch (err) {
 			throw new StorageSetErr(this.#adapter.platform, 'extensionId', err.message);
 		}
@@ -79,7 +79,7 @@ export class Store implements StoreClient {
 
 	async removeExtensionId(): Promise<void> {
 		try {
-			return await this.#adapter.deleteItem('extensionId');
+			return await this.#adapter.delete('extensionId');
 		} catch (err) {
 			throw new StorageDeleteErr(this.#adapter.platform, 'extensionId', err.message);
 		}
@@ -87,7 +87,7 @@ export class Store implements StoreClient {
 
 	async removeAnonId(): Promise<void> {
 		try {
-			return await this.#adapter.deleteItem('anonId');
+			return await this.#adapter.delete('anonId');
 		} catch (err) {
 			throw new StorageDeleteErr(this.#adapter.platform, 'anonId', err.message);
 		}
@@ -95,7 +95,7 @@ export class Store implements StoreClient {
 
 	async getDebug(): Promise<string | null> {
 		try {
-			return await this.#adapter.getItem('DEBUG');
+			return await this.#adapter.get('DEBUG');
 		} catch (err) {
 			throw new StorageGetErr(this.#adapter.platform, 'DEBUG', err.message);
 		}


### PR DESCRIPTION
## Explanation
Shift storage interfaces to be closer to the ones mwp is using. We will then be able to use 1 single storage adapter across all our flow.

Improved tests to make sure its using the right storage for each test case, was incorrectly mocking whole store which is not ideal.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
