### PR TITLE
fix: install modal not closing

### DIFF
--- a/packages/sdk-multichain/src/ui/index.ts
+++ b/packages/sdk-multichain/src/ui/index.ts
@@ -46,6 +46,7 @@ export class ModalFactory<T extends FactoryModals = FactoryModals> {
 	}
 
 	async unload(error?: Error) {
+		this.modal?.unmount();
 		await this.successCallback?.(error);
 	}
 


### PR DESCRIPTION
## Explanation
This issue only happens on web install modal.

Due to the recent improvements and separation of concerns applied to the multichain sdk the install modal was not unloading, despite we were capturing the error message "User closed modal" but the install modal was never going away.

Every single time we request the install modal to show we are creating a new session request and showing a QRCode. If we leave the window open with the QRCode for more than 60 seconds another automatic QRCode will display

https://github.com/user-attachments/assets/60a95cec-7722-4e90-8b61-0c229149a38b



## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unmounts the active modal during `unload()` to ensure the install modal properly closes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f31b64540af3c9b00a95afe64803b099810e0e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->