### PR TITLE
fix: multichain cold start issue with RPCClient

### DIFF
--- a/packages/sdk-multichain/src/multichain/index.ts
+++ b/packages/sdk-multichain/src/multichain/index.ts
@@ -433,8 +433,9 @@ export class MultichainSDK extends MultichainCore {
 
 		this.__provider ??= getMultichainClient({ transport });
 
-		const client = new RPCClient(this.provider, this.options.api, sdkInfo);
+		const client = new RPCClient(this.transport, this.options.api, sdkInfo);
 		const secure = isSecure();
+
 		const shouldOpenDeeplink = secure && !preferDesktop;
 
 		// Call the client invoke method first
@@ -442,15 +443,13 @@ export class MultichainSDK extends MultichainCore {
 
 		// Schedule the deeplink to open 100ms after the invoke method is called
 		if (shouldOpenDeeplink) {
-			setTimeout(() => {
-				if (this.options.mobile?.preferredOpenLink) {
-					this.options.mobile.preferredOpenLink(METAMASK_DEEPLINK_BASE, '_self');
-				} else {
-					this.openDeeplink(METAMASK_DEEPLINK_BASE, METAMASK_CONNECT_BASE_URL);
-				}
-			}, 1000);
+			if (this.options.mobile?.preferredOpenLink) {
+				this.options.mobile.preferredOpenLink(METAMASK_DEEPLINK_BASE, '_self');
+			} else {
+				this.openDeeplink(METAMASK_DEEPLINK_BASE, METAMASK_CONNECT_BASE_URL);
+			}
 		}
 
-		return invokePromise;
+		return invokePromise as Promise<Json>;
 	}
 }

--- a/packages/sdk-multichain/src/multichain/index.ts
+++ b/packages/sdk-multichain/src/multichain/index.ts
@@ -435,15 +435,22 @@ export class MultichainSDK extends MultichainCore {
 
 		const client = new RPCClient(this.provider, this.options.api, sdkInfo);
 		const secure = isSecure();
+		const shouldOpenDeeplink = secure && !preferDesktop;
 
-		if (secure && !preferDesktop) {
-			if (this.options.mobile?.preferredOpenLink) {
-				this.options.mobile.preferredOpenLink(METAMASK_DEEPLINK_BASE, '_self');
-			} else {
-				this.openDeeplink(METAMASK_DEEPLINK_BASE, METAMASK_CONNECT_BASE_URL);
-			}
+		// Call the client invoke method first
+		const invokePromise = client.invokeMethod(request);
+
+		// Schedule the deeplink to open 100ms after the invoke method is called
+		if (shouldOpenDeeplink) {
+			setTimeout(() => {
+				if (this.options.mobile?.preferredOpenLink) {
+					this.options.mobile.preferredOpenLink(METAMASK_DEEPLINK_BASE, '_self');
+				} else {
+					this.openDeeplink(METAMASK_DEEPLINK_BASE, METAMASK_CONNECT_BASE_URL);
+				}
+			}, 1000);
 		}
 
-		return client.invokeMethod(request);
+		return invokePromise;
 	}
 }


### PR DESCRIPTION
## Explanation
The issue happens because the multichain-api-client is getting the session for the first RPC request that we run, this affects the user experience forcing the user to go back to the Dapp until the session is delivered.

I've replaced usage in RPCClient from this.provider to this.transport which does not trigger this extra RPC request.

This also makes the use of this.provider in multichain, no longer needed. We're basically using all the transport stuff from multichain-api-client but not the provider itself, not even for default transports now.

For the previous, I'd propose to create a separate PR to remove provider from the SDK and just use transports but will require a bunch of tests to be re-visited

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> RPC calls now use transport.request (not provider) and invocation starts before opening the deeplink; tests updated accordingly.
> 
> - **MultichainSDK**:
>   - `invokeMethod` now instantiates `RPCClient` with `transport` and starts `invokeMethod` before opening the deeplink when `secure && !preferDesktop`; returns the invoke promise.
> - **RPCClient**:
>   - Accepts `ExtendedTransport` instead of provider; redirects write/personal methods via `transport.request` using `wallet_invokeMethod`, returning `response.result` and handling `response.error`.
>   - Read-only flow via HTTP unchanged (Infura/custom RPC handling, headers, parsing, errors).
> - **Tests**:
>   - Updated to mock `transport.request` and expectations for redirect/fallback paths; retain fetch-based assertions for readonly cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90a2ca871ef45e8e18a4eed363daccb544343ca6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->