### PR TITLE
chore: make multichain react playground marked as private so npm publish doesnt attempt to publish it

### DIFF
--- a/playground/multichain-react/package.json
+++ b/playground/multichain-react/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@metamask/sdk-multichain-react",
+	"private": true,
 	"publishConfig": {
 		"access": "restricted",
 		"registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
We need to make the @metamask/sdk-multichain-react package private like we do all the other playgrounds to avoid NPM Publish CI action attempting to publish it along with other packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `@metamask/sdk-multichain-react` as private in `playground/multichain-react/package.json` to prevent publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b72a7ce5eee9d81eb1f1e6864fc4984f86bc3374. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->