### PR TITLE
Refactor Analytics Client for V2 Namespaced Events

### DIFF
--- a/packages/sdk-analytics/README.md
+++ b/packages/sdk-analytics/README.md
@@ -1,39 +1,79 @@
 # MetaMask SDK Analytics
 
+This package provides a client for tracking analytics events for dApps and other components using the MetaMask SDK. It is designed to be fully type-safe, leveraging a schema generated from a backend OpenAPI specification.
+
 ## Overview
 
-The `@metamask/sdk-analytics` package tracks analytics events for dApps using the MetaMask SDK. It provides a TypeScript-based client for sending events to an analytics API with batching and schema validation.
+The analytics client is a singleton that exposes two distinct sub-clients for different API versions:
 
-## Purpose
+-   `analytics.v1`: A legacy client for sending events to the V1 backend endpoint. Its interface is designed for backward compatibility.
+-   `analytics.v2`: A modern, namespaced client for sending events to the V2 backend endpoint. This is the recommended client for all new implementations.
 
-Enables dApps to:
-
-- Track SDK events (e.g., sdk_initialized, connection_initiated).
-- Send events to an analytics API.
-- Ensure type safety with OpenAPI schemas.
-
-## Features
-
-- Event Tracking: Supports events like sdk_initialized, sdk_used_chain, and wallet actions.
-- Batching: Events are batched for efficient network usage.
-- Error Handling: Uses exponential backoff for failed requests.
-- Type Safety: Leverages TypeScript and OpenAPI schemas.
+A single `analytics.enable()` call controls event tracking for both clients.
 
 ## Usage
 
-Import the global client, enable it, set global props and track events.
+### For New Implementations (V2)
 
-```typescript
-import { analytics } from '@metamask/sdk-analytics';
+The V2 client uses a "namespaced" approach. Each event belongs to a specific namespace, which must be configured before tracking.
 
-analytics.enable();
+1.  **Import the client:**
+    ```typescript
+    import { analytics } from '@metamask/sdk-analytics';
+    ```
 
-analytics.setGlobalProperty('sdk_version', '1.0.0');
-analytics.setGlobalProperty('platform', 'web-desktop');
+2.  **Enable tracking:**
+    This should be done once when your application starts.
+    ```typescript
+    analytics.enable();
+    ```
 
-analytics.track('sdk_initialized', {
-  dapp_id: 'example.com',
-  anon_id: 'bbbc1727-8b85-433a-a26a-e9df70ddc81c',
-  integration_type: 'direct',
-});
-```
+3.  **Set up your namespace:**
+    Configure any common properties that should be included with every event for your namespace. For SDKs, this should include `package_name` and `package_version`.
+    ```typescript
+    import { name as packageName, version as packageVersion } from '../package.json';
+
+    analytics.v2.setup('sdk/connect', {
+      package_name: packageName,
+      package_version: packageVersion,
+      platform: 'web-desktop',
+    });
+    ```
+
+4.  **Track an event:**
+    The `track` method is fully type-safe. Your editor will provide autocomplete for the `namespace`, `eventName`, and the `properties` required for that event, all based on the master schema.
+    ```typescript
+    analytics.v2.track('sdk/connect', 'sdk_initialized', {
+      dapp_id: 'aave.com',
+      anon_id: 'some-anonymous-uuid',
+      integration_type: 'direct',
+    });
+    ```
+
+### For Migrating Legacy V1 Code
+
+The `v1` client provides an interface that is backward compatible with previous versions of this package, making migration straightforward.
+
+1.  **Enable tracking:**
+    ```typescript
+    import { analytics } from '@metamask/sdk-analytics';
+
+    analytics.enable();
+    ```
+
+2.  **Set global properties:**
+    Use `setGlobalProperty` to set common properties for all V1 events.
+    ```typescript
+    analytics.v1.setGlobalProperty('sdk_version', '0.9.0');
+    analytics.v1.setGlobalProperty('platform', 'web-desktop');
+    ```
+
+3.  **Track an event:**
+    The `track` method on the `v1` client uses the original flat event structure.
+    ```typescript
+    analytics.v1.track('sdk_initialized', {
+      dapp_id: 'example.com',
+      anon_id: 'some-anonymous-uuid',
+      integration_type: 'direct',
+    });
+    ```

