### PR TITLE
Revert "Release/116.0.0 (#1364)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "116.0.0",
+  "version": "115.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.34.0]
-### Added
-- Introduces a new `hideReturnToAppNotification` option (default false) and passes it through to deeplink/QR URLs ([#1350](https://github.com/MetaMask/metamask-sdk/pull/1350))
-
 ## [0.33.1]
 ### Fixed
 - chore: pin `debug` package to `4.3.4` due to npm compromise ([#1342](https://github.com/MetaMask/metamask-sdk/pull/1342))
@@ -503,8 +499,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.34.0...HEAD
-[0.34.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.1...@metamask/sdk@0.34.0
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.1...HEAD
 [0.33.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.0...@metamask/sdk@0.33.1
 [0.33.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.32.1...@metamask/sdk@0.33.0
 [0.32.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.32.0...@metamask/sdk@0.32.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.34.0",
+  "version": "0.33.1",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
This reverts commit 97749a27d23fbc7835ac59b127a67c6e1e24b3ac.

[NPM publish for 116.0.0 failed due to commit message mismatch.](https://github.com/MetaMask/metamask-sdk/actions/runs/19238107566/job/54996401783)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the previous release by rolling back root and SDK package versions and removing 0.34.0 changelog entries/links.
> 
> - **Release/Versioning**:
>   - Revert root `package.json` version to `115.0.0`.
>   - Revert `packages/sdk/package.json` version to `0.33.1`.
>   - Update `packages/sdk/CHANGELOG.md`:
>     - Remove `0.34.0` entry.
>     - Adjust `[Unreleased]` compare link to start from `0.33.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfaaa2ce7c08987254fcd51ca64d0e12ba3bc32e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->