### PR TITLE
fix:add indexdb storage

### DIFF
--- a/packages/sdk-multichain/package.json
+++ b/packages/sdk-multichain/package.json
@@ -34,6 +34,7 @@
     "@react-native-async-storage/async-storage": "^1.19.6",
     "@vitest/coverage-v8": "^3.2.4",
     "esbuild-plugin-umd-wrapper": "^3.0.0",
+    "fake-indexeddb": "^6.0.1",
     "jsdom": "^26.1.0",
     "nock": "^14.0.4",
     "prettier": "^3.3.3",

--- a/packages/sdk-multichain/src/connect.test.ts
+++ b/packages/sdk-multichain/src/connect.test.ts
@@ -1,15 +1,9 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Tests require it */
 /** biome-ignore-all lint/style/noNonNullAssertion: Tests require it */
-import fs from 'node:fs';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { JSDOM as Page } from 'jsdom';
 import * as t from 'vitest';
 import type { MultiChainFNOptions, MultichainCore, Scope } from './domain';
 // Carefull, order of import matters to keep mocks working
-import { createTest, type MockedData, mockSessionData, type TestSuiteOptions } from './fixtures.test';
-import { createMetamaskSDK as createMetamaskSDKWeb } from './index.browser';
-import { createMetamaskSDK as createMetamaskSDKRN } from './index.native';
-import { createMetamaskSDK as createMetamaskSDKNode } from './index.node';
+import { runTestsInNodeEnv, runTestsInRNEnv, runTestsInWebEnv, type MockedData, mockSessionData, type TestSuiteOptions } from './fixtures.test';
 import { Store } from './store';
 
 function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options: sdkOptions, ...options }: TestSuiteOptions<T>) {
@@ -228,70 +222,8 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 
 const exampleDapp = { name: 'Test Dapp', url: 'https://test.dapp' };
 
-const baseTestOptions = { options: { dapp: exampleDapp }, tests: testSuite };
+const baseTestOptions = { dapp: exampleDapp };
 
-createTest({
-	...baseTestOptions,
-	platform: 'node',
-	createSDK: createMetamaskSDKNode,
-	setupMocks: () => {
-		const memfs = new Map<string, any>();
-		t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => {
-			return memfs.has(path.toString());
-		});
-		t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => {
-			return memfs.set(path.toString(), data);
-		});
-		t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => {
-			return memfs.get(path.toString());
-		});
-	},
-});
-
-createTest({
-	...baseTestOptions,
-	platform: 'rn',
-	createSDK: createMetamaskSDKRN,
-	setupMocks: (nativeStorageStub) => {
-		t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => {
-			return nativeStorageStub.getItem(key);
-		});
-		t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => {
-			return nativeStorageStub.setItem(key, value);
-		});
-		t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => {
-			return nativeStorageStub.removeItem(key);
-		});
-	},
-});
-
-createTest({
-	...baseTestOptions,
-	platform: 'web',
-	createSDK: createMetamaskSDKWeb,
-	setupMocks: (nativeStorageStub) => {
-		const dom = new Page('<!DOCTYPE html><p>Hello world</p>', { url: exampleDapp.url });
-		const globalStub = {
-			...dom.window,
-			addEventListener: t.vi.fn(),
-			removeEventListener: t.vi.fn(),
-			localStorage: nativeStorageStub,
-			ethereum: {
-				isMetaMask: true,
-			},
-		};
-		t.vi.stubGlobal('navigator', {
-			...dom.window.navigator,
-			product: 'Chrome',
-			language: 'en-US',
-		});
-		t.vi.stubGlobal('window', globalStub);
-		t.vi.stubGlobal('location', dom.window.location);
-		t.vi.stubGlobal('document', dom.window.document);
-		t.vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
-		t.vi.stubGlobal('requestAnimationFrame', t.vi.fn());
-		// t.vi.spyOn(webStorage, 'StoreAdapterWeb').mockImplementation(() => {
-		// 	return nativeStorageStub as any;
-		// });
-	},
-});
+runTestsInNodeEnv(baseTestOptions, testSuite);
+runTestsInRNEnv(baseTestOptions, testSuite);
+runTestsInWebEnv(baseTestOptions, testSuite, exampleDapp.url);

