### PR TITLE
fix: remove unused date-fns dependency from sdk-communication-layer

### DIFF
--- a/packages/sdk-communication-layer/CHANGELOG.md
+++ b/packages/sdk-communication-layer/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove unused `date-fns` dependency ([#1395](https://github.com/MetaMask/metamask-sdk/pull/1395))
 
 ## [0.33.2]
 ### Changed

--- a/packages/sdk-communication-layer/package.json
+++ b/packages/sdk-communication-layer/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@metamask/sdk-analytics": "workspace:*",
     "bufferutil": "^4.0.8",
-    "date-fns": "^2.29.3",
     "debug": "4.3.4",
     "utf-8-validate": "^5.0.2",
     "uuid": "^8.3.2"

--- a/packages/sdk-communication-layer/rollup.config.js
+++ b/packages/sdk-communication-layer/rollup.config.js
@@ -22,7 +22,6 @@ const umdGlobals = {
   eciesjs: 'ECIES',
   debug: 'debug',
   uuid: 'uuid',
-  'date-fns': 'dateFns',
   buffer: 'Buffer',
   'readable-stream': 'ReadableStream',
   tslib: 'tslib',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13014,7 +13014,6 @@ __metadata:
     bufferutil: ^4.0.8
     concurrently: ^9.1.2
     cross-fetch: ^4.0.0
-    date-fns: ^2.29.3
     debug: 4.3.4
     eciesjs: ^0.4.11
     eslint: ^7.30.0


### PR DESCRIPTION
## Description

`@metamask/sdk-communication-layer` declares `date-fns: ^2.29.3` as a dependency, but nothing in the package (or anywhere in the monorepo) imports it — the only references are the `package.json` entry and a stale `'date-fns': 'dateFns'` UMD-globals entry in `rollup.config.js`.

As reported in #1352, this forces consumers to install the full date-fns v2 tree (~25MB unpacked) for nothing, and the v2 pin can't dedupe against date-fns v3/v4 used by downstream apps.

This removes the dependency and the stale rollup global instead of bumping it, since it's dead weight.

Fixes #1352

## Testing

- `yarn install` — lockfile updated, no other packages affected
- `yarn workspace @metamask/sdk-communication-layer build` — all four targets (browser ES/UMD, RN, node) build clean
- `yarn workspace @metamask/sdk-communication-layer test` — 66 suites / 313 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only cleanup with no runtime code changes; lowers install footprint and avoids unnecessary v2 date-fns in the tree.
> 
> **Overview**
> Removes the unused **`date-fns`** dependency from `@metamask/sdk-communication-layer`, so consumers no longer pull in a large v2 tree that the package never used.
> 
> The change drops `date-fns` from **`package.json`**, removes the stale **`'date-fns': 'dateFns'`** UMD global from **`rollup.config.js`**, updates **`yarn.lock`**, and records the removal under **[Unreleased]** in **`CHANGELOG.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bb17b508ea55e639cff80a6ca709420569b753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->