### PR TITLE
docs: deprecate MetaMask SDK in READMEs; point to MetaMask Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# MetaMask SDK
+# MetaMask SDK (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> This repository is deprecated and no longer actively maintained. MetaMask SDK has been superseded by **MetaMask Connect**, a ground-up rewrite with a streamlined API, direct wallet communication (no relay server), and multichain support out of the box.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — drop-in EVM dapp integration (browser, Node.js, React Native)
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — multichain dapp integration (EVM + non-EVM)
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+>
+> **New repo:** <https://github.com/MetaMask/connect-monorepo>
+
+---
 
 [![codecov](https://codecov.io/gh/MetaMask/metamask-sdk/graph/badge.svg?token=6B3Z3724OO)](https://codecov.io/gh/MetaMask/metamask-sdk)
 

--- a/packages/sdk-analytics/README.md
+++ b/packages/sdk-analytics/README.md
@@ -1,4 +1,12 @@
-# MetaMask SDK Analytics
+# MetaMask SDK Analytics (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> `@metamask/sdk-analytics` is deprecated and no longer actively maintained. Analytics functionality is now provided by [`@metamask/connect-analytics`](https://github.com/MetaMask/connect-monorepo/tree/main/packages/analytics) in the MetaMask Connect monorepo.
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 ## Overview
 

--- a/packages/sdk-communication-layer/README.md
+++ b/packages/sdk-communication-layer/README.md
@@ -1,4 +1,17 @@
-# MetaMask SDK Communication Layer
+# MetaMask SDK Communication Layer (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> `@metamask/sdk-communication-layer` is deprecated and no longer actively maintained. MetaMask Connect replaces the socket-based relay architecture with direct wallet communication via the Mobile Wallet Protocol, eliminating the need for a separate communication layer.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — drop-in EVM dapp integration
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — multichain dapp integration
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 ## Installation
 

--- a/packages/sdk-install-modal-web/README.md
+++ b/packages/sdk-install-modal-web/README.md
@@ -1,1 +1,12 @@
-# sdk-install-modal-web
+# SDK Install Modal Web (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> This package is deprecated and no longer actively maintained. It has been superseded by the MetaMask Connect packages.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — drop-in EVM dapp integration
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — multichain dapp integration
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>

--- a/packages/sdk-multichain-ui/README.md
+++ b/packages/sdk-multichain-ui/README.md
@@ -1,4 +1,12 @@
-# sdk-install-modal-web
+# SDK Multichain UI (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> This package is deprecated and no longer actively maintained. It has been superseded by [`@metamask/multichain-ui`](https://github.com/MetaMask/connect-monorepo/tree/main/packages/multichain-ui) in the MetaMask Connect monorepo.
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 Install modal web package for multichain, renders and uses the new mobile wallet protocol ConnectionRequest QRCodes.
 

--- a/packages/sdk-multichain/README.md
+++ b/packages/sdk-multichain/README.md
@@ -1,4 +1,17 @@
-# MetaMask SDK Multichain
+# MetaMask SDK Multichain (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> `@metamask/sdk-multichain` is deprecated and no longer actively maintained. Its functionality has been superseded by **MetaMask Connect**, which provides a cleaner multichain API, direct wallet communication (no relay server), and improved protocol support.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — the direct successor for multichain dapp integration
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — if you only need EVM chain support
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 The MetaMask SDK Multichain is a protocol-based, domain-driven SDK that enables seamless integration with MetaMask wallets across multiple blockchain networks and platforms.
 

--- a/packages/sdk-react-native/README.md
+++ b/packages/sdk-react-native/README.md
@@ -1,4 +1,17 @@
-# MetaMask SDK React Native
+# MetaMask SDK React Native (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> `@metamask/sdk-react-native` is deprecated and no longer actively maintained. It has been superseded by **MetaMask Connect**, which offers a streamlined API, direct wallet communication (no relay server), and first-class multichain support.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — drop-in EVM dapp integration (browser, Node.js, React Native)
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — multichain dapp integration (EVM + non-EVM)
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 The MetaMask SDK React Native allows developers to integrate MetaMask seamlessly into React Native applications.
 

--- a/packages/sdk-react-ui/README.md
+++ b/packages/sdk-react-ui/README.md
@@ -1,4 +1,17 @@
-# MetaMask SDK React
+# MetaMask SDK React UI (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> `@metamask/sdk-react-ui` is deprecated and no longer actively maintained. It has been superseded by **MetaMask Connect**, which offers a streamlined API, direct wallet communication (no relay server), and first-class multichain support.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — drop-in EVM dapp integration (browser, Node.js, React Native)
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — multichain dapp integration (EVM + non-EVM)
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 The MetaMask SDK React UI allows developer an easier integration to the MetaMask SDK on React-based apps.
 On top of exporting the hooks from `@metamask/sdk-react`, it also provides wrapper around wagmi hooks and a basic UI button component to connect to MetaMask.

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -1,4 +1,17 @@
-# MetaMask SDK React
+# MetaMask SDK React (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> `@metamask/sdk-react` is deprecated and no longer actively maintained. It has been superseded by **MetaMask Connect**, which offers a streamlined API, direct wallet communication (no relay server), and first-class multichain support.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — drop-in EVM dapp integration (browser, Node.js, React Native)
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — multichain dapp integration (EVM + non-EVM)
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 The MetaMask SDK React allows developer an easier integration to the MetaMask SDK on React-based apps.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,17 @@
-# MetaMask SDK
+# MetaMask SDK (Deprecated)
+
+> **⚠️ DEPRECATED**
+>
+> `@metamask/sdk` is deprecated and no longer actively maintained. It has been superseded by **MetaMask Connect**, which offers a streamlined API, direct wallet communication (no relay server), and first-class multichain support.
+>
+> **Migrate to:**
+>
+> - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm) — drop-in EVM dapp integration (browser, Node.js, React Native)
+> - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain) — multichain dapp integration (EVM + non-EVM)
+>
+> **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
+
+---
 
 The MetaMask SDK enables developers to easily connect their dapps with a MetaMask wallet (Extension or Mobile) no matter the dapp environment or platform.
 