--- a/packages/sdk-multichain/src/invoke.test.ts
+++ b/packages/sdk-multichain/src/invoke.test.ts
@@ -1,20 +1,11 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Tests require it */
 /** biome-ignore-all lint/style/noNonNullAssertion: Tests require it */
-import fs from 'node:fs';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { JSDOM as Page } from 'jsdom';
 import * as t from 'vitest';
 import { vi } from 'vitest';
 import type { InvokeMethodOptions, MultiChainFNOptions, MultichainCore } from './domain';
 // Carefull, order of import matters to keep mocks working
-import { createTest, type MockedData, type TestSuiteOptions } from './fixtures.test';
-import { createMetamaskSDK as createMetamaskSDKWeb } from './index.browser';
-import { createMetamaskSDK as createMetamaskSDKRN } from './index.native';
-import { createMetamaskSDK as createMetamaskSDKNode } from './index.node';
+import { runTestsInNodeEnv, runTestsInRNEnv, runTestsInWebEnv, type MockedData, type TestSuiteOptions } from './fixtures.test';
 import { Store } from './store';
-import * as nodeStorage from './store/adapters/node';
-import * as rnStorage from './store/adapters/rn';
-import * as webStorage from './store/adapters/web';
 
 vi.mock('cross-fetch', () => {
 	const mockFetch = vi.fn();
@@ -135,57 +126,8 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 
 const exampleDapp = { name: 'Test Dapp', url: 'https://test.dapp' };
 
-const baseTestOptions = { options: { dapp: exampleDapp }, tests: testSuite };
+const baseTestOptions = { dapp: exampleDapp };
 
-createTest({
-	...baseTestOptions,
-	platform: 'node',
-	createSDK: createMetamaskSDKNode,
-	setupMocks: () => {
-		const memfs = new Map<string, any>();
-		t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => memfs.has(path.toString()));
-		t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => memfs.set(path.toString(), data));
-		t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => memfs.get(path.toString()));
-	},
-});
-
-createTest({
-	...baseTestOptions,
-	platform: 'rn',
-	createSDK: createMetamaskSDKRN,
-	setupMocks: (nativeStorageStub) => {
-		t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => nativeStorageStub.getItem(key));
-		t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => nativeStorageStub.setItem(key, value));
-		t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.removeItem(key));
-	},
-});
-
-createTest({
-	...baseTestOptions,
-	platform: 'web',
-	createSDK: createMetamaskSDKWeb,
-	setupMocks: (nativeStorageStub) => {
-		const dom = new Page('<!DOCTYPE html><p>Hello world</p>', {
-			url: exampleDapp.url,
-		});
-		const globalStub = {
-			...dom.window,
-			addEventListener: t.vi.fn(),
-			removeEventListener: t.vi.fn(),
-			localStorage: nativeStorageStub,
-			ethereum: {
-				isMetaMask: true,
-			},
-		};
-		t.vi.stubGlobal('navigator', {
-			...dom.window.navigator,
-			product: 'Chrome',
-			language: 'en-US',
-		});
-		t.vi.stubGlobal('window', globalStub);
-		t.vi.stubGlobal('location', dom.window.location);
-		t.vi.stubGlobal('document', dom.window.document);
-		t.vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
-		t.vi.stubGlobal('requestAnimationFrame', t.vi.fn());
-	},
-});
+runTestsInNodeEnv(baseTestOptions, testSuite);
+runTestsInRNEnv(baseTestOptions, testSuite);
+runTestsInWebEnv(baseTestOptions, testSuite, exampleDapp.url);

--- a/packages/sdk-multichain/src/session.test.ts
+++ b/packages/sdk-multichain/src/session.test.ts
@@ -1,18 +1,9 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Tests require it */
 /** biome-ignore-all lint/style/noNonNullAssertion: Tests require it */
-import fs from 'node:fs';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { JSDOM as Page } from 'jsdom';
 import * as t from 'vitest';
 import type { MultiChainFNOptions, MultichainCore, Scope, SessionData } from './domain';
 // Carefull, order of import matters to keep mocks working
