### PR TITLE
fix: kotlin nullable-receiver compile errors in sdk-react-native android module

### DIFF
--- a/packages/sdk-react-native/CHANGELOG.md
+++ b/packages/sdk-react-native/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix Kotlin nullable-receiver compile errors on newer React Native versions ([#1398](https://github.com/MetaMask/metamask-sdk/pull/1398))
 
 ## [0.3.13]
 ### Changed

--- a/packages/sdk-react-native/android/src/main/java/io/metamask/reactnativesdk/MetaMaskReactNativeSdkModule.kt
+++ b/packages/sdk-react-native/android/src/main/java/io/metamask/reactnativesdk/MetaMaskReactNativeSdkModule.kt
@@ -137,6 +137,7 @@ class MetaMaskReactNativeSdkModule(reactContext: ReactApplicationContext) : Reac
         val ethereumRequests = mutableListOf<EthereumRequest>()
         for (i in 0 until reqArray.size()) {
             val req = reqArray.getMap(i)
+                ?: throw IllegalArgumentException("Request at index $i must be a map")
             val method = req.getString("method") ?: throw IllegalArgumentException("Method is required")
             val params: Any? = req.getDynamic("params").asAny()
             ethereumRequests.add(EthereumRequest(method = method, params = params))
@@ -179,8 +180,8 @@ class MetaMaskReactNativeSdkModule(reactContext: ReactApplicationContext) : Reac
             ReadableType.Boolean -> this.asBoolean()
             ReadableType.Number -> this.asDouble()
             ReadableType.String -> this.asString()
-            ReadableType.Map -> this.asMap().toHashMap()
-            ReadableType.Array -> this.asArray().toArrayList()
+            ReadableType.Map -> this.asMap()?.toHashMap()
+            ReadableType.Array -> this.asArray()?.toArrayList()
             else -> throw IllegalArgumentException("Unsupported type")
         }
     }


### PR DESCRIPTION
## Description

`@metamask/sdk-react-native` fails to compile on Android with newer React Native versions (#1308):

```
MetaMaskReactNativeSdkModule.kt:140:29 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'ReadableMap?'
MetaMaskReactNativeSdkModule.kt:141:35 …
MetaMaskReactNativeSdkModule.kt:182:45 … 'ReadableMap?'
MetaMaskReactNativeSdkModule.kt:183:49 … 'ReadableArray?'
```

Newer RN annotates `ReadableArray.getMap(i)` and `Dynamic.asMap()`/`asArray()` as `@Nullable`, so Kotlin rejects the unsafe calls. This handles the nulls explicitly:

- `batchRequest`: `reqArray.getMap(i) ?: throw IllegalArgumentException("Request at index $i must be a map")` — same failure mode as the existing missing-`method` check, and lines 140–141 then operate on a non-null receiver
- `Dynamic.asAny()`: safe calls (`asMap()?.toHashMap()`, `asArray()?.toArrayList()`) — the function already returns `Any?`

Both patterns compile identically against older RN where these getters are platform types, so no behavior change for existing consumers.

Fixes #1308

## Testing

Mechanical null-safety change verified against the compiler errors reported in the issue (the reporter's repro is at [Arthur-Kamau/react-native-sample](https://github.com/Arthur-Kamau/react-native-sample)). I don't have an Android toolchain in this environment to run `compileDebugKotlin` locally — flagging that honestly; the change only touches the four reported lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny compile-time null-handling change in the Android bridge; intended behavior unchanged on older RN, with slightly clearer errors for malformed batch entries.
> 
> **Overview**
> Fixes **Android build failures** on newer React Native versions where `ReadableArray.getMap`, `Dynamic.asMap`, and `Dynamic.asArray` are `@Nullable`, which broke Kotlin compilation in `MetaMaskReactNativeSdkModule`.
> 
> In **`batchRequest`**, a null entry from `getMap(i)` now throws `IllegalArgumentException` (aligned with existing validation for missing `method`). In **`Dynamic.asAny()`**, map/array branches use safe calls so nested params can resolve to `null` without crashing the compiler.
> 
> Changelog updated under **Unreleased → Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2177e560fecf43cc786f67257f4d2c3030622da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->