### PR TITLE
fix: qr code not rendering on iPad Safari in install modal

### DIFF
--- a/packages/sdk-install-modal-web/CHANGELOG.md
+++ b/packages/sdk-install-modal-web/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix QR code not rendering on iPad Safari in the install/select modals ([#1397](https://github.com/MetaMask/metamask-sdk/pull/1397))
 
 ## [0.32.2]
 ### Changed

--- a/packages/sdk-install-modal-web/src/components/style.css
+++ b/packages/sdk-install-modal-web/src/components/style.css
@@ -162,8 +162,8 @@
     justify-content: right;
 }
 
-#sdk-mm-qrcode {
-    svg {
-        width: 50%;
-    }
+#sdk-mm-qrcode svg {
+    width: 50%;
+    height: auto;
+    aspect-ratio: 1 / 1;
 }

--- a/packages/sdk-install-modal-web/src/components/widget-wrapper/resetStyles.css
+++ b/packages/sdk-install-modal-web/src/components/widget-wrapper/resetStyles.css
@@ -129,8 +129,8 @@ table {
   border-spacing: 0;
 }
 
-#sdk-mm-qrcode {
-  svg {
-      width: 50%;
-  }
+#sdk-mm-qrcode svg {
+  width: 50%;
+  height: auto;
+  aspect-ratio: 1 / 1;
 }


### PR DESCRIPTION
## Description

Fixes the install modal showing no QR code on iPad (#1218).

Root cause is a two-part failure:
1. The QR `<svg>` from `encodeQR(link, 'svg', …)` carries only a `viewBox` — no `width`/`height` attributes — so its rendered size depends entirely on CSS.
2. The only sizing rule uses **native CSS nesting**:
   ```css
   #sdk-mm-qrcode {
       svg { width: 50%; }
   }
   ```
   Native nesting is only supported in Safari 16.5+ (17.2 for the `&`-less relaxed form). Older iPad Safari drops the whole rule, leaving an SVG with no intrinsic size inside a flex container — which WebKit collapses to 0×0.

The fix un-nests the selector (works in every browser) and adds `height: auto; aspect-ratio: 1 / 1` so the square QR keeps its shape. Applied to both `style.css` and `widget-wrapper/resetStyles.css`, covering both `mm-install-modal` and `mm-select-modal`.

Fixes #1218

## Testing

- `yarn workspace @metamask/sdk-install-modal-web build` — compiled output now contains `#sdk-mm-qrcode svg{width:50%;height:auto;aspect-ratio:1 / 1}` (verified in `dist`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS-only change for modal QR display with no auth, data, or API impact.
> 
> **Overview**
> Fixes **invisible QR codes** in the install and select modals on iPad Safari by replacing nested `#sdk-mm-qrcode { svg { … } }` rules with a flat `#sdk-mm-qrcode svg` selector in `style.css` and `resetStyles.css`, so sizing applies on browsers that drop unsupported native nesting.
> 
> The updated rule keeps **50% width** and adds **`height: auto`** and **`aspect-ratio: 1 / 1`** so viewBox-only SVGs get a non-zero square layout instead of collapsing in flex. The unreleased changelog notes the fix ([#1397](https://github.com/MetaMask/metamask-sdk/pull/1397)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36b6694da06c8561e94ef1469d291363162e6719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->