### PR DESCRIPTION
## Summary

This PR adds deprecation notices to the monorepo root README and all published / consumer-facing package READMEs.

## What changed

- Call out that MetaMask SDK is deprecated and superseded by **MetaMask Connect**.
- Link to replacement packages:
  - [`@metamask/connect-evm`](https://www.npmjs.com/package/@metamask/connect-evm)
  - [`@metamask/connect-multichain`](https://www.npmjs.com/package/@metamask/connect-multichain)
- Link migration and product docs: https://docs.metamask.io/metamask-connect
- Root README also links to the successor repo: https://github.com/MetaMask/connect-monorepo

## Packages / paths updated

- `README.md` (root)
- `packages/sdk/README.md`
- `packages/sdk-react/README.md`
- `packages/sdk-react-native/README.md`
- `packages/sdk-react-ui/README.md`
- `packages/sdk-communication-layer/README.md`
- `packages/sdk-multichain/README.md`
- `packages/sdk-multichain-ui/README.md`
- `packages/sdk-analytics/README.md`
- `packages/sdk-install-modal-web/README.md`

## Validation

Documentation-only change; no build or tests run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add deprecation notices and migration links; no runtime code or behavior is modified.
> 
> **Overview**
> Adds prominent **deprecation banners** to the root `README.md` and multiple package READMEs, explicitly stating MetaMask SDK is no longer maintained and has been superseded by **MetaMask Connect**.
> 
> Updates the docs to point users to replacement packages (e.g. `@metamask/connect-evm`, `@metamask/connect-multichain`, and `@metamask/connect-analytics`), the migration/docs URL, and (in the root README) the new successor repository link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be7b6b36b594473b6142f76ae60fa9dc9a92f571. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->