--- a/packages/sdk-analytics/src/analytics.test.ts
+++ b/packages/sdk-analytics/src/analytics.test.ts
@@ -5,79 +5,161 @@ import * as t from 'vitest';
 import Analytics from './analytics';
 import type * as schema from './schema';
 
-t.describe('Analytics Integration', () => {
+type EventV1 = schema.components['schemas']['Event'];
+type EventV2 = schema.components['schemas']['EventV2'];
+
+const BASE_URL = 'http://localhost:8000';
+
+t.describe('Analytics Client', () => {
   let analytics: Analytics;
-  let scope: nock.Scope;
 
-  const event: schema.components['schemas']['SdkInitializedEvent'] = {
-    name: 'sdk_initialized',
-    sdk_version: '1.0.0',
-    dapp_id: 'aave.com',
-    anon_id: 'bbbc1727-8b85-433a-a26a-e9df70ddc81c',
-    platform: 'web-desktop',
-    integration_type: 'direct',
-  };
-
-  t.afterAll(() => {
-    /* eslint-disable-next-line import-x/no-named-as-default-member */
+  t.beforeEach(() => {
+    analytics = new Analytics(BASE_URL);
     nock.cleanAll();
   });
 
-  t.it('should do nothing when disabled', async () => {
-    let captured: Event[] = [];
-    scope = nock('http://127.0.0.1')
-      .post('/v1/events', (body) => {
-        captured = body; // Capture the request body directly
-        return true; // Accept any body to proceed with the intercept
-      })
-      .optionally()
-      .reply(
-        200,
-        { status: 'success' },
-        { 'Content-Type': 'application/json' },
-      );
-
-    analytics = new Analytics('http://127.0.0.1');
-    analytics.track(event.name, { ...event });
-
-    // Wait for the Sender to flush the event (baseIntervalMs = 200ms + buffer)
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    // Verify the captured payload
-    t.expect(captured).toEqual([]);
-
-    scope.done();
+  t.afterAll(() => {
+    nock.cleanAll();
   });
 
-  t.it('should track an event when enabled', async () => {
-    let captured: Event[] = [];
-    scope = nock('http://127.0.0.2')
-      .post('/v1/events', (body) => {
-        captured = body; // Capture the request body directly
-        return true; // Accept any body to proceed with the intercept
-      })
-      .reply(
-        200,
-        { status: 'success' },
-        { 'Content-Type': 'application/json' },
-      );
+  t.it('should do nothing if enable() is not called', async () => {
+    // Set up nock to fail the test if any request is made
+    const scope = nock(BASE_URL)
+      .post('/v1/events')
+      .reply(200)
+      .post('/v2/events')
+      .reply(200);
 
-    analytics = new Analytics('http://127.0.0.2');
-    analytics.enable();
-    analytics.setGlobalProperty('sdk_version', event.sdk_version);
-    analytics.setGlobalProperty('anon_id', event.anon_id);
-    analytics.setGlobalProperty('platform', event.platform);
-    analytics.setGlobalProperty('integration_type', event.integration_type);
-    analytics.track(event.name, { dapp_id: 'some-non-global-property' });
+    analytics.v1.track('sdk_initialized', {});
+    analytics.v2.setup('sdk/connect', {});
+    analytics.v2.track('sdk/connect', 'sdk_initialized', {
+      package_name: 'test',
+      package_version: '1.0.0',
+      dapp_id: 'test',
+      anon_id: 'test',
+      platform: 'web-desktop',
+      integration_type: 'test',
+    });
 
-    // Wait for the Sender to flush the event (baseIntervalMs = 200ms + buffer)
+    // Wait a bit to ensure no flush happens
     await new Promise((resolve) => setTimeout(resolve, 300));
 
-    // Verify the captured payload
-    t.expect(captured).toEqual([
-      { ...event, dapp_id: 'some-non-global-property' },
-    ]);
+    t.expect(scope.isDone()).toBe(false); // No requests should have been made
+  });
 
-    scope.done();
+  t.describe('analytics.v1', () => {
+    t.it(
+      'should send a correctly formatted V1 event to the /v1/events endpoint',
+      async () => {
+        let capturedBody: EventV1[] | undefined;
+        const scope = nock(BASE_URL)
+          .post('/v1/events', (body) => {
+            capturedBody = body;
+            return true;
+          })
+          .reply(200, { status: 'success' });
+
+        analytics.enable();
+        analytics.v1.setGlobalProperty('platform', 'web-desktop');
+        analytics.v1.track('sdk_initialized', {
+          sdk_version: '0.0.1',
+          dapp_id: 'test.com',
+          anon_id: 'anon-123',
+          integration_type: 'test',
+        });
+
+        // Wait for the sender to flush
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        t.expect(scope.isDone()).toBe(true);
+        t.expect(capturedBody).toBeDefined();
+        t.expect(capturedBody).toHaveLength(1);
+        t.expect(capturedBody?.[0]).toEqual({
+          name: 'sdk_initialized',
+          platform: 'web-desktop', // Global property
+          sdk_version: '0.0.1',
+          dapp_id: 'test.com',
+          anon_id: 'anon-123',
+          integration_type: 'test',
+        });
+      },
+    );
+  });
+
+  t.describe('analytics.v2', () => {
+    const sdkConnectProps = {
+      package_name: '@metamask/sdk-multichain',
+      package_version: '1.0.0',
+      dapp_id: 'aave.com',
+      anon_id: 'anon-456',
+      platform: 'web-desktop',
+      integration_type: 'direct',
+    } as const;
+
+    t.it(
+      'should send a correctly formatted V2 event to the /v2/events endpoint',
+      async () => {
+        let capturedBody: EventV2[] | undefined;
+        const scope = nock(BASE_URL)
+          .post('/v2/events', (body) => {
+            capturedBody = body;
+            return true;
+          })
+          .reply(200, { status: 'success' });
+
+        analytics.enable();
+        analytics.v2.setup('sdk/connect', {
+          package_name: sdkConnectProps.package_name,
+          package_version: sdkConnectProps.package_version,
+          platform: sdkConnectProps.platform,
+        });
+
+        analytics.v2.track('sdk/connect', 'sdk_initialized', {
+          dapp_id: sdkConnectProps.dapp_id,
+          anon_id: sdkConnectProps.anon_id,
+          integration_type: sdkConnectProps.integration_type,
+        });
+
+        // Wait for the sender to flush
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        t.expect(scope.isDone()).toBe(true);
+        t.expect(capturedBody).toBeDefined();
+        t.expect(capturedBody).toHaveLength(1);
+        t.expect(capturedBody?.[0]).toEqual({
+          namespace: 'sdk/connect',
+          event_name: 'sdk_initialized',
+          properties: {
+            // Merged from setup() and track()
+            package_name: sdkConnectProps.package_name,
+            package_version: sdkConnectProps.package_version,
+            dapp_id: sdkConnectProps.dapp_id,
+            anon_id: sdkConnectProps.anon_id,
+            platform: sdkConnectProps.platform,
+            integration_type: sdkConnectProps.integration_type,
+          },
+        });
+      },
+    );
+
+    t.it(
+      'should throw an error if track() is called for a namespace without setup',
+      () => {
+        analytics.enable();
+        // This should throw because 'mobile/sdk-connect-v2' was never set up
+        t.expect(() =>
+          analytics.v2.track(
+            'mobile/sdk-connect-v2',
+            'wallet_action_received',
+            {
+              anon_id: 'test',
+              platform: 'mobile',
+            },
+          ),
+        ).toThrow(
+          'No configuration found for namespace: "mobile/sdk-connect-v2"',
+        );
+      },
+    );
   });
 });

--- a/packages/sdk-analytics/src/analytics.ts
+++ b/packages/sdk-analytics/src/analytics.ts
@@ -1,22 +1,52 @@
 /* eslint-disable no-restricted-syntax */
+
 import createClient from 'openapi-fetch';
 
 import type * as schema from './schema';
 import Sender from './sender';
 
-type Event = schema.components['schemas']['Event'];
+type Paths = schema.paths;
+type EventV1 = schema.components['schemas']['Event'];
+type EventV2 = schema.components['schemas']['EventV2'];
 
-class Analytics {
-  private enabled = false;
+type Namespaces = EventV2['namespace'];
+type EventPayloadForNamespace<T extends Namespaces> = Extract<
+  EventV2,
+  { namespace: T }
+>;
+type EventNameForNamespace<T extends Namespaces> =
+  EventPayloadForNamespace<T>['event_name'];
+type PropertiesForEvent<
+  TNs extends Namespaces,
+  TEv extends EventNameForNamespace<TNs>,
+> = Extract<EventPayloadForNamespace<TNs>, { event_name: TEv }>['properties'];
 
-  private readonly sender: Sender<Event>;
+type PropertiesForNamespace<T extends Namespaces> = Extract<
+  EventV2,
+  { namespace: T }
+>['properties'];
+
+type SetupPropertiesForNamespace<T extends Namespaces> = Partial<
+  PropertiesForNamespace<T>
+>;
+
+type TrackPropertiesForEvent<TNs extends Namespaces> = Partial<
+  PropertiesForNamespace<TNs>
+>;
+
+class AnalyticsV1 {
+  private readonly sender: Sender<EventV1>;
+
+  private readonly enabled: () => boolean;
 
   private properties: Record<string, string> = {};
 
-  constructor(baseUrl: string) {
-    const client = createClient<schema.paths>({ baseUrl });
+  constructor(baseUrl: string, enabled: () => boolean) {
+    this.enabled = enabled;
 
-    const sendFn = async (batch: Event[]): Promise<void> => {
+    const client = createClient<Paths>({ baseUrl });
+
+    const sendFn = async (batch: EventV1[]): Promise<void> => {
       const res = await client.POST('/v1/events', { body: batch });
       if (res.response.status !== 200) {
         throw new Error(res.error);
@@ -26,16 +56,27 @@ class Analytics {
     this.sender = new Sender({ batchSize: 100, baseTimeoutMs: 200, sendFn });
   }
 
-  public enable(): void {
-    this.enabled = true;
-  }
-
+  /**
+   * Sets a global property to be included in all V1 events.
+   *
+   * @param key - The property key.
+   * @param value - The property value.
+   */
   public setGlobalProperty(key: string, value: string): void {
     this.properties[key] = value;
   }
 
-  public track<T extends Event>(name: T['name'], properties: Partial<T>): void {
-    if (!this.enabled) {
+  /**
+   * Tracks a V1 analytics event if enabled.
+   *
+   * @param name - The name of the event.
+   * @param properties - Additional properties for the event.
+   */
+  public track<T extends EventV1>(
+    name: T['name'],
+    properties: Partial<T>,
+  ): void {
+    if (!this.enabled()) {
       return;
     }
 
@@ -46,6 +87,103 @@ class Analytics {
     } as T;
 
     this.sender.enqueue(event);
+  }
+}
+
+class AnalyticsV2 {
+  private readonly sender: Sender<EventV2>;
+
+  private readonly enabled: () => boolean;
+
+  private readonly namespaceConfigs: Map<
+    Namespaces,
+    { properties: Record<string, unknown> }
+  > = new Map();
+
+  constructor(baseUrl: string, enabled: () => boolean) {
+    this.enabled = enabled;
+
+    const client = createClient<Paths>({ baseUrl });
+
+    const sendFn = async (batch: EventV2[]): Promise<void> => {
+      const res = await client.POST('/v2/events', { body: batch });
+      if (res.response.status !== 200) {
+        throw new Error(res.error);
+      }
+    };
+
+    this.sender = new Sender({ batchSize: 100, baseTimeoutMs: 200, sendFn });
+  }
+
+  /**
+   * Configures common properties for a specific V2 namespace.
+   * Merges with any existing properties for the namespace.
+   *
+   * @param namespace - The namespace to configure.
+   * @param properties - Common properties to include in all events for this namespace.
+   */
+  public setup<TNs extends Namespaces>(
+    namespace: TNs,
+    properties: SetupPropertiesForNamespace<TNs>,
+  ): void {
+    const existing = this.namespaceConfigs.get(namespace)?.properties ?? {};
+    this.namespaceConfigs.set(namespace, {
+      properties: { ...existing, ...properties },
+    });
+  }
+
+  /**
+   * Tracks a V2 namespaced analytics event if enabled.
+   *
+   * @param namespace - The namespace of the event.
+   * @param eventName - The name of the event.
+   * @param properties - Additional properties for the event.
+   */
+  public track<TNs extends Namespaces>(
+    namespace: TNs,
+    eventName: EventNameForNamespace<TNs>,
+    properties: TrackPropertiesForEvent<TNs>,
+  ): void {
+    if (!this.enabled()) {
+      return;
+    }
+
+    const config = this.namespaceConfigs.get(namespace);
+    if (!config) {
+      throw new Error(
+        `No configuration found for namespace: "${namespace}". Make sure to call setup() first.`,
+      );
+    }
+
+    const merged = {
+      ...config.properties,
+      ...properties,
+    } as unknown as PropertiesForEvent<TNs, typeof eventName>;
+
+    const event = {
+      namespace,
+      event_name: eventName,
+      properties: merged,
+    } as EventV2;
+
+    this.sender.enqueue(event);
+  }
+}
+
+class Analytics {
+  private enabled = false;
+
+  public readonly v1: AnalyticsV1;
+
+  public readonly v2: AnalyticsV2;
+
+  constructor(baseUrl: string) {
+    this.v1 = new AnalyticsV1(baseUrl, () => this.enabled);
+    this.v2 = new AnalyticsV2(baseUrl, () => this.enabled);
+  }
+
+  public enable(): void {
+    this.enabled = true;
   }
 }
 

--- a/packages/sdk-analytics/src/schema.ts
+++ b/packages/sdk-analytics/src/schema.ts
@@ -53,6 +53,55 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Track V2 namespaced events
+         * @description Endpoint to submit namespaced analytics events for the MetaMask SDK (version 2).
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["EventV2"][];
+                };
+            };
+            responses: {
+                /** @description Events tracked successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description Indicates the success of the event tracking.
+                             * @example success
+                             */
+                            status?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -420,6 +469,47 @@ export interface components {
              * @enum {string}
              */
             platform: "extension" | "mobile";
+        };
+        EventV2: components["schemas"]["SDKConnectPayload"] | components["schemas"]["MobileSDKConnectV2Payload"];
+        SDKConnectPayload: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            namespace: "sdk/connect";
+            /** @enum {string} */
+            event_name: "sdk_initialized" | "sdk_connection_initiated" | "sdk_connection_established" | "sdk_connection_rejected" | "sdk_connection_failed" | "sdk_action_requested" | "sdk_action_succeeded" | "sdk_action_failed" | "sdk_action_rejected";
+            properties: components["schemas"]["SDKConnectProperties"];
+        };
+        MobileSDKConnectV2Payload: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            namespace: "mobile/sdk-connect-v2";
+            /** @enum {string} */
+            event_name: "wallet_connection_request_received" | "wallet_connection_request_failed" | "wallet_connection_user_approved" | "wallet_connection_user_rejected" | "wallet_action_received" | "wallet_action_user_approved" | "wallet_action_user_rejected";
+            properties: components["schemas"]["MobileSDKConnectV2Properties"];
+        };
+        SDKConnectProperties: {
+            package_name: string;
+            package_version: string;
+            dapp_id: string;
+            /** Format: uuid */
+            anon_id: string;
+            /** @enum {string} */
+            platform: "web-desktop" | "web-mobile" | "nodejs" | "in-app-browser" | "react-native";
+            integration_type: string;
+            /** @enum {string} */
+            transport_type?: "direct" | "mwp-ws";
+            action?: string;
+            caip_chain_id?: string;
+        };
+        MobileSDKConnectV2Properties: {
+            /** Format: uuid */
+            anon_id: string;
+            /** @enum {string} */
+            platform: "mobile";
         };
     };
     responses: never;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR refactors the SDK Analytics client to support our new V2 namespaced analytics architecture. The client is now split into analytics.v1 (for backward compatibility) and a new  analytics.v2 for namespaced event tracking.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a namespaced V2 analytics client alongside legacy V1, add /v2 schema/types, refactor client API, update tests, and rewrite README with new usage and migration.
> 
> - **Analytics Client (`packages/sdk-analytics/src/analytics.ts`)**:
>   - Split into `analytics.v1` and `analytics.v2`; single `enable()` gates both.
>   - V1: global properties via `setGlobalProperty`, `track(name, props)`; batched sending to `/v1/events`.
>   - V2: namespaced API with `setup(namespace, props)` and `track(namespace, eventName, props)`; batched sending to `/v2/events`.
> - **Schema (`packages/sdk-analytics/src/schema.ts`)**:
>   - Add `POST /v2/events` endpoint.
>   - Define `EventV2` union with `sdk/connect` and `mobile/sdk-connect-v2` payloads and properties.
> - **Tests (`packages/sdk-analytics/src/analytics.test.ts`)**:
>   - Add coverage for disabled state (no sends), V1 payload formatting with globals, V2 namespaced payload merge, and error when tracking without `setup`.
> - **Docs (`packages/sdk-analytics/README.md`)**:
>   - Rewrite to document V2 namespaced client, setup/track usage, and V1 migration with global properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23d2697f364ede72cb14c87748fe2dce8ac44619. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->