### PR TITLE
feat: Add option to hide return modal

### DIFF
--- a/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.test.ts
+++ b/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.test.ts
@@ -36,20 +36,20 @@ describe('RemoteCommunicationPostMessageStream', () => {
     );
   });
 
-  it('should initialize with hideReturnToAppModal option', () => {
+  it('should initialize with hideReturnToAppNotification option', () => {
     const instanceWithOption = new RemoteCommunicationPostMessageStream({
       name: ProviderConstants.PROVIDER,
       remote: mockRemoteCommunication,
       deeplinkProtocol: false,
       platformManager: mockPlatformManager,
-      hideReturnToAppModal: true,
+      hideReturnToAppNotification: true,
     });
 
-    expect(instanceWithOption.state.hideReturnToAppModal).toBe(true);
+    expect(instanceWithOption.state.hideReturnToAppNotification).toBe(true);
   });
 
-  it('should have hideReturnToAppModal as false by default', () => {
-    expect(instance.state.hideReturnToAppModal).toBe(false);
+  it('should have hideReturnToAppNotification as false by default', () => {
+    expect(instance.state.hideReturnToAppNotification).toBe(false);
   });
 
   it('should call _write properly', async () => {

--- a/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.test.ts
+++ b/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.test.ts
@@ -36,6 +36,22 @@ describe('RemoteCommunicationPostMessageStream', () => {
     );
   });
 
+  it('should initialize with hideReturnToAppModal option', () => {
+    const instanceWithOption = new RemoteCommunicationPostMessageStream({
+      name: ProviderConstants.PROVIDER,
+      remote: mockRemoteCommunication,
+      deeplinkProtocol: false,
+      platformManager: mockPlatformManager,
+      hideReturnToAppModal: true,
+    });
+
+    expect(instanceWithOption.state.hideReturnToAppModal).toBe(true);
+  });
+
+  it('should have hideReturnToAppModal as false by default', () => {
+    expect(instance.state.hideReturnToAppModal).toBe(false);
+  });
+
   it('should call _write properly', async () => {
     const chunk = 'someData';
     const encoding = 'utf8';

--- a/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts
+++ b/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts
@@ -14,7 +14,7 @@ interface RemoteCommunicationPostMessageStreamState {
   _name: any;
   remote: RemoteCommunication | null;
   deeplinkProtocol: boolean;
-  hideReturnToAppModal?: boolean;
+  hideReturnToAppNotification?: boolean;
   platformManager: PlatformManager | null;
 }
 
@@ -26,7 +26,7 @@ export class RemoteCommunicationPostMessageStream
     _name: null,
     remote: null,
     deeplinkProtocol: false,
-    hideReturnToAppModal: false,
+    hideReturnToAppNotification: false,
     platformManager: null,
   };
 
@@ -34,12 +34,12 @@ export class RemoteCommunicationPostMessageStream
     name,
     remote,
     deeplinkProtocol,
-    hideReturnToAppModal,
+    hideReturnToAppNotification,
     platformManager,
   }: {
     name: ProviderConstants;
     deeplinkProtocol: boolean;
-    hideReturnToAppModal?: boolean;
+    hideReturnToAppNotification?: boolean;
     remote: RemoteCommunication;
     platformManager: PlatformManager;
   }) {
@@ -49,8 +49,8 @@ export class RemoteCommunicationPostMessageStream
     this.state._name = name;
     this.state.remote = remote;
     this.state.deeplinkProtocol = deeplinkProtocol;
-    this.state.hideReturnToAppModal =
-      hideReturnToAppModal ?? this.state.hideReturnToAppModal;
+    this.state.hideReturnToAppNotification =
+      hideReturnToAppNotification ?? this.state.hideReturnToAppNotification;
     this.state.platformManager = platformManager;
 
     this._onMessage = this._onMessage.bind(this);

--- a/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts
+++ b/packages/sdk/src/PostMessageStream/RemoteCommunicationPostMessageStream.ts
@@ -14,6 +14,7 @@ interface RemoteCommunicationPostMessageStreamState {
   _name: any;
   remote: RemoteCommunication | null;
   deeplinkProtocol: boolean;
+  hideReturnToAppModal?: boolean;
   platformManager: PlatformManager | null;
 }
 
@@ -25,6 +26,7 @@ export class RemoteCommunicationPostMessageStream
     _name: null,
     remote: null,
     deeplinkProtocol: false,
+    hideReturnToAppModal: false,
     platformManager: null,
   };
 
@@ -32,10 +34,12 @@ export class RemoteCommunicationPostMessageStream
     name,
     remote,
     deeplinkProtocol,
+    hideReturnToAppModal,
     platformManager,
   }: {
     name: ProviderConstants;
     deeplinkProtocol: boolean;
+    hideReturnToAppModal?: boolean;
     remote: RemoteCommunication;
     platformManager: PlatformManager;
   }) {
@@ -45,6 +49,8 @@ export class RemoteCommunicationPostMessageStream
     this.state._name = name;
     this.state.remote = remote;
     this.state.deeplinkProtocol = deeplinkProtocol;
+    this.state.hideReturnToAppModal =
+      hideReturnToAppModal ?? this.state.hideReturnToAppModal;
     this.state.platformManager = platformManager;
 
     this._onMessage = this._onMessage.bind(this);

--- a/packages/sdk/src/PostMessageStream/getPostMessageStream.test.ts
+++ b/packages/sdk/src/PostMessageStream/getPostMessageStream.test.ts
@@ -59,4 +59,38 @@ describe('getPostMessageStream', () => {
       platformManager: fakePlatformManager,
     });
   });
+
+  it('should pass hideReturnToAppModal from remoteConnection state', () => {
+    const fakeConnector = {};
+    const fakePlatformManager = {};
+    const hideReturnToAppModal = true;
+    mockRemoteConnection.mockImplementation(
+      () =>
+        ({
+          getConnector: jest.fn().mockReturnValue(fakeConnector),
+          getPlatformManager: jest.fn().mockReturnValue(fakePlatformManager),
+          state: {
+            deeplinkProtocol: false,
+            hideReturnToAppModal,
+          },
+        } as any),
+    );
+
+    const result = getPostMessageStream({
+      name: ProviderConstants.CONTENT_SCRIPT,
+      remoteConnection: new RemoteConnection({
+        getConnector: jest.fn().mockReturnValue(fakeConnector),
+      } as any),
+      debug: false,
+    } as any);
+
+    expect(result).toBeInstanceOf(RemoteCommunicationPostMessageStream);
+    expect(mockPostMessageStream).toHaveBeenCalledWith({
+      name: ProviderConstants.CONTENT_SCRIPT,
+      remote: fakeConnector,
+      deeplinkProtocol: false,
+      platformManager: fakePlatformManager,
+      hideReturnToAppModal,
+    });
+  });
 });

