### PR TITLE
fix: prevent glitch in default transport with a "connecting" state

### DIFF
--- a/packages/sdk-multichain/src/multichain/index.ts
+++ b/packages/sdk-multichain/src/multichain/index.ts
@@ -242,6 +242,15 @@ export class MultichainSDK extends MultichainCore {
 	}
 
 	private async showInstallModal(desktopPreferred: boolean, scopes: Scope[], caipAccountIds: CaipAccountId[]) {
+		if (typeof window !== 'undefined') {
+			window.addEventListener('beforeunload', async () => {
+				if (this.options.ui.factory.modal) {
+					//Modal is still visible, remove storage to prevent glitch with "connecting" state
+					await this.storage.removeTransport();
+				}
+				logger('beforeunload');
+			});
+		}
 		return new Promise<void>((resolve, reject) => {
 			// Use Connection Modal
 			this.options.ui.factory.renderInstallModal(


### PR DESCRIPTION
## Explanation
There is currently an issue in the multichain sdk, affecting the browser.
If the user clicks connect and has no extension installed the ShowInstall modal will display on screen.

When this happens, we automatically setup the Mobile Wallet protocol transport as used transport, the glitch happens if the user clicks refresh screen without closing the install modal. If that happens, we will have stored MWP as default transport when we have no proof this is the transport the user wants.

Upon the screen refresh it automatically tries to connect to MWP but it has nothing to connect into, because connection never succeeded.

This buggy behavior is fixed by listening to window.addEventListener('beforeunload') event and removing the transport if the modal is still visible.

> Important to mention that we have no guarantees really that we will be able to run
> ```await this.storage.removeTransport();``` and that call will resolve before browser refreshes. I've tested and we do provide enough time to complete, just a note here...

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a beforeunload handler to remove stored transport when the install modal is open and manages its lifecycle to prevent stale connections and leaks.
> 
> - **MultichainSDK (`packages/sdk-multichain/src/multichain/index.ts`)**:
>   - Add `onBeforeUnload` to remove stored transport if the install modal is visible.
>   - Introduce one-time `beforeunload` listener management:
>     - `createBeforeUnloadListener` registers/unregisters the handler; stored in `__beforeUnloadListener`.
>     - Listener initialized once in `showInstallModal` and disposed in `disconnect`.
>   - `disconnect` now invokes and clears the `beforeunload` listener before tearing down transport and state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97bd3a5692c09bf54eae9de1cb203cb167b7fd7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->