### PR TITLE
fix: install modal QRCode regeneration

### DIFF
--- a/packages/sdk-multichain/src/multichain/index.ts
+++ b/packages/sdk-multichain/src/multichain/index.ts
@@ -247,6 +247,9 @@ export class MultichainSDK extends MultichainCore {
 			this.options.ui.factory.renderInstallModal(
 				desktopPreferred,
 				async () => {
+					if (this.dappClient.state === 'CONNECTED' || this.dappClient.state === 'CONNECTING') {
+						await this.dappClient.disconnect();
+					}
 					return new Promise<ConnectionRequest>((resolveConnectionRequest) => {
 						this.dappClient.on('session_request', (sessionRequest: SessionRequest) => {
 							resolveConnectionRequest({

--- a/packages/sdk-multichain/src/ui/modals/base/AbstractInstallModal.ts
+++ b/packages/sdk-multichain/src/ui/modals/base/AbstractInstallModal.ts
@@ -47,7 +47,7 @@ export abstract class AbstractInstallModal extends Modal<InstallWidgetProps, QRL
 		this.expirationInterval = setInterval(async () => {
 			const { sessionRequest } = currentConnectionRequest;
 			const now = Date.now();
-			const remainingMs = sessionRequest.expiresAt - now;
+			const remainingMs = sessionRequest.expiresAt - now - 55000;
 
 			const remainingSeconds = Math.floor(remainingMs / 1000);
 
@@ -58,6 +58,7 @@ export abstract class AbstractInstallModal extends Modal<InstallWidgetProps, QRL
 			}
 
 			if (now >= sessionRequest.expiresAt) {
+				this.stopExpirationCheck();
 				logger('[UI: InstallModal-nodejs()] ⏰ QR code EXPIRED! Generating new one...');
 				try {
 					// Generate new session request

--- a/packages/sdk-multichain/src/ui/modals/base/AbstractInstallModal.ts
+++ b/packages/sdk-multichain/src/ui/modals/base/AbstractInstallModal.ts
@@ -47,7 +47,7 @@ export abstract class AbstractInstallModal extends Modal<InstallWidgetProps, QRL
 		this.expirationInterval = setInterval(async () => {
 			const { sessionRequest } = currentConnectionRequest;
 			const now = Date.now();
-			const remainingMs = sessionRequest.expiresAt - now - 55000;
+			const remainingMs = sessionRequest.expiresAt - now;
 
 			const remainingSeconds = Math.floor(remainingMs / 1000);
 

--- a/packages/sdk-multichain/src/ui/modals/node/install.ts
+++ b/packages/sdk-multichain/src/ui/modals/node/install.ts
@@ -21,12 +21,14 @@ export class InstallModal extends AbstractInstallModal {
 			console.log(`EXPIRES IN: ${formattedTime}`);
 		}
 	}
+
 	renderQRCode(link: QRLink, connectionRequest: ConnectionRequest): void {
 		const { sessionRequest } = connectionRequest;
 		const expiresIn = sessionRequest.expiresAt - Date.now();
 		const expiresInSeconds = Math.floor(expiresIn / 1000);
 		const shouldLog = shouldLogCountdown(expiresInSeconds);
 		const formattedTime = formatRemainingTime(expiresIn);
+		this.startExpirationCheck(connectionRequest);
 
 		this.displayQRWithCountdown(link, expiresIn);
 
@@ -41,7 +43,6 @@ export class InstallModal extends AbstractInstallModal {
 		}
 		const { link, connectionRequest } = this;
 		this.renderQRCode(link, connectionRequest);
-		this.startExpirationCheck(connectionRequest);
 	}
 
 	unmount(): void {


### PR DESCRIPTION
## Explanation
Fixes the QRCode regenerating on install modals, issue affecting both install modal web and install modal node.

This change will disconnect any pending connection and renew it once the 60 seconds of the session request expire. Still this leaves enough timeout time for the user to reply without affecting.


### How to test
#### Node
```bash
yarn build
```

cd into playground/multichain-node
run

```bash
yarn start connect
```

U should see the QRCode regenerate after the specified seconds on screen.


#### Web
```bash
yarn build
```

cd into playground/multichain-react
run

```bash
yarn start
```

Open http://localhost:3000/test-dapp-multichain

Click connect and wait for 60 seconds for the QRCode to automatically regenerate



## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures QR codes auto-regenerate on expiry, starts/stops expiration checks correctly, and resets any active MWP connection before initiating a new session.
> 
> - **UI/Modals**:
>   - `AbstractInstallModal`: Stop expiration check before regenerating; refresh QR/link/expiry and re-render on each tick.
>   - `ui/modals/node/install`: Start expiration check in `renderQRCode`; remove from `mount`; ensure cleanup in `unmount`.
> - **Core**:
>   - `multichain/index.ts`: Before creating a new `ConnectionRequest`, disconnect `dappClient` if `CONNECTED` or `CONNECTING`.
> - **Transport (MWP)**:
>   - `transports/mwp/index.ts`: Use a local `connectionPromise` with timeout handling during `connect()` and clear timers on completion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bbc1a2c143948641e4ed57823be7a58c9dd27a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->