### PR TITLE
fix: add room membership checks. Broadcast errors to room only

### DIFF
--- a/packages/sdk-socket-server-next/e2e/api-config.test.ts
+++ b/packages/sdk-socket-server-next/e2e/api-config.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import { app } from '../src/api-config';
+import { app } from '../src/analytics-api';
 
 jest.mock('analytics-node');
 

--- a/packages/sdk-socket-server-next/jest.config.ts
+++ b/packages/sdk-socket-server-next/jest.config.ts
@@ -1,0 +1,18 @@
+import baseConfig from '../../jest.config.base';
+
+module.exports = {
+  ...baseConfig,
+  testMatch: [
+    '**/__tests__/**/*.[jt]s?(x)',
+    '**/?(*.)+(spec|test).[tj]s?(x)',
+  ],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^analytics-node$': '<rootDir>/e2e/analytics-node.ts',
+  },
+  clearMocks: true,
+  resetMocks: false,
+  restoreMocks: false,
+  watchman: false,
+};

--- a/packages/sdk-socket-server-next/jest.setup.ts
+++ b/packages/sdk-socket-server-next/jest.setup.ts
@@ -1,0 +1,12 @@
+/* eslint-disable node/no-process-env */
+// Jest setup: ensure required environment variables are present so that
+// `analytics-api` does not call `process.exit(1)` when it loads.
+process.env.REDIS_NODES =
+  process.env.REDIS_NODES ?? 'redis://localhost:6379';
+process.env.NODE_ENV = process.env.NODE_ENV ?? 'test';
+
+// Some tests mock `./analytics-api` so the side-effectful logger setup in
+// `./config` never runs. Initialise the logger here so `getLogger()` returns
+// a real winston logger from any module under test.
+// eslint-disable-next-line import/no-unassigned-import
+import './src/config';

