### PR TITLE
docs: update connect repo links to MetaMask/metamask-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
 >
-> **New repo:** <https://github.com/MetaMask/connect-monorepo>
+> **New repo:** <https://github.com/MetaMask/metamask-connect>
 
 ---
 

--- a/packages/sdk-analytics/README.md
+++ b/packages/sdk-analytics/README.md
@@ -2,7 +2,7 @@
 
 > **⚠️ DEPRECATED**
 >
-> `@metamask/sdk-analytics` is deprecated and no longer actively maintained. Analytics functionality is now provided by [`@metamask/connect-analytics`](https://github.com/MetaMask/connect-monorepo/tree/main/packages/analytics) in the MetaMask Connect monorepo.
+> `@metamask/sdk-analytics` is deprecated and no longer actively maintained. Analytics functionality is now provided by [`@metamask/connect-analytics`](https://github.com/MetaMask/metamask-connect/tree/main/packages/analytics) in the MetaMask Connect monorepo.
 >
 > **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
 

--- a/packages/sdk-multichain-ui/README.md
+++ b/packages/sdk-multichain-ui/README.md
@@ -2,7 +2,7 @@
 
 > **⚠️ DEPRECATED**
 >
-> This package is deprecated and no longer actively maintained. It has been superseded by [`@metamask/multichain-ui`](https://github.com/MetaMask/connect-monorepo/tree/main/packages/multichain-ui) in the MetaMask Connect monorepo.
+> This package is deprecated and no longer actively maintained. It has been superseded by [`@metamask/multichain-ui`](https://github.com/MetaMask/metamask-connect/tree/main/packages/multichain-ui) in the MetaMask Connect monorepo.
 >
 > **Migration guide & docs:** <https://docs.metamask.io/metamask-connect>
 


### PR DESCRIPTION
## Description

The MetaMask Connect monorepo is being renamed from `MetaMask/connect-monorepo` to `MetaMask/metamask-connect`. This updates the three stale repo pointers in this repo's deprecation/migration notices so they point at the new repo URL.

Files updated:
- `README.md` — "New repo" pointer
- `packages/sdk-analytics/README.md` — link to the analytics package in the new repo
- `packages/sdk-multichain-ui/README.md` — link to the multichain-ui package in the new repo

These are doc-only link changes (`MetaMask/connect-monorepo` → `MetaMask/metamask-connect`). The docs-site links (`docs.metamask.io/metamask-connect`) already used the new name and are unchanged.

## Related

- MetaMask/connect-monorepo#267 (the repo rename)
- MetaMask/metamask-extension#41829
- MetaMask/metamask-mobile#28906

> Note: GitHub will redirect the old `connect-monorepo` URLs, so nothing is broken today — this just removes the stale name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL updates with no runtime or security impact.
> 
> **Overview**
> Updates deprecation and migration notices so GitHub links use **`MetaMask/metamask-connect`** instead of the old **`MetaMask/connect-monorepo`** name.
> 
> The root **`README.md`** “New repo” URL is updated, and package READMEs for **`sdk-analytics`** and **`sdk-multichain-ui`** now link to the corresponding paths under the renamed monorepo. Docs site URLs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fdc802f1aa800801ab6220f387ab5dd86911df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->