-import { createTest, type MockedData, mockSessionData, type TestSuiteOptions } from './fixtures.test';
-import { createMetamaskSDK as createMetamaskSDKWeb } from './index.browser';
-import { createMetamaskSDK as createMetamaskSDKRN } from './index.native';
-import { createMetamaskSDK as createMetamaskSDKNode } from './index.node';
-import * as nodeStorage from './store/adapters/node';
-import * as rnStorage from './store/adapters/rn';
-import * as webStorage from './store/adapters/web';
+import { runTestsInNodeEnv, runTestsInRNEnv, runTestsInWebEnv, type MockedData, mockSessionData, type TestSuiteOptions } from './fixtures.test';
 
 import * as loggerModule from './domain/logger';
 import { Store } from './store';
@@ -147,57 +138,8 @@ function testSuite<T extends MultiChainFNOptions>({ platform, createSDK, options
 
 const exampleDapp = { name: 'Test Dapp', url: 'https://test.dapp' };
 
-const baseTestOptions = { options: { dapp: exampleDapp }, tests: testSuite };
+const baseTestOptions = { dapp: exampleDapp };
 
-createTest({
-	...baseTestOptions,
-	platform: 'node',
-	createSDK: createMetamaskSDKNode,
-	setupMocks: () => {
-		const memfs = new Map<string, any>();
-		t.vi.spyOn(fs, 'existsSync').mockImplementation((path) => memfs.has(path.toString()));
-		t.vi.spyOn(fs, 'writeFileSync').mockImplementation((path, data) => memfs.set(path.toString(), data));
-		t.vi.spyOn(fs, 'readFileSync').mockImplementation((path) => memfs.get(path.toString()));
-	},
-});
-
-createTest({
-	...baseTestOptions,
-	platform: 'rn',
-	createSDK: createMetamaskSDKRN,
-	setupMocks: (nativeStorageStub) => {
-		t.vi.spyOn(AsyncStorage, 'getItem').mockImplementation(async (key) => nativeStorageStub.getItem(key));
-		t.vi.spyOn(AsyncStorage, 'setItem').mockImplementation(async (key, value) => nativeStorageStub.setItem(key, value));
-		t.vi.spyOn(AsyncStorage, 'removeItem').mockImplementation(async (key) => nativeStorageStub.removeItem(key));
-	},
-});
-
-createTest({
-	...baseTestOptions,
-	platform: 'web',
-	createSDK: createMetamaskSDKWeb,
-	setupMocks: (nativeStorageStub) => {
-		const dom = new Page('<!DOCTYPE html><p>Hello world</p>', {
-			url: exampleDapp.url,
-		});
-		const globalStub = {
-			...dom.window,
-			addEventListener: t.vi.fn(),
-			removeEventListener: t.vi.fn(),
-			localStorage: nativeStorageStub,
-			ethereum: {
-				isMetaMask: true,
-			},
-		};
-		t.vi.stubGlobal('navigator', {
-			...dom.window.navigator,
-			product: 'Chrome',
-			language: 'en-US',
-		});
-		t.vi.stubGlobal('window', globalStub);
-		t.vi.stubGlobal('location', dom.window.location);
-		t.vi.stubGlobal('document', dom.window.document);
-		t.vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
-		t.vi.stubGlobal('requestAnimationFrame', t.vi.fn());
-	},
-});
+runTestsInNodeEnv(baseTestOptions, testSuite);
+runTestsInRNEnv(baseTestOptions, testSuite);
+runTestsInWebEnv(baseTestOptions, testSuite, exampleDapp.url);

--- a/packages/sdk-multichain/src/store/adapters/web.ts
+++ b/packages/sdk-multichain/src/store/adapters/web.ts
@@ -1,23 +1,72 @@
 import { StoreAdapter } from '../../domain';
 
+type kvStores = 'sdk-kv-store' | 'key-value-pairs';
+
 export class StoreAdapterWeb extends StoreAdapter {
+	static readonly DB_NAME = 'multichain-kv-store';
+
 	readonly platform = 'web';
+	readonly dbPromise: Promise<IDBDatabase>;
 
 	private get internal() {
-		if (typeof window === 'undefined' || !window.localStorage) {
-			throw new Error('localStorage is not available in this environment');
+		if (typeof window === 'undefined' || !window.indexedDB) {
+			throw new Error('indexedDB is not available in this environment');
 		}
-		return window.localStorage;
+		return window.indexedDB;
 	}
+
+	constructor(
+		private storeName: kvStores = 'sdk-kv-store',
+		private prefix = 'mwp-',
+	) {
+		super();
+		this.dbPromise = new Promise((resolve, reject) => {
+			const request = this.internal.open(StoreAdapterWeb.DB_NAME, 1);
+			request.onerror = () => reject(new Error('Failed to open IndexedDB.'));
+			request.onsuccess = () => resolve(request.result);
+			request.onupgradeneeded = () => {
+				request.result.createObjectStore(storeName);
+			};
+		});
+	}
+
 	async get(key: string): Promise<string | null> {
-		return this.internal.getItem(key);
+		const { storeName } = this;
+		const db = await this.dbPromise;
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(storeName, 'readonly');
+			const store = tx.objectStore(storeName);
+			const request = store.get(this.getKey(key));
+			request.onerror = () => reject(new Error('Failed to get value from IndexedDB.'));
+			request.onsuccess = () => resolve((request.result as string) ?? null);
+		});
 	}
 
 	async set(key: string, value: string): Promise<void> {
-		return this.internal.setItem(key, value);
+		const { storeName } = this;
+		const db = await this.dbPromise;
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(storeName, 'readwrite');
+			const store = tx.objectStore(storeName);
+			const request = store.put(value, this.getKey(key));
+			request.onerror = () => reject(new Error('Failed to set value in IndexedDB.'));
+			request.onsuccess = () => resolve();
+		});
 	}
 
 	async delete(key: string): Promise<void> {
-		return this.internal.removeItem(key);
+		const { storeName } = this;
+		const db = await this.dbPromise;
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(storeName, 'readwrite');
+			const store = tx.objectStore(storeName);
+			const request = store.delete(this.getKey(key));
+			request.onerror = () => reject(new Error('Failed to delete value from IndexedDB.'));
+			request.onsuccess = () => resolve();
+		});
+	}
+
+	private getKey(key: string): string {
+		return `${this.prefix}${key}`;
 	}
 }