--- a/packages/sdk-socket-server-next/src/protocol/handleChannelRejected.test.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleChannelRejected.test.ts
@@ -1,0 +1,191 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { v4 as uuidv4 } from 'uuid';
+
+const mockPubClient = {
+  get: jest.fn(),
+  setex: jest.fn(),
+};
+
+jest.mock('../analytics-api', () => ({
+  pubClient: mockPubClient,
+}));
+
+jest.mock('@socket.io/redis-adapter', () => ({
+  createAdapter: jest.fn(),
+}));
+
+import {
+  handleChannelRejected,
+  ChannelRejectedParams,
+} from './handleChannelRejected';
+import { ChannelConfig } from './handleJoinChannel';
+
+function makeSocket({
+  rooms,
+  socketId = 'socket-id-1',
+}: {
+  rooms: string[];
+  socketId?: string;
+}) {
+  const broadcastToEmit = jest.fn();
+  return {
+    id: socketId,
+    request: { socket: { remoteAddress: '127.0.0.1' } },
+    rooms: new Set(rooms),
+    broadcast: {
+      to: jest.fn(() => ({ emit: broadcastToEmit })),
+    },
+  } as any;
+}
+
+describe('handleChannelRejected participant check (HackerOne 3604630)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects requests from a non-participant socket on a fresh channel', async () => {
+    const channelId = uuidv4();
+    const socket = makeSocket({ rooms: [] });
+
+    // No existing channelConfig: this is a fresh channelId an attacker is
+    // poking at.
+    mockPubClient.get.mockResolvedValueOnce(null);
+
+    const callback = jest.fn();
+    const params: ChannelRejectedParams = {
+      io: {} as any,
+      socket,
+      channelId,
+    };
+
+    await handleChannelRejected(params, callback);
+
+    expect(callback).toHaveBeenCalledWith('not authorized', undefined);
+    // Must not write any rejected entry to redis on a non-participant request.
+    expect(mockPubClient.setex).not.toHaveBeenCalled();
+    expect(socket.broadcast.to).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests from a non-participant socket even when a channelConfig with no wallet exists', async () => {
+    const channelId = uuidv4();
+    const socket = makeSocket({ rooms: [] });
+
+    // Existing config but no wallet recorded yet (e.g. only the dapp has
+    // joined). The reconnect-and-reject flow only applies to wallets that
+    // had previously joined.
+    const existingConfig: ChannelConfig = {
+      clients: { dapp: 'dapp-socket-id', wallet: '' },
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    mockPubClient.get.mockResolvedValueOnce(JSON.stringify(existingConfig));
+
+    const callback = jest.fn();
+    const params: ChannelRejectedParams = {
+      io: {} as any,
+      socket,
+      channelId,
+    };
+
+    await handleChannelRejected(params, callback);
+
+    expect(callback).toHaveBeenCalledWith('not authorized', undefined);
+    expect(mockPubClient.setex).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with an invalid channelId', async () => {
+    const socket = makeSocket({ rooms: [] });
+    const callback = jest.fn();
+    const params: ChannelRejectedParams = {
+      io: {} as any,
+      socket,
+      channelId: 'not-a-uuid',
+    };
+
+    await handleChannelRejected(params, callback);
+
+    expect(callback).toHaveBeenCalledWith('error_id', undefined);
+    expect(mockPubClient.get).not.toHaveBeenCalled();
+    expect(mockPubClient.setex).not.toHaveBeenCalled();
+  });
+
+  it('allows the request when the socket is a live in-room participant', async () => {
+    const channelId = uuidv4();
+    const socket = makeSocket({ rooms: [channelId] });
+
+    mockPubClient.get.mockResolvedValueOnce(null);
+    mockPubClient.setex.mockResolvedValueOnce('OK');
+
+    const callback = jest.fn();
+    const params: ChannelRejectedParams = {
+      io: {} as any,
+      socket,
+      channelId,
+    };
+
+    await handleChannelRejected(params, callback);
+
+    expect(mockPubClient.setex).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(null, { success: true });
+  });
+
+  it('allows the post-reconnect reject flow when channelConfig has a known wallet', async () => {
+    const channelId = uuidv4();
+    // Wallet has reconnected, so its socket is not in the room.
+    const socket = makeSocket({
+      rooms: [],
+      socketId: 'wallet-reconnected-socket-id',
+    });
+
+    const existingConfig: ChannelConfig = {
+      clients: {
+        wallet: 'previous-wallet-socket-id',
+        dapp: 'dapp-socket-id',
+      },
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    mockPubClient.get.mockResolvedValueOnce(JSON.stringify(existingConfig));
+    mockPubClient.setex.mockResolvedValueOnce('OK');
+
+    const callback = jest.fn();
+    const params: ChannelRejectedParams = {
+      io: {} as any,
+      socket,
+      channelId,
+    };
+
+    await handleChannelRejected(params, callback);
+
+    expect(mockPubClient.setex).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(mockPubClient.setex.mock.calls[0][2]);
+    expect(payload.rejected).toBe(true);
+
+    expect(socket.broadcast.to).toHaveBeenCalledWith(channelId);
+    expect(callback).toHaveBeenCalledWith(null, { success: true });
+  });
+
+  it('does not modify a channel that is already in the ready state', async () => {
+    const channelId = uuidv4();
+    const socket = makeSocket({ rooms: [channelId] });
+
+    const existingConfig: ChannelConfig = {
+      clients: { wallet: 'wallet-id', dapp: 'dapp-id' },
+      ready: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    mockPubClient.get.mockResolvedValueOnce(JSON.stringify(existingConfig));
+
+    const callback = jest.fn();
+    const params: ChannelRejectedParams = {
+      io: {} as any,
+      socket,
+      channelId,
+    };
+
+    await handleChannelRejected(params, callback);
+
+    expect(mockPubClient.setex).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-socket-server-next/src/protocol/handleChannelRejected.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleChannelRejected.ts
@@ -1,4 +1,5 @@
 import { Server, Socket } from 'socket.io';
+import { validate } from 'uuid';
 import { pubClient } from '../analytics-api';
 import { config } from '../config';
 import { getLogger } from '../logger';
@@ -27,12 +28,37 @@ export const handleChannelRejected = async (
   const socketId = socket.id;
   const clientIp = socket.request.socket.remoteAddress;
 
+  if (!validate(channelId)) {
+    logger.warn(`[handleChannelRejected] ${channelId} invalid channelId`, {
+      channelId,
+      socketId,
+      clientIp,
+    });
+    callback?.('error_id', undefined);
+    return;
+  }
+
   // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
   const channelConfigKey = `channel_config:{${channelId}}`;
   const existingConfig = await pubClient.get(channelConfigKey);
   let channelConfig: ChannelConfig | null = existingConfig
     ? (JSON.parse(existingConfig) as ChannelConfig)
     : null;
+
+  const isInRoom = socket.rooms.has(channelId);
+  const isKnownWalletParticipant = Boolean(channelConfig?.clients?.wallet);
+  if (!isInRoom && !isKnownWalletParticipant) {
+    logger.warn(
+      `[handleChannelRejected] non-participant rejected request for ${channelId}`,
+      {
+        channelId,
+        socketId,
+        clientIp,
+      },
+    );
+    callback?.('not authorized', undefined);
+    return;
+  }
 
   if (channelConfig) {
     logger.debug(

--- a/packages/sdk-socket-server-next/src/protocol/handleMessage.test.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleMessage.test.ts
@@ -1,0 +1,95 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { v4 as uuidv4 } from 'uuid';
+
+const mockPubClient = {
+  get: jest.fn(),
+  set: jest.fn(),
+  rpush: jest.fn(),
+  expire: jest.fn(),
+};
+
+jest.mock('../analytics-api', () => ({
+  pubClient: mockPubClient,
+}));
+
+jest.mock('../rate-limiter', () => ({
+  rateLimiterMessage: { consume: jest.fn().mockResolvedValue(undefined) },
+  resetRateLimits: jest.fn(),
+  increaseRateLimits: jest.fn(),
+  setLastConnectionErrorTimestamp: jest.fn(),
+}));
+
+jest.mock('@socket.io/redis-adapter', () => ({
+  createAdapter: jest.fn(),
+}));
+
+import { handleMessage, MessageParams } from './handleMessage';
+
+type Emit = jest.Mock;
+
+function makeSocket(channelId: string) {
+  const broadcastToEmit: Emit = jest.fn();
+  const broadcastEmit: Emit = jest.fn();
+
+  const broadcast = {
+    to: jest.fn(() => ({ emit: broadcastToEmit })),
+    emit: broadcastEmit,
+  };
+
+  return {
+    socket: {
+      id: 'socket-id-1',
+      handshake: { address: '127.0.0.1' },
+      request: { socket: { remoteAddress: '127.0.0.1' } },
+      rooms: new Set([channelId]),
+      broadcast,
+      emit: jest.fn(),
+    } as any,
+    broadcastToEmit,
+    broadcastEmit,
+    broadcastTo: broadcast.to,
+  };
+}
+
+describe('handleMessage error path', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('scopes the error broadcast to the channel room (regression: HackerOne 3604630)', async () => {
+    const channelId = uuidv4();
+    const { socket, broadcastTo, broadcastToEmit, broadcastEmit } =
+      makeSocket(channelId);
+
+    // Force handleMessage to throw inside its try-block by making
+    // pubClient.get reject.
+    mockPubClient.get.mockRejectedValueOnce(new Error('boom'));
+
+    const callback = jest.fn();
+
+    const params: MessageParams = {
+      io: {} as any,
+      socket,
+      channelId,
+      clientType: 'dapp',
+      context: 'dapp',
+      message: 'encrypted-string',
+      hasRateLimit: false,
+      callback,
+    };
+
+    await handleMessage(params);
+
+    expect(broadcastTo).toHaveBeenCalledWith(channelId);
+    expect(broadcastToEmit).toHaveBeenCalledWith(
+      `message-${channelId}`,
+      expect.objectContaining({ error: 'boom' }),
+    );
+
+    // CRITICAL: error must NOT be broadcast to all sockets (which would
+    // leak the active channel ID).
+    expect(broadcastEmit).not.toHaveBeenCalled();
+
+    expect(callback).toHaveBeenCalledWith('boom');
+  });
+});

--- a/packages/sdk-socket-server-next/src/protocol/handleMessage.ts
+++ b/packages/sdk-socket-server-next/src/protocol/handleMessage.ts
@@ -114,7 +114,7 @@ export const handleMessage = async ({
       ackId = uuidv4();
       // Store in the correct message queue
       const otherQueue = clientType === 'dapp' ? 'wallet' : 'dapp';
-      // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})  
+      // Force keys into the same hash slot in Redis Cluster, using a hash tag (a substring enclosed in curly braces {})
       const queueKey = `queue:{${channelId}}:${otherQueue}`;
       const persistedMsg: QueuedMessage = {
         message,
@@ -174,8 +174,7 @@ export const handleMessage = async ({
       clientIp,
     });
 
-    // emit an error message back to the client, if appropriate
-    socket.broadcast.emit(`message-${channelId}`, {
+    socket.broadcast.to(channelId).emit(`message-${channelId}`, {
       error: error instanceof Error ? error.message : 'Unknown error occurred',
     });
 

--- a/packages/sdk-socket-server-next/src/socket-config.test.ts
+++ b/packages/sdk-socket-server-next/src/socket-config.test.ts
@@ -1,0 +1,217 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { createServer } from 'http';
+import { AddressInfo } from 'net';
+import { v4 as uuidv4 } from 'uuid';
+import { Server as IOServer } from 'socket.io';
+import { io as ioClient, Socket as ClientSocket } from 'socket.io-client';
+
+const mockPubClient = {
+  on: jest.fn(),
+  duplicate: jest.fn(() => ({ on: jest.fn() })),
+  get: jest.fn(),
+  set: jest.fn(),
+  setex: jest.fn(),
+  incrby: jest.fn().mockResolvedValue(1),
+  del: jest.fn(),
+};
+
+jest.mock('./analytics-api', () => ({
+  pubClient: mockPubClient,
+}));
+
+jest.mock('@socket.io/redis-adapter', () => ({
+  createAdapter: () => undefined,
+}));
+
+const handleAck = jest.fn().mockResolvedValue(undefined);
+const handlePing = jest.fn().mockResolvedValue(undefined);
+const handleMessage = jest.fn().mockResolvedValue(undefined);
+const handleChannelRejected = jest.fn().mockResolvedValue(undefined);
+const handleJoinChannel = jest.fn().mockResolvedValue(undefined);
+const handleCheckRoom = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('./protocol/handleAck', () => ({
+  handleAck: (...args: unknown[]) => handleAck(...args),
+}));
+jest.mock('./protocol/handlePing', () => ({
+  handlePing: (...args: unknown[]) => handlePing(...args),
+}));
+jest.mock('./protocol/handleMessage', () => ({
+  handleMessage: (...args: unknown[]) => handleMessage(...args),
+}));
+jest.mock('./protocol/handleChannelRejected', () => ({
+  handleChannelRejected: (...args: unknown[]) => handleChannelRejected(...args),
+}));
+jest.mock('./protocol/handleJoinChannel', () => ({
+  handleJoinChannel: (...args: unknown[]) => handleJoinChannel(...args),
+}));
+jest.mock('./protocol/handleCheckRoom', () => ({
+  handleCheckRoom: (...args: unknown[]) => handleCheckRoom(...args),
+}));
+
+import { configureSocketServer } from './socket-config';
+
+type ServerHandle = {
+  ioServer: IOServer;
+  close: () => Promise<void>;
+  port: number;
+};
+
+async function startServer(): Promise<ServerHandle> {
+  const httpServer = createServer();
+  const ioServer = await configureSocketServer(httpServer);
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const { port } = httpServer.address() as AddressInfo;
+
+  return {
+    ioServer,
+    port,
+    close: async () => {
+      // socket.io's `Server.close` also closes the underlying http
+      // server, so we don't call httpServer.close() separately.
+      await new Promise<void>((resolve) => {
+        ioServer.close(() => resolve());
+      });
+    },
+  };
+}
+
+function connectClient(port: number): Promise<ClientSocket> {
+  return new Promise((resolve, reject) => {
+    const client = ioClient(`http://127.0.0.1:${port}`, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    });
+    client.on('connect', () => resolve(client));
+    client.on('connect_error', reject);
+  });
+}
+
+async function settle() {
+  // Wait long enough for the server to process the emitted event.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+describe('socket-config room-membership guards (HackerOne 3604630)', () => {
+  let handle: ServerHandle | undefined;
+  let client: ClientSocket | undefined;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    handle = await startServer();
+  });
+
+  afterEach(async () => {
+    client?.disconnect();
+    client = undefined;
+    if (handle) {
+      await handle.close();
+      handle = undefined;
+    }
+  });
+
+  it('blocks ping from a socket that has not joined the channel room', async () => {
+    if (!handle) {
+      throw new Error('server not initialised');
+    }
+    const channelId = uuidv4();
+    client = await connectClient(handle.port);
+
+    client.emit(
+      'ping',
+      { id: channelId, clientType: 'dapp' },
+      () => undefined,
+    );
+    await settle();
+
+    expect(handlePing).not.toHaveBeenCalled();
+  });
+
+  it('blocks ack from a socket that has not joined the channel room', async () => {
+    if (!handle) {
+      throw new Error('server not initialised');
+    }
+    const channelId = uuidv4();
+    client = await connectClient(handle.port);
+
+    client.emit('ack', {
+      channelId,
+      ackId: uuidv4(),
+      clientType: 'dapp',
+    });
+    await settle();
+
+    expect(handleAck).not.toHaveBeenCalled();
+  });
+
+  it('blocks message from a socket that has not joined the channel room', async () => {
+    if (!handle) {
+      throw new Error('server not initialised');
+    }
+    const channelId = uuidv4();
+    client = await connectClient(handle.port);
+
+    client.emit(
+      'message',
+      {
+        id: channelId,
+        message: 'encrypted',
+        context: 'dapp',
+        clientType: 'dapp',
+        plaintext: '',
+      },
+      () => undefined,
+    );
+    await settle();
+
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it('forwards ping and ack to the protocol handlers when the socket is in the channel room', async () => {
+    if (!handle) {
+      throw new Error('server not initialised');
+    }
+    const channelId = uuidv4();
+    client = await connectClient(handle.port);
+
+    // Move the corresponding server-side socket into the channel room
+    // directly (bypassing the mocked join_channel handler) so we can
+    // verify the positive case for both guards.
+    const sockets = await handle.ioServer.fetchSockets();
+    expect(sockets).toHaveLength(1);
+    await sockets[0].join(channelId);
+
+    client.emit(
+      'ping',
+      { id: channelId, clientType: 'dapp' },
+      () => undefined,
+    );
+    client.emit('ack', {
+      channelId,
+      ackId: uuidv4(),
+      clientType: 'dapp',
+    });
+    await settle();
+
+    expect(handlePing).toHaveBeenCalledTimes(1);
+    expect(handleAck).toHaveBeenCalledTimes(1);
+  });
+
+  it('still forwards rejected to handleChannelRejected (participant check is inside the handler)', async () => {
+    if (!handle) {
+      throw new Error('server not initialised');
+    }
+    const channelId = uuidv4();
+    client = await connectClient(handle.port);
+
+    client.emit('rejected', { channelId });
+    await settle();
+
+    expect(handleChannelRejected).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sdk-socket-server-next/src/socket-config.ts
+++ b/packages/sdk-socket-server-next/src/socket-config.ts
@@ -228,6 +228,17 @@ export const configureSocketServer = async (
         const start = Date.now();
         incrementAck();
 
+        // only ack if we are in the room (prevents non-member sockets from
+        // permanently deleting queued messages for arbitrary channels)
+        if (!socket.rooms.has(channelId)) {
+          logger.warn(`ack ${channelId} not in room`, {
+            channelId,
+            socketId,
+            clientIp,
+          });
+          return;
+        }
+
         const ackParams: ACKParams = {
           io,
           socket,
@@ -304,6 +315,17 @@ export const configureSocketServer = async (
       ) => {
         const start = Date.now();
         incrementPing();
+
+        // only ping if we are in the room (prevents non-member sockets from
+        // retrieving queued messages for arbitrary channels)
+        if (!socket.rooms.has(id)) {
+          logger.warn(`ping ${id} not in room`, {
+            channelId: id,
+            socketId,
+            clientIp,
+          });
+          return;
+        }
 
         handlePing({
           channelId: id,


### PR DESCRIPTION
## Explanation

- **`ping` and `ack` handlers (`socket-config.ts`)** now bail out with a
  warning if `socket.rooms.has(channelId)` is false, mirroring the existing
  `message` and `leave_channel` guards. Non-member sockets can no longer reach
  `handlePing` / `handleAck`.
- **`rejected` handler (`handleChannelRejected.ts`)** gets a participant
  check. A naive room-membership guard would break the legitimate flow because
  `rejectChannel.ts` reconnects the socket before emitting `rejected` and the
  reconnected socket is no longer in the channel room. Instead we accept the
  request only if either:
  1. the socket is currently in the channel room (live participant), or
  2. an existing `channel_config.clients.wallet` entry is recorded in Redis
     (the wallet had previously joined and is rejecting after a reconnect).
  An invalid channel ID also short-circuits with `error_id` now.
- **`handleMessage.ts:178`** error broadcast is scoped to the channel room
  (`socket.broadcast.to(channelId).emit(...)`), so an in-room client's error
  no longer leaks the channel ID to every other connected socket.

## References

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1549

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on live Socket.IO channel operations and Redis side effects; mistakes could break legitimate wallet reconnect/reject flows or leave channels open to abuse.
> 
> **Overview**
> Addresses **HackerOne 3604630** by tightening who can act on a channel in `sdk-socket-server-next`.
> 
> **Socket layer:** `ack` and `ping` (and existing `message` wiring covered by tests) now bail out unless `socket.rooms` includes the channel ID, so unrelated connections cannot ack/delete or pull queued messages for arbitrary UUIDs.
> 
> **`handleChannelRejected`:** Validates `channelId` as a UUID, then requires the socket to be in the room or a known wallet participant (post-reconnect reject) before writing Redis or broadcasting; other callers get `not authorized` / `error_id` with no `setex`.
> 
> **`handleMessage`:** On failure, errors are emitted via `broadcast.to(channelId)` instead of a global broadcast, avoiding leakage of active channel IDs.
> 
> Adds package **Jest** config/setup (env for `analytics-api`, logger init) and regression tests; e2e import updated to `analytics-api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93319fbe94f97db2d1d7db25f9ec3a96f667f794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->