### PR TITLE
fix: integration with default transport

### DIFF
--- a/packages/sdk-multichain/src/session.test.ts
+++ b/packages/sdk-multichain/src/session.test.ts
@@ -98,18 +98,17 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 			if (platform === 'web') {
 				t.expect(mockedData.mockDefaultTransport.request).toHaveBeenCalledWith(
 					t.expect.objectContaining({
-						jsonrpc: '2.0',
 						method: 'wallet_getSession',
 					}),
 
-					undefined,
+					{ timeout: 60 * 1000 },
 				);
 				t.expect(mockedData.mockDefaultTransport.request).toHaveBeenCalledWith(
 					t.expect.objectContaining({
 						method: 'wallet_revokeSession',
 						params: mockSessionData,
 					}),
-					undefined,
+					{ timeout: 60 * 1000 },
 				);
 
 				t.expect(mockedData.mockDefaultTransport.request).toHaveBeenCalledWith(
@@ -119,7 +118,7 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 							optionalScopes: mockedSessionUpgradeData.sessionScopes,
 						},
 					}),
-					undefined,
+					{ timeout: 60 * 1000 },
 				);
 			} else {
 				t.expect(mockedData.mockDappClient.sendRequest).toHaveBeenCalledWith(
@@ -168,10 +167,9 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 			if (platform === 'web') {
 				t.expect(mockedData.mockDefaultTransport.request).toHaveBeenCalledWith(
 					t.expect.objectContaining({
-						jsonrpc: '2.0',
 						method: 'wallet_getSession',
 					}),
-					undefined,
+					{ timeout: 60 * 1000 },
 				);
 				t.expect(mockedData.mockDefaultTransport.request).toHaveBeenCalledWith(
 					t.expect.objectContaining({
@@ -180,7 +178,7 @@ function testSuite<T extends MultichainOptions>({ platform, createSDK, options: 
 							optionalScopes: mockSessionData.sessionScopes,
 						},
 					}),
-					undefined,
+					{ timeout: 60 * 1000 },
 				);
 			} else {
 				t.expect(mockedData.mockDappClient.sendRequest).toHaveBeenCalledWith(

--- a/packages/sdk-multichain/src/ui/index.test.ts
+++ b/packages/sdk-multichain/src/ui/index.test.ts
@@ -330,7 +330,7 @@ t.describe('ModalFactory', () => {
 				await constructorArgs.onClose();
 
 				// Multichain SDK is what will close the modal instead
-				t.expect(mockModal.unmount).not.toHaveBeenCalled();
+				t.expect(mockModal.unmount).toHaveBeenCalled();
 			});
 
 			t.it('should handle desktop onboarding correctly', async () => {


### PR DESCRIPTION
## Explanation
Fixes the integration with the default transport. 

This PR fixes some issues connecting and sending RPC requests directly into the chrome extension from browser.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 60s request timeouts, notification management (including sessionChanged), improved error handling, and updates tests; requests now delegate directly without manual JSON-RPC id.
> 
> - **Transport (`packages/sdk-multichain/src/multichain/transports/default/index.ts`)**:
>   - Add 60s default request timeout and apply to `wallet_getSession`, `wallet_revokeSession`, `wallet_createSession`.
>   - Introduce notification callback registry; emit `wallet_sessionChanged` after connect; clear callbacks on disconnect; `onNotification` returns unsubscribe.
>   - Delegate `request` directly to underlying transport (remove manual `jsonrpc`/`id`).
>   - Throw on `wallet_createSession` errors.
> - **Tests**:
>   - Update web session tests to expect `{ timeout: 60 * 1000 }` and no `jsonrpc` field in requests.
>   - Adjust UI test: `renderInstallModal` `onClose` now unmounts modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9c9d7e6100008a9ef90209628349d5df3c57763. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->