--- a/packages/sdk/src/PostMessageStream/getPostMessageStream.test.ts
+++ b/packages/sdk/src/PostMessageStream/getPostMessageStream.test.ts
@@ -60,10 +60,10 @@ describe('getPostMessageStream', () => {
     });
   });
 
-  it('should pass hideReturnToAppModal from remoteConnection state', () => {
+  it('should pass hideReturnToAppNotification from remoteConnection state', () => {
     const fakeConnector = {};
     const fakePlatformManager = {};
-    const hideReturnToAppModal = true;
+    const hideReturnToAppNotification = true;
     mockRemoteConnection.mockImplementation(
       () =>
         ({
@@ -71,7 +71,7 @@ describe('getPostMessageStream', () => {
           getPlatformManager: jest.fn().mockReturnValue(fakePlatformManager),
           state: {
             deeplinkProtocol: false,
-            hideReturnToAppModal,
+            hideReturnToAppNotification,
           },
         } as any),
     );
@@ -90,7 +90,7 @@ describe('getPostMessageStream', () => {
       remote: fakeConnector,
       deeplinkProtocol: false,
       platformManager: fakePlatformManager,
-      hideReturnToAppModal,
+      hideReturnToAppNotification,
     });
   });
 });

--- a/packages/sdk/src/PostMessageStream/getPostMessageStream.ts
+++ b/packages/sdk/src/PostMessageStream/getPostMessageStream.ts
@@ -25,7 +25,8 @@ export const getPostMessageStream = ({
     name,
     remote: remoteConnection?.getConnector(),
     deeplinkProtocol: remoteConnection?.state.deeplinkProtocol,
-    hideReturnToAppNotification: remoteConnection?.state.hideReturnToAppNotification,
+    hideReturnToAppNotification:
+      remoteConnection?.state.hideReturnToAppNotification,
     platformManager: remoteConnection?.getPlatformManager(),
   });
 };

--- a/packages/sdk/src/PostMessageStream/getPostMessageStream.ts
+++ b/packages/sdk/src/PostMessageStream/getPostMessageStream.ts
@@ -25,6 +25,7 @@ export const getPostMessageStream = ({
     name,
     remote: remoteConnection?.getConnector(),
     deeplinkProtocol: remoteConnection?.state.deeplinkProtocol,
+    hideReturnToAppModal: remoteConnection?.state.hideReturnToAppModal,
     platformManager: remoteConnection?.getPlatformManager(),
   });
 };

