### PR TITLE
Revert "Release 116.0.0 (#1380)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "116.0.0",
+  "version": "115.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.34.0]
-### Added
-- Introduces a new `hideReturnToAppNotification` option (default false) and passes it through to deeplink/QR URLs ([#1350](https://github.com/MetaMask/metamask-sdk/pull/1350))
-
 ## [0.33.1]
 ### Fixed
 - chore: pin `debug` package to `4.3.4` due to npm compromise ([#1342](https://github.com/MetaMask/metamask-sdk/pull/1342))
@@ -503,8 +499,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.34.0...HEAD
-[0.34.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.1...@metamask/sdk@0.34.0
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.1...HEAD
 [0.33.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.0...@metamask/sdk@0.33.1
 [0.33.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.32.1...@metamask/sdk@0.33.0
 [0.32.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.32.0...@metamask/sdk@0.32.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.34.0",
+  "version": "0.33.1",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
This reverts commit 45f413683c24c6d0ad93f5706618e27376bf321e.

😢 [116.0.0 Release NPM Publish Step in CI Failed again](https://github.com/MetaMask/metamask-sdk/actions/runs/19279486910)


Need to make the multichain react playground marked as private so npm publish doesnt attempt to publish it. PR to do so [here](https://github.com/MetaMask/metamask-sdk/pull/1381)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rolls back the monorepo and @metamask/sdk versions and reverts the 0.34.0 changelog entry/links.
> 
> - **Version Reverts**:
>   - `package.json`: set `version` back to `115.0.0` (was `116.0.0`).
>   - `packages/sdk/package.json`: set `version` back to `0.33.1` (was `0.34.0`).
> - **Changelog**:
>   - `packages/sdk/CHANGELOG.md`: remove `0.34.0` section and update `[Unreleased]` compare link to start from `0.33.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6aa8e8afc701b30841950aba21586af675987c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->