### PR TITLE
fix: bundle openapi-fetch into sdk-analytics dist to avoid broken .cjs resolution

### DIFF
--- a/packages/sdk-analytics/CHANGELOG.md
+++ b/packages/sdk-analytics/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix: bundle openapi-fetch into sdk-analytics dist to avoid broken .cjs resolution ([#1399](https://github.com/MetaMask/metamask-sdk/pull/1399))
 
 ## [0.0.6]
 ### Changed

--- a/packages/sdk-analytics/package.json
+++ b/packages/sdk-analytics/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup",
     "lint": "eslint src --ext .ts,.tsx --ignore-pattern 'src/schema.ts'",
     "lint:fix": "eslint src --ext .ts,.tsx --fix --ignore-pattern 'src/schema.ts'",
     "lint:changelog": "../../scripts/validate-changelog.sh @metamask/sdk-analytics",
@@ -28,6 +28,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-promise": "^7.1.0",
     "nock": "^14.0.4",
+    "openapi-fetch": "^0.13.5",
     "prettier": "^3.3.3",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
@@ -38,8 +39,5 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "license": "MIT",
-  "dependencies": {
-    "openapi-fetch": "^0.13.5"
-  }
+  "license": "MIT"
 }

--- a/packages/sdk-analytics/tsup.config.ts
+++ b/packages/sdk-analytics/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  // Bundle `openapi-fetch` into the output instead of leaving it as a
+  // runtime `require()`/`import`. Its `require` export condition points to
+  // `dist/cjs/index.cjs`, and webpack configs that have no rule for `.cjs`
+  // files (e.g. create-react-app) emit that file as a static asset URL,
+  // which makes `createClient` resolve to a string at runtime and throw
+  // "import_openapi_fetch.default is not a function".
+  // See https://github.com/MetaMask/metamask-sdk/issues/1340
+  noExternal: ['openapi-fetch'],
+});


### PR DESCRIPTION
## Description

Fixes #1340

### Root cause

`@metamask/sdk-analytics` ships a CJS bundle (`dist/index.js`) that contains a runtime `require("openapi-fetch")`. openapi-fetch's `require` export condition resolves to `dist/cjs/index.cjs` — a **`.cjs`** file. Webpack configs that have no module rule for `.cjs` (notably create-react-app / react-scripts 5, whose final `asset/resource` fallback only excludes `js|mjs|jsx|ts|tsx`) emit that file as a **static asset URL** instead of parsing it as JavaScript:

```js
// module for "openapi-fetch" inside a CRA production bundle:
518(e,t,r){"use strict";e.exports=r.p+"static/media/index.e68f0740787a395b4ef6.cjs"}
```

So `import_openapi_fetch.default` is a URL *string*, and the module-level `new Analytics(...)` singleton throws `import_openapi_fetch.default is not a function` the moment the package is loaded. This matches the reports here and in Web3Auth/web3auth-web#2224 (same error via `@web3auth/modal` → `@metamask/sdk` → `@metamask/sdk-analytics`), and explains why Vite-based apps are unaffected (Vite handles `.cjs`).

Note this is not an openapi-fetch version regression — 0.13.5 and 0.13.8 ship byte-equivalent packaging (verified by diffing the npm tarballs), and an import-style/interop tweak in our source cannot help, because in the failing toolchain the resolved module contains no function at all.

### Fix

Bundle openapi-fetch into the dist output via tsup `noExternal` (config moved to a `tsup.config.ts`, following the existing `sdk-multichain` precedent), so consumer bundlers never resolve the problematic `.cjs` file. openapi-fetch is tiny (~6 kB min, no runtime deps) and the emitted `d.ts` was already self-contained, so `openapi-fetch` moves from `dependencies` to `devDependencies`. `yarn.lock` is unchanged.

## Testing

Reproduction (before fix), minimal CRA app whose entry does `import { analytics } from '@metamask/sdk-analytics'`, with published `@metamask/sdk-analytics@0.0.5` + `openapi-fetch@0.13.8` (the reporter's versions):

```
npx react-scripts build   # react-scripts 5.0.1
node build/static/js/main.*.js
# TypeError: (0 , f.default) is not a function
#     at new <anonymous> (...)   <- Analytics constructor, exactly the reported error
```

After replacing the installed package with this branch's build and rebuilding the same CRA app:

```
node build/static/js/main.*.js
# analytics loaded: object
```

Also verified plain webpack 5 (default config) bundles both before and after without error, so this changes nothing for toolchains that already worked.

Commands run in the monorepo:

- `yarn workspace @metamask/sdk-analytics build` — succeeds; `grep openapi_fetch dist/index.js` has no matches (dependency fully inlined, dist 4 kB → 17 kB)
- `node -e "require('.../dist/index.js')"` and ESM `import` of `dist/index.mjs` — both load; `analytics.track` is a function
- `yarn workspace @metamask/sdk-analytics test:ci` — 2 files, 6 tests passed
- `yarn workspace @metamask/sdk-communication-layer build` — succeeds (downstream consumer)
- Not run: full monorepo test suite / e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change for a deprecated analytics package; increases dist size but avoids changing runtime API or security-sensitive logic.
> 
> **Overview**
> Fixes runtime failures in **create-react-app** and similar Webpack setups where `@metamask/sdk-analytics` loaded `openapi-fetch` as an external `require`, which resolved to a `.cjs` file that Webpack treated as a static asset—so `createClient` was a URL string and analytics threw **"default is not a function"** on import.
> 
> **`openapi-fetch` is now inlined** into the published ESM/CJS dist via a new `tsup.config.ts` with `noExternal: ['openapi-fetch']`, and the build script delegates to `tsup` instead of inline CLI flags. The dependency moves from **`dependencies` to `devDependencies`** since consumers no longer resolve it at install time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4fbdbb20e5347f9a89fd893fa756476b6cd31e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->