--- a/packages/sdk/src/PostMessageStream/getPostMessageStream.ts
+++ b/packages/sdk/src/PostMessageStream/getPostMessageStream.ts
@@ -25,7 +25,7 @@ export const getPostMessageStream = ({
     name,
     remote: remoteConnection?.getConnector(),
     deeplinkProtocol: remoteConnection?.state.deeplinkProtocol,
-    hideReturnToAppModal: remoteConnection?.state.hideReturnToAppModal,
+    hideReturnToAppNotification: remoteConnection?.state.hideReturnToAppNotification,
     platformManager: remoteConnection?.getPlatformManager(),
   });
 };

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -199,6 +199,33 @@ describe('MetaMaskSDK', () => {
       expect(sdk.options).toMatchObject(options);
     });
 
+    it('should initialize with hideReturnToAppModal option', () => {
+      const options: MetaMaskSDKOptions = {
+        hideReturnToAppModal: true,
+        dappMetadata: {
+          name: 'Test DApp',
+          url: 'http://test-dapp.com',
+        },
+      };
+
+      sdk = new MetaMaskSDK(options);
+
+      expect(sdk.options.hideReturnToAppModal).toBe(true);
+    });
+
+    it('should have hideReturnToAppModal as undefined by default', () => {
+      const options: MetaMaskSDKOptions = {
+        dappMetadata: {
+          name: 'Test DApp',
+          url: 'http://test-dapp.com',
+        },
+      };
+
+      sdk = new MetaMaskSDK(options);
+
+      expect(sdk.options.hideReturnToAppModal).toBeUndefined();
+    });
+
     it('should set max listeners', () => {
       expect(sdk.getMaxListeners()).toBe(50);
     });

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -223,7 +223,7 @@ describe('MetaMaskSDK', () => {
 
       sdk = new MetaMaskSDK(options);
 
-      expect(sdk.options.hideReturnToAppNotification).toBeFalsy();
+      expect(sdk.options.hideReturnToAppNotification).toBe(false);
     });
 
     it('should set max listeners', () => {

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -199,9 +199,9 @@ describe('MetaMaskSDK', () => {
       expect(sdk.options).toMatchObject(options);
     });
 
-    it('should initialize with hideReturnToAppModal option', () => {
+    it('should initialize with hideReturnToAppNotification option', () => {
       const options: MetaMaskSDKOptions = {
-        hideReturnToAppModal: true,
+        hideReturnToAppNotification: true,
         dappMetadata: {
           name: 'Test DApp',
           url: 'http://test-dapp.com',
@@ -210,10 +210,10 @@ describe('MetaMaskSDK', () => {
 
       sdk = new MetaMaskSDK(options);
 
-      expect(sdk.options.hideReturnToAppModal).toBe(true);
+      expect(sdk.options.hideReturnToAppNotification).toBe(true);
     });
 
-    it('should have hideReturnToAppModal as undefined by default', () => {
+    it('should have hideReturnToAppNotification as undefined by default', () => {
       const options: MetaMaskSDKOptions = {
         dappMetadata: {
           name: 'Test DApp',
@@ -223,7 +223,7 @@ describe('MetaMaskSDK', () => {
 
       sdk = new MetaMaskSDK(options);
 
-      expect(sdk.options.hideReturnToAppModal).toBeUndefined();
+      expect(sdk.options.hideReturnToAppNotification).toBeUndefined();
     });
 
     it('should set max listeners', () => {

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -223,7 +223,7 @@ describe('MetaMaskSDK', () => {
 
       sdk = new MetaMaskSDK(options);
 
-      expect(sdk.options.hideReturnToAppNotification).toBeUndefined();
+      expect(sdk.options.hideReturnToAppNotification).toBeFalsy();
     });
 
     it('should set max listeners', () => {

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -213,7 +213,7 @@ describe('MetaMaskSDK', () => {
       expect(sdk.options.hideReturnToAppNotification).toBe(true);
     });
 
-    it('should have hideReturnToAppNotification as undefined by default', () => {
+    it('should have hideReturnToAppNotification as false by default', () => {
       const options: MetaMaskSDKOptions = {
         dappMetadata: {
           name: 'Test DApp',

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -269,6 +269,10 @@ export class MetaMaskSDK extends EventEmitter2 {
       options._source = DEFAULT_SDK_SOURCE;
     }
 
+    if (this.options.hideReturnToAppNotification === undefined) {
+      this.options.hideReturnToAppNotification = false;
+    }
+
     // Automatically initialize the SDK to keep the same behavior as before
     this.init()
       .then(() => {

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -95,7 +95,7 @@ export interface MetaMaskSDKOptions {
    * If true, MetaMask Mobile will hide the modal that invites the user to return to the app after performing an action on MetaMask Mobile.
    * This should be used when the app is loaded in an iframe inside the MetaMask Mobile browser.
    */
-  hideReturnToAppModal?: boolean;
+  hideReturnToAppNotification?: boolean;
 
   /**
    * If true, the SDK will shim the window.web3 object with the provider returned by the SDK (useful for compatibility with older browser).
@@ -226,7 +226,7 @@ export class MetaMaskSDK extends EventEmitter2 {
       enableAnalytics: true,
       shouldShimWeb3: true,
       useDeeplink: true,
-      hideReturnToAppModal: false,
+      hideReturnToAppNotification: false,
       extensionOnly: true,
       headless: false,
       dappMetadata: {

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -92,6 +92,12 @@ export interface MetaMaskSDKOptions {
   useDeeplink?: boolean;
 
   /**
+   * If true, MetaMask Mobile will hide the modal that invites the user to return to the app after performing an action on MetaMask Mobile.
+   * This should be used when the app is loaded in an iframe inside the MetaMask Mobile browser.
+   */
+  hideReturnToAppModal?: boolean;
+
+  /**
    * If true, the SDK will shim the window.web3 object with the provider returned by the SDK (useful for compatibility with older browser).
    */
   shouldShimWeb3?: boolean;
@@ -220,6 +226,7 @@ export class MetaMaskSDK extends EventEmitter2 {
       enableAnalytics: true,
       shouldShimWeb3: true,
       useDeeplink: true,
+      hideReturnToAppModal: false,
       extensionOnly: true,
       headless: false,
       dappMetadata: {

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.test.ts
@@ -57,7 +57,7 @@ describe('performSDKInitialization', () => {
       injectProvider: true,
       shouldShimWeb3: true,
       useDeeplink: true,
-      hideReturnToAppModal: false,
+      hideReturnToAppNotification: false,
       storage: {
         enabled: true,
       },

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.test.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.test.ts
@@ -57,6 +57,7 @@ describe('performSDKInitialization', () => {
       injectProvider: true,
       shouldShimWeb3: true,
       useDeeplink: true,
+      hideReturnToAppModal: false,
       storage: {
         enabled: true,
       },

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
@@ -57,6 +57,7 @@ export async function performSDKInitialization(instance: MetaMaskSDK) {
   options.shouldShimWeb3 = options.shouldShimWeb3 ?? true;
   options.extensionOnly = options.extensionOnly ?? true;
   options.useDeeplink = options.useDeeplink ?? true;
+  options.hideReturnToAppModal = options.hideReturnToAppModal ?? false;
   options.storage = options.storage ?? {
     enabled: true,
   };

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
@@ -57,7 +57,7 @@ export async function performSDKInitialization(instance: MetaMaskSDK) {
   options.shouldShimWeb3 = options.shouldShimWeb3 ?? true;
   options.extensionOnly = options.extensionOnly ?? true;
   options.useDeeplink = options.useDeeplink ?? true;
-  options.hideReturnToAppModal = options.hideReturnToAppModal ?? false;
+  options.hideReturnToAppNotification = options.hideReturnToAppNotification ?? false;
   options.storage = options.storage ?? {
     enabled: true,
   };

--- a/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
+++ b/packages/sdk/src/services/MetaMaskSDK/InitializerManager/performSDKInitialization.ts
@@ -57,7 +57,9 @@ export async function performSDKInitialization(instance: MetaMaskSDK) {
   options.shouldShimWeb3 = options.shouldShimWeb3 ?? true;
   options.extensionOnly = options.extensionOnly ?? true;
   options.useDeeplink = options.useDeeplink ?? true;
-  options.hideReturnToAppNotification = options.hideReturnToAppNotification ?? false;
+  options.hideReturnToAppNotification =
+    options.hideReturnToAppNotification ?? false;
+
   options.storage = options.storage ?? {
     enabled: true,
   };

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
@@ -317,4 +317,83 @@ describe('write function', () => {
       expect(mockSendMessage).toHaveBeenCalled();
     });
   });
+
+  describe('hideReturnToAppModal URL parameter', () => {
+    beforeEach(() => {
+      mockIsReady.mockReturnValue(true);
+      mockIsConnected.mockReturnValue(true);
+      mockIsAuthorized.mockReturnValue(true);
+      mockIsMobileWeb.mockReturnValue(false);
+      mockIsSecure.mockReturnValue(true);
+      mockGetChannelId.mockReturnValue('some_channel_id');
+      mockIsMetaMaskInstalled.mockReturnValue(true);
+      mockGetKeyInfo.mockReturnValue({ ecies: { public: 'test_public_key' } });
+      mockHasDeeplinkProtocol.mockReturnValue(false);
+      mockExtractMethod.mockReturnValue({
+        method: Object.keys(METHODS_TO_REDIRECT)[0],
+        data: {
+          data: {
+            jsonrpc: '2.0',
+            method: Object.keys(METHODS_TO_REDIRECT)[0],
+            params: [],
+          },
+        },
+        triggeredInstaller: false,
+      });
+    });
+
+    it('should include hr=1 in URL when hideReturnToAppModal is true', async () => {
+      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppModal =
+        true;
+
+      await write(
+        mockRemoteCommunicationPostMessageStream,
+        { jsonrpc: '2.0', method: Object.keys(METHODS_TO_REDIRECT)[0] },
+        'utf8',
+        callback,
+      );
+
+      expect(mockOpenDeeplink).toHaveBeenCalledWith(
+        expect.stringContaining('hr=1'),
+        expect.stringContaining('hr=1'),
+        '_self',
+      );
+    });
+
+    it('should include hr=0 in URL when hideReturnToAppModal is false', async () => {
+      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppModal =
+        false;
+
+      await write(
+        mockRemoteCommunicationPostMessageStream,
+        { jsonrpc: '2.0', method: Object.keys(METHODS_TO_REDIRECT)[0] },
+        'utf8',
+        callback,
+      );
+
+      expect(mockOpenDeeplink).toHaveBeenCalledWith(
+        expect.stringContaining('hr=0'),
+        expect.stringContaining('hr=0'),
+        '_self',
+      );
+    });
+
+    it('should include hr=0 in URL when hideReturnToAppModal is undefined', async () => {
+      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppModal =
+        undefined;
+
+      await write(
+        mockRemoteCommunicationPostMessageStream,
+        { jsonrpc: '2.0', method: Object.keys(METHODS_TO_REDIRECT)[0] },
+        'utf8',
+        callback,
+      );
+
+      expect(mockOpenDeeplink).toHaveBeenCalledWith(
+        expect.stringContaining('hr=0'),
+        expect.stringContaining('hr=0'),
+        '_self',
+      );
+    });
+  });
 });

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.test.ts
@@ -318,7 +318,7 @@ describe('write function', () => {
     });
   });
 
-  describe('hideReturnToAppModal URL parameter', () => {
+  describe('hideReturnToAppNotification URL parameter', () => {
     beforeEach(() => {
       mockIsReady.mockReturnValue(true);
       mockIsConnected.mockReturnValue(true);
@@ -342,8 +342,8 @@ describe('write function', () => {
       });
     });
 
-    it('should include hr=1 in URL when hideReturnToAppModal is true', async () => {
-      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppModal =
+    it('should include hr=1 in URL when hideReturnToAppNotification is true', async () => {
+      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppNotification =
         true;
 
       await write(
@@ -360,8 +360,8 @@ describe('write function', () => {
       );
     });
 
-    it('should include hr=0 in URL when hideReturnToAppModal is false', async () => {
-      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppModal =
+    it('should include hr=0 in URL when hideReturnToAppNotification is false', async () => {
+      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppNotification =
         false;
 
       await write(
@@ -378,8 +378,8 @@ describe('write function', () => {
       );
     });
 
-    it('should include hr=0 in URL when hideReturnToAppModal is undefined', async () => {
-      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppModal =
+    it('should include hr=0 in URL when hideReturnToAppNotification is undefined', async () => {
+      mockRemoteCommunicationPostMessageStream.state.hideReturnToAppNotification =
         undefined;
 
       await write(

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -101,7 +101,7 @@ export async function write(
     const pubKey = instance.state.remote?.getKeyInfo()?.ecies.public ?? '';
     let urlParams = encodeURI(
       `channelId=${channelId}&pubkey=${pubKey}&comm=socket&t=d&v=2&hr=${
-        instance.state.hideReturnToAppModal ? 1 : 0
+        instance.state.hideReturnToAppNotification ? 1 : 0
       }`,
     );
 

--- a/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
+++ b/packages/sdk/src/services/RemoteCommunicationPostMessageStream/write.ts
@@ -100,7 +100,9 @@ export async function write(
 
     const pubKey = instance.state.remote?.getKeyInfo()?.ecies.public ?? '';
     let urlParams = encodeURI(
-      `channelId=${channelId}&pubkey=${pubKey}&comm=socket&t=d&v=2`,
+      `channelId=${channelId}&pubkey=${pubKey}&comm=socket&t=d&v=2&hr=${
+        instance.state.hideReturnToAppModal ? 1 : 0
+      }`,
     );
 
     if (activeDeeplinkProtocol) {

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.test.ts
@@ -223,4 +223,55 @@ describe('startConnection', () => {
       );
     });
   });
+
+  describe('hideReturnToAppModal URL parameter', () => {
+    beforeEach(() => {
+      mockIsSecure.mockReturnValue(true);
+    });
+
+    it('should pass hr=1 when hideReturnToAppModal is true', async () => {
+      state.hideReturnToAppModal = true;
+
+      await startConnection(state, options);
+
+      // Vérifier que le QR code link contient hr=1
+      expect(state.qrcodeLink).toContain('hr=1');
+    });
+
+    it('should pass hr=0 when hideReturnToAppModal is false', async () => {
+      state.hideReturnToAppModal = false;
+
+      await startConnection(state, options);
+
+      // Vérifier que le QR code link contient hr=0
+      expect(state.qrcodeLink).toContain('hr=0');
+    });
+
+    it('should pass hr=0 when hideReturnToAppModal is undefined', async () => {
+      state.hideReturnToAppModal = undefined;
+
+      await startConnection(state, options);
+
+      // Vérifier que le QR code link contient hr=0
+      expect(state.qrcodeLink).toContain('hr=0');
+    });
+
+    it('should include hr parameter in connectWith scenarios', async () => {
+      mockIsSecure.mockReturnValue(false);
+      state.hideReturnToAppModal = true;
+      const connectWith = {
+        method: 'eth_sign',
+        params: ['0x123456', '0xabcdef'],
+        id: '123',
+      };
+
+      await startConnection(state, options, { connectWith });
+
+      expect(mockConnectWithModalInstaller).toHaveBeenCalledWith(
+        state,
+        options,
+        expect.stringContaining('hr=1'),
+      );
+    });
+  });
 });

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.test.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.test.ts
@@ -224,13 +224,13 @@ describe('startConnection', () => {
     });
   });
 
-  describe('hideReturnToAppModal URL parameter', () => {
+  describe('hideReturnToAppNotification URL parameter', () => {
     beforeEach(() => {
       mockIsSecure.mockReturnValue(true);
     });
 
-    it('should pass hr=1 when hideReturnToAppModal is true', async () => {
-      state.hideReturnToAppModal = true;
+    it('should pass hr=1 when hideReturnToAppNotification is true', async () => {
+      state.hideReturnToAppNotification = true;
 
       await startConnection(state, options);
 
@@ -238,8 +238,8 @@ describe('startConnection', () => {
       expect(state.qrcodeLink).toContain('hr=1');
     });
 
-    it('should pass hr=0 when hideReturnToAppModal is false', async () => {
-      state.hideReturnToAppModal = false;
+    it('should pass hr=0 when hideReturnToAppNotification is false', async () => {
+      state.hideReturnToAppNotification = false;
 
       await startConnection(state, options);
 
@@ -247,8 +247,8 @@ describe('startConnection', () => {
       expect(state.qrcodeLink).toContain('hr=0');
     });
 
-    it('should pass hr=0 when hideReturnToAppModal is undefined', async () => {
-      state.hideReturnToAppModal = undefined;
+    it('should pass hr=0 when hideReturnToAppNotification is undefined', async () => {
+      state.hideReturnToAppNotification = undefined;
 
       await startConnection(state, options);
 
@@ -258,7 +258,7 @@ describe('startConnection', () => {
 
     it('should include hr parameter in connectWith scenarios', async () => {
       mockIsSecure.mockReturnValue(false);
-      state.hideReturnToAppModal = true;
+      state.hideReturnToAppNotification = true;
       const connectWith = {
         method: 'eth_sign',
         params: ['0x123456', '0xabcdef'],

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
@@ -149,7 +149,7 @@ export async function startConnection(
     let linkParams = `channelId=${channelId}&v=2&comm=${
       state.communicationLayerPreference ?? ''
     }&pubkey=${pubKey}${qrCodeOrigin}&originatorInfo=${base64OriginatorInfo}&hr=${
-      state.hideReturnToAppModal ? 1 : 0
+      state.hideReturnToAppNotification ? 1 : 0
     }`;
 
     if (connectWith) {

--- a/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/ConnectionManager/startConnection.ts
@@ -148,7 +148,9 @@ export async function startConnection(
 
     let linkParams = `channelId=${channelId}&v=2&comm=${
       state.communicationLayerPreference ?? ''
-    }&pubkey=${pubKey}${qrCodeOrigin}&originatorInfo=${base64OriginatorInfo}`;
+    }&pubkey=${pubKey}${qrCodeOrigin}&originatorInfo=${base64OriginatorInfo}&hr=${
+      state.hideReturnToAppModal ? 1 : 0
+    }`;
 
     if (connectWith) {
       const base64Rpc = base64Encode(JSON.stringify(connectWith));

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -93,7 +93,7 @@ export interface RemoteConnectionState {
   connector?: RemoteCommunication;
   qrcodeLink?: string;
   useDeeplink?: boolean;
-  hideReturnToAppModal?: boolean;
+  hideReturnToAppNotification?: boolean;
   developerMode: boolean;
   analytics?: Analytics;
   authorized: boolean;
@@ -147,7 +147,7 @@ export class RemoteConnection {
     this.state.analytics = options.analytics;
     this.state.preferDesktop = options.preferDesktop ?? false;
     this.state.useDeeplink = options.sdk.options.useDeeplink;
-    this.state.hideReturnToAppModal = options.sdk.options.hideReturnToAppModal;
+    this.state.hideReturnToAppNotification = options.sdk.options.hideReturnToAppNotification;
     this.state.communicationLayerPreference =
       options.communicationLayerPreference;
     this.state.platformManager = options.platformManager;

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -147,7 +147,9 @@ export class RemoteConnection {
     this.state.analytics = options.analytics;
     this.state.preferDesktop = options.preferDesktop ?? false;
     this.state.useDeeplink = options.sdk.options.useDeeplink;
-    this.state.hideReturnToAppNotification = options.sdk.options.hideReturnToAppNotification;
+    this.state.hideReturnToAppNotification =
+      options.sdk.options.hideReturnToAppNotification;
+
     this.state.communicationLayerPreference =
       options.communicationLayerPreference;
     this.state.platformManager = options.platformManager;

--- a/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
+++ b/packages/sdk/src/services/RemoteConnection/RemoteConnection.ts
@@ -93,6 +93,7 @@ export interface RemoteConnectionState {
   connector?: RemoteCommunication;
   qrcodeLink?: string;
   useDeeplink?: boolean;
+  hideReturnToAppModal?: boolean;
   developerMode: boolean;
   analytics?: Analytics;
   authorized: boolean;
@@ -146,6 +147,7 @@ export class RemoteConnection {
     this.state.analytics = options.analytics;
     this.state.preferDesktop = options.preferDesktop ?? false;
     this.state.useDeeplink = options.sdk.options.useDeeplink;
+    this.state.hideReturnToAppModal = options.sdk.options.hideReturnToAppModal;
     this.state.communicationLayerPreference =
       options.communicationLayerPreference;
     this.state.platformManager = options.platformManager;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-5

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new hideReturnToAppNotification option (default false) and passes it through to deeplink/QR URLs as hr=0/1; refactors SDK option initialization and updates tests.
> 
> - **SDK Options**:
>   - Add `hideReturnToAppNotification` (default `false`) to `MetaMaskSDKOptions` and `defaultMetaMaskSDKOptions`.
>   - Refactor constructor to merge with `defaultMetaMaskSDKOptions`; auto-fill `dappMetadata.url` if missing in web env.
>   - Set default in `performSDKInitialization` and expected options in tests.
> - **Remote Connection**:
>   - Add `hideReturnToAppNotification` to `RemoteConnectionState`; initialize from `sdk.options`.
>   - In `startConnection`, append `hr=0/1` to `linkParams` and ensure it’s included for `connectWith` flows; QR link reflects `hr`.
> - **PostMessageStream**:
>   - Add `hideReturnToAppNotification` to `RemoteCommunicationPostMessageStream` state and constructor.
>   - `getPostMessageStream` forwards the flag from `remoteConnection.state`.
> - **URL Handling**:
>   - In `write`, include `hr=0/1` in deeplink URL params based on `state.hideReturnToAppNotification`.
> - **Tests**:
>   - Add/adjust tests covering option defaults, constructor merge, flag propagation, and presence of `hr=0/1` in generated links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7caf78f539d6611696a3b44d61780b8a3585652e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->