### PR TITLE
Release 116.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-sdk-monorepo",
-  "version": "115.0.0",
+  "version": "116.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0]
+### Added
+- Introduces a new `hideReturnToAppNotification` option (default false) and passes it through to deeplink/QR URLs ([#1350](https://github.com/MetaMask/metamask-sdk/pull/1350))
+
 ## [0.33.1]
 ### Fixed
 - chore: pin `debug` package to `4.3.4` due to npm compromise ([#1342](https://github.com/MetaMask/metamask-sdk/pull/1342))
@@ -499,7 +503,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [FEAT] improve logging + update examples ([#99](https://github.com/MetaMask/metamask-sdk/pull/99))
 
-[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.34.0...HEAD
+[0.34.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.1...@metamask/sdk@0.34.0
 [0.33.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.33.0...@metamask/sdk@0.33.1
 [0.33.0]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.32.1...@metamask/sdk@0.33.0
 [0.32.1]: https://github.com/MetaMask/metamask-sdk/compare/@metamask/sdk@0.32.0...@metamask/sdk@0.32.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sdk",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "description": "",
   "homepage": "https://github.com/MetaMask/metamask-sdk#readme",
   "bugs": {


### PR DESCRIPTION
## [0.34.0]
### Added
- Introduces a new `hideReturnToAppNotification` option (default false) and passes it through to deeplink/QR URLs ([#1350](https://github.com/MetaMask/metamask-sdk/pull/1350))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps monorepo to 116.0.0 and updates `@metamask/sdk` to 0.34.0 adding `hideReturnToAppNotification` option passed through deeplink/QR URLs.
> 
> - **Release/Versioning**
>   - Bump root `package.json` version to `116.0.0`.
>   - Bump `@metamask/sdk` version to `0.34.0` in `packages/sdk/package.json`.
> - **SDK Changelog (`packages/sdk/CHANGELOG.md`)**
>   - Add `0.34.0` entry introducing `hideReturnToAppNotification` (default `false`) and propagation via deeplink/QR URLs.
>   - Update comparison links to reference `0.34.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6913c1665a2f307c413057d0c795ede112467090. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->