--- a/packages/sdk-multichain/src/store/index.test.ts
+++ b/packages/sdk-multichain/src/store/index.test.ts
@@ -11,6 +11,7 @@ import { StoreAdapterNode } from './adapters/node';
 import { StoreAdapterRN } from './adapters/rn';
 import { StoreAdapterWeb } from './adapters/web';
 import { Store } from './index';
+import { IDBFactory as FakeIndexedDB } from 'fake-indexeddb';
 
 /**
  * Dummy mocked storage to keep track of data between tests
@@ -42,6 +43,7 @@ function createStoreTests(adapterName: string, createAdapter: () => StoreAdapter
 
 	t.afterEach(async () => {
 		nativeStorageStub.data.clear();
+
 		cleanupMocks?.();
 	});
 
@@ -246,6 +248,7 @@ t.describe(`Store with WebAdapter`, () => {
 		() => {
 			t.vi.stubGlobal('window', {
 				localStorage: nativeStorageStub,
+				indexedDB: new FakeIndexedDB(),
 			});
 		},
 	);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11231,6 +11231,7 @@ __metadata:
     cross-fetch: ^4.1.0
     esbuild-plugin-umd-wrapper: ^3.0.0
     eventemitter3: ^5.0.1
+    fake-indexeddb: ^6.0.1
     jsdom: ^26.1.0
     nock: ^14.0.4
     prettier: ^3.3.3
@@ -32012,6 +32013,13 @@ __metadata:
   version: 0.1.8
   resolution: "eyes@npm:0.1.8"
   checksum: c31703a92bf36ba75ee8d379ee7985c24ee6149f3a6175f44cec7a05b178c38bce9836d3ca48c9acb0329a960ac2c4b2ead4e60cdd4fe6e8c92cad7cd6913687
+  languageName: node
+  linkType: hard
+
+"fake-indexeddb@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "fake-indexeddb@npm:6.0.1"
+  checksum: c4b8a0576cf3165238494b67641539d4ff36194e038b36e6992449eb882923dfaadba78a62cfc7d5ae9a5c0ac2fa1e70af5cb6c2228dc764ac79b65f0e68e942
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation
Add simple storage wrapper using indexeddb for web platforms and dapps. 
This same new storage will be used for dappClient and mwp.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
