### PR TITLE
fix: emit proper events when extension provider connection is cancelled or rejected

### DIFF
--- a/packages/sdk/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/ProviderManager/connectWithExtensionProvider.test.ts
@@ -1,5 +1,6 @@
 import { EventType, TrackingEvents } from '@metamask/sdk-communication-layer';
 import { MetaMaskSDK } from '../../../sdk';
+import { MetaMaskSDKEvent } from '../../../types/MetaMaskSDKEvents';
 import { PROVIDER_UPDATE_TYPE } from '../../../types/ProviderUpdateType';
 import { STORAGE_PROVIDER_TYPE } from '../../../config';
 import * as loggerModule from '../../../utils/logger';
@@ -68,16 +69,39 @@ describe('connectWithExtensionProvider', () => {
   });
 
   it('should handle error during account request', async () => {
-    mockRequest.mockRejectedValue(new Error('Some error'));
+    const error = new Error('User rejected the request');
+    mockRequest.mockRejectedValue(error);
 
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const originalProvider = instance.activeProvider;
+    instance.sdkProvider = originalProvider;
 
-    await connectWithExtensionProvider(instance);
+    await expect(connectWithExtensionProvider(instance)).rejects.toThrow(
+      'User rejected the request',
+    );
 
+    // Should log the error
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       `[MetaMaskSDK: connectWithExtensionProvider()] can't request accounts error`,
-      new Error('Some error'),
+      error,
     );
+
+    // Should emit ConnectWithResponse event with error
+    expect(instance.emit).toHaveBeenCalledWith(
+      MetaMaskSDKEvent.ConnectWithResponse,
+      { error },
+    );
+
+    // Should send analytics event for rejection
+    expect(mockSendAnalyticsEvent).toHaveBeenCalledWith({
+      event: TrackingEvents.REJECTED,
+    });
+
+    // Should restore original provider
+    expect(instance.activeProvider).toBe(originalProvider);
+    expect((global.window as any).ethereum).toBe(originalProvider);
+
+    consoleWarnSpy.mockRestore();
   });
 
   it('should log debug information', async () => {
@@ -118,5 +142,57 @@ describe('connectWithExtensionProvider', () => {
   it('should set instance.extensionActive to true if connection is successful', async () => {
     await connectWithExtensionProvider(instance);
     expect(instance.extensionActive).toBe(true);
+  });
+
+  it('should handle error when analytics is disabled', async () => {
+    const error = new Error('Connection cancelled');
+    mockRequest.mockRejectedValue(error);
+
+    // Disable analytics
+    instance.options.enableAnalytics = false;
+
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const originalProvider = instance.activeProvider;
+    instance.sdkProvider = originalProvider;
+
+    await expect(connectWithExtensionProvider(instance)).rejects.toThrow(
+      'Connection cancelled',
+    );
+
+    // Should still emit the error event
+    expect(instance.emit).toHaveBeenCalledWith(
+      MetaMaskSDKEvent.ConnectWithResponse,
+      { error },
+    );
+
+    // Should NOT send analytics event when disabled
+    expect(mockSendAnalyticsEvent).not.toHaveBeenCalledWith({
+      event: TrackingEvents.REJECTED,
+    });
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should handle error when sdkProvider is not set', async () => {
+    const error = new Error('User denied access');
+    mockRequest.mockRejectedValue(error);
+
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    instance.sdkProvider = undefined; // No previous provider to restore
+
+    await expect(connectWithExtensionProvider(instance)).rejects.toThrow(
+      'User denied access',
+    );
+
+    // Should emit error event
+    expect(instance.emit).toHaveBeenCalledWith(
+      MetaMaskSDKEvent.ConnectWithResponse,
+      { error },
+    );
+
+    // activeProvider should be set to extension (not restored since no sdkProvider)
+    expect(instance.activeProvider).toStrictEqual((global.window as any).extension);
+
+    consoleWarnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Explanation

This PR fixes an issue where SDK hooks do not receive feedback when users cancel or close the MetaMask extension connection window. Previously reported in issues #214 and partially addressed in #1202, this problem persisted because `connectWithExtensionProvider` was silently catching and ignoring connection errors without emitting appropriate events.

## References

* Related to #214 and